### PR TITLE
Adding GitHub Actions for building/testing/linting and deploying code documentation

### DIFF
--- a/.github/workflows/deploy-cargo-docs.yaml
+++ b/.github/workflows/deploy-cargo-docs.yaml
@@ -20,7 +20,7 @@ jobs:
                   override: true
 
             - name: Generate Documentation
-              run: cargo doc --no-deps
+              run: make docs
 
             - name: Deploy to GitHub Pages
               uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy-cargo-docs.yaml
+++ b/.github/workflows/deploy-cargo-docs.yaml
@@ -1,0 +1,29 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    deploy-docs:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v2
+
+            - name: Install Rust
+              uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: stable
+                  profile: minimal
+                  override: true
+
+            - name: Generate Documentation
+              run: cargo doc --no-deps
+
+            - name: Deploy to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: ./target/doc

--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -1,0 +1,26 @@
+name: Rust
+
+on:
+    push:
+        branches: ["main"]
+    pull_request:
+        branches: ["main"]
+
+env:
+    CARGO_TERM_COLOR: always
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Build
+              run: cargo build --release --verbose
+
+            - name: Run tests
+              run: cargo test --verbose
+
+            - name: Linting
+              run: make lint

--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -19,8 +19,5 @@ jobs:
             - name: Build
               run: cargo build --release --verbose
 
-            - name: Run tests
-              run: cargo test --verbose
-
-            - name: Linting
-              run: make lint
+            - name: Linting and testing
+              run: make tests

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ format:
 	cargo fmt
 
 tests: lint
-	cargo test
+	cargo test --verbose
 
 clean:
 	cargo clean

--- a/xlsx/src/lib.rs
+++ b/xlsx/src/lib.rs
@@ -1,4 +1,4 @@
-//! This cate reads an xlsx file and transforms it into an internal representation ([`Model`]).
+//! This crate reads an xlsx file and transforms it into an internal representation ([`Model`]).
 //! An `xlsx` is a zip file containing a set of folders and `xml` files. The IronCalc json structure mimics the relevant parts of the Excel zip.
 //! Although the xlsx structure is quite complicated, it's essentials regarding the spreadsheet technology are easier to grasp.
 //!


### PR DESCRIPTION
This PR adds some additional code documentation to `base/src/actions.rs` and adds 2 new GitHub Actions.  Those GitHub Actions are responsible for:

1. Building, testing, and linting the repository when any pushes or PRs occur on the `main` branch.  This will ensure that any failing tests are caught before being pushed.
2. Automatically uploading documentation generated by `cargo doc --no-deps` to GitHub Pages to serve as a static website.  This will allow contributors to quickly view up-to-date documentation.

In order to get GitHub Pages to serve the new documentation that is being pushed to the `gh-pages` branch, we need to also:

1. Go to the "Pages" section for the repository's settings on GitHub.
2. Select the `gh-pages` branch as the source for the GitHub Pages site.
3. Save the changes.

NOTE: The workflow uses `secrets.GITHUB_TOKEN` for authentication, which is automatically provided by GitHub Actions and does not need manual setup.