### PR TITLE
Adding additional lexer unit tests

### DIFF
--- a/base/src/expressions/lexer/test/test_common.rs
+++ b/base/src/expressions/lexer/test/test_common.rs
@@ -4,7 +4,7 @@ use crate::language::get_language;
 use crate::locale::get_locale;
 
 use crate::expressions::{
-    lexer::{Lexer, LexerMode},
+    lexer::{Lexer, LexerError, LexerMode},
     token::TokenType::*,
     token::{Error, OpCompare, OpProduct, OpSum},
     types::ParsedReference,
@@ -412,6 +412,20 @@ fn test_name_r1c1p() {
 }
 
 #[test]
+fn test_reference_r1c1_error() {
+    let mut lx = new_lexer("$A$4", false);
+    lx.mode = LexerMode::R1C1;
+    assert_eq!(
+        lx.next_token(),
+        Illegal(LexerError {
+            position: 1,
+            message: "Cannot parse A1 reference in R1C1 mode".to_string(),
+        })
+    );
+    assert_eq!(lx.next_token(), EOF);
+}
+
+#[test]
 fn test_name_wrong_ref() {
     let mut lx = new_lexer("Sheet1!2", false);
     assert!(matches!(lx.next_token(), Illegal(_)));
@@ -563,13 +577,13 @@ fn test_range() {
                 column: 1,
                 row: 1,
                 absolute_column: false,
-                absolute_row: false
+                absolute_row: false,
             },
             right: ParsedReference {
                 column: 2,
                 row: 3,
                 absolute_column: false,
-                absolute_row: false
+                absolute_row: false,
             },
         }
     );
@@ -626,6 +640,22 @@ fn test_ampersand() {
     assert_eq!(lx.next_token(), Number(1.0));
     assert_eq!(lx.next_token(), And);
     assert_eq!(lx.next_token(), Number(2.0));
+    assert_eq!(lx.next_token(), EOF);
+}
+
+#[test]
+fn test_comma() {
+    // Used for testing locales where the comma is not a decimal separator
+    let mut lx = new_lexer("12,34", false);
+    assert_eq!(lx.next_token(), Number(12.0));
+    assert_eq!(lx.next_token(), Comma);
+    assert_eq!(lx.next_token(), Number(34.0));
+    assert_eq!(lx.next_token(), EOF);
+
+    // Used for testing locales where the comma is the decimal separator
+    let mut lx = new_lexer("12,34", false);
+    lx.locale.numbers.symbols.decimal = ",".to_string();
+    assert_eq!(lx.next_token(), Number(12.34));
     assert_eq!(lx.next_token(), EOF);
 }
 

--- a/base/src/expressions/lexer/test/test_common.rs
+++ b/base/src/expressions/lexer/test/test_common.rs
@@ -577,13 +577,13 @@ fn test_range() {
                 column: 1,
                 row: 1,
                 absolute_column: false,
-                absolute_row: false,
+                absolute_row: false
             },
             right: ParsedReference {
                 column: 2,
                 row: 3,
                 absolute_column: false,
-                absolute_row: false,
+                absolute_row: false
             },
         }
     );

--- a/base/src/expressions/lexer/test/test_ranges.rs
+++ b/base/src/expressions/lexer/test/test_ranges.rs
@@ -34,7 +34,7 @@ fn test_range() {
                 row: 4,
                 absolute_column: false,
                 absolute_row: false,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -58,7 +58,7 @@ fn test_range_absolute_column() {
                 row: 4,
                 absolute_column: false,
                 absolute_row: true,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -82,7 +82,7 @@ fn test_range_with_sheet() {
                 row: 4,
                 absolute_column: false,
                 absolute_row: false,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -106,8 +106,41 @@ fn test_range_with_sheet_with_space() {
                 row: 44,
                 absolute_column: false,
                 absolute_row: false,
-            }
+            },
         }
+    );
+    assert_eq!(lx.next_token(), EOF);
+}
+
+#[test]
+fn test_range_error() {
+    let mut lx = new_lexer("'Sheet 1'!3.4:5");
+    assert_eq!(
+        lx.next_token(),
+        Illegal(LexerError {
+            position: 10,
+            message: "Expecting reference in range".to_string(),
+        })
+    );
+    assert_eq!(lx.next_token(), EOF);
+
+    let mut lx = new_lexer("'Sheet 1'!3:A2");
+    assert_eq!(
+        lx.next_token(),
+        Illegal(LexerError {
+            position: 14,
+            message: "Error parsing Range".to_string()
+        })
+    );
+    assert_eq!(lx.next_token(), EOF);
+
+    let mut lx = new_lexer("'Sheet 1'!3:");
+    assert_eq!(
+        lx.next_token(),
+        Illegal(LexerError {
+            position: 12,
+            message: "Error parsing Range".to_string()
+        })
     );
     assert_eq!(lx.next_token(), EOF);
 }
@@ -130,7 +163,7 @@ fn test_range_column() {
                 row: LAST_ROW,
                 absolute_column: false,
                 absolute_row: true,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -167,7 +200,7 @@ fn test_range_column_absolute1() {
                 row: LAST_ROW,
                 absolute_column: false,
                 absolute_row: true,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -191,7 +224,7 @@ fn test_range_column_absolute2() {
                 row: LAST_ROW,
                 absolute_column: true,
                 absolute_row: true,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -215,7 +248,7 @@ fn test_range_rows() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -239,7 +272,7 @@ fn test_range_rows_absolute1() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -263,7 +296,7 @@ fn test_range_rows_absolute2() {
                 row: 55,
                 absolute_column: true,
                 absolute_row: true,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -287,7 +320,7 @@ fn test_range_column_sheet() {
                 row: LAST_ROW,
                 absolute_column: false,
                 absolute_row: true,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -311,7 +344,7 @@ fn test_range_column_sheet_absolute() {
                 row: LAST_ROW,
                 absolute_column: true,
                 absolute_row: true,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -332,7 +365,7 @@ fn test_range_column_sheet_absolute() {
                 row: LAST_ROW,
                 absolute_column: true,
                 absolute_row: true,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -356,7 +389,7 @@ fn test_range_rows_sheet() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -376,7 +409,7 @@ fn test_range_rows_sheet() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -407,7 +440,7 @@ fn test_non_range_invalid_variable_name_a03() {
             row: 3,
             column: 1,
             absolute_column: false,
-            absolute_row: false
+            absolute_row: false,
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -423,7 +456,7 @@ fn test_non_range_invalid_variable_name_sheet1_a03() {
             row: 3,
             column: 1,
             absolute_column: false,
-            absolute_row: false
+            absolute_row: false,
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -447,7 +480,7 @@ fn test_range_rows_with_0() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            }
+            },
         }
     );
     assert_eq!(lx.next_token(), EOF);

--- a/base/src/expressions/lexer/test/test_ranges.rs
+++ b/base/src/expressions/lexer/test/test_ranges.rs
@@ -34,7 +34,7 @@ fn test_range() {
                 row: 4,
                 absolute_column: false,
                 absolute_row: false,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -58,7 +58,7 @@ fn test_range_absolute_column() {
                 row: 4,
                 absolute_column: false,
                 absolute_row: true,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -82,7 +82,7 @@ fn test_range_with_sheet() {
                 row: 4,
                 absolute_column: false,
                 absolute_row: false,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -106,7 +106,7 @@ fn test_range_with_sheet_with_space() {
                 row: 44,
                 absolute_column: false,
                 absolute_row: false,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -163,7 +163,7 @@ fn test_range_column() {
                 row: LAST_ROW,
                 absolute_column: false,
                 absolute_row: true,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -200,7 +200,7 @@ fn test_range_column_absolute1() {
                 row: LAST_ROW,
                 absolute_column: false,
                 absolute_row: true,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -224,7 +224,7 @@ fn test_range_column_absolute2() {
                 row: LAST_ROW,
                 absolute_column: true,
                 absolute_row: true,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -248,7 +248,7 @@ fn test_range_rows() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -272,7 +272,7 @@ fn test_range_rows_absolute1() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -296,7 +296,7 @@ fn test_range_rows_absolute2() {
                 row: 55,
                 absolute_column: true,
                 absolute_row: true,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -320,7 +320,7 @@ fn test_range_column_sheet() {
                 row: LAST_ROW,
                 absolute_column: false,
                 absolute_row: true,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -344,7 +344,7 @@ fn test_range_column_sheet_absolute() {
                 row: LAST_ROW,
                 absolute_column: true,
                 absolute_row: true,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -365,7 +365,7 @@ fn test_range_column_sheet_absolute() {
                 row: LAST_ROW,
                 absolute_column: true,
                 absolute_row: true,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -389,7 +389,7 @@ fn test_range_rows_sheet() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -409,7 +409,7 @@ fn test_range_rows_sheet() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -440,7 +440,7 @@ fn test_non_range_invalid_variable_name_a03() {
             row: 3,
             column: 1,
             absolute_column: false,
-            absolute_row: false,
+            absolute_row: false
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -456,7 +456,7 @@ fn test_non_range_invalid_variable_name_sheet1_a03() {
             row: 3,
             column: 1,
             absolute_column: false,
-            absolute_row: false,
+            absolute_row: false
         }
     );
     assert_eq!(lx.next_token(), EOF);
@@ -480,7 +480,7 @@ fn test_range_rows_with_0() {
                 row: 5,
                 absolute_column: true,
                 absolute_row: false,
-            },
+            }
         }
     );
     assert_eq!(lx.next_token(), EOF);

--- a/base/src/expressions/test.rs
+++ b/base/src/expressions/test.rs
@@ -10,6 +10,11 @@ fn test_error_codes() {
         Error::NA,
         Error::NUM,
         Error::ERROR,
+        Error::NIMPL,
+        Error::SPILL,
+        Error::CALC,
+        Error::CIRC,
+        Error::NULL
     ];
     for (i, error) in errors.iter().enumerate() {
         let s = format!("{}", error);


### PR DESCRIPTION
Adding additional unit tests to the lexer to improve test coverage gaps outlined in [Codecov](https://app.codecov.io/gh/ironcalc/IronCalc/blob/main/base%2Fsrc%2Fexpressions%2Flexer%2Fmod.rs).