### PR TITLE
Adding garbage collector for `model.shared_strings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,14 @@
 
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: https://github.com/ironcalc/IronCalc/blob/main/LICENSE-MIT
-
 [apache-badge]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
 [apache-url]: https://github.com/ironcalc/IronCalc/blob/main/LICENSE-Apache-2.0
-
 [codecov-badge]: https://codecov.io/gh/ironcalc/IronCalc/graph/badge.svg?token=ASJX12CHNR
 [codecov-url]: https://codecov.io/gh/ironcalc/IronCalc
-
 [actions-badge]: https://github.com/ironcalc/ironcalc/actions/workflows/rust-build-test.yaml/badge.svg
 [actions-url]: https://github.com/ironcalc/IronCalc/actions/workflows/rust-build-test.yaml?query=workflow%3ARust+branch%3Amain
-
 [docs-url]: https://docs.rs/ironcalc
 [docs-badge]: https://img.shields.io/docsrs/ironcalc?logo=rust&style=flat-square
-
 [discord-badge]: https://img.shields.io/discord/1206947691058171904.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/zZYWfh3RHJ
 
@@ -52,6 +47,7 @@ make tests
 Note that this runs unit tests, integration tests, linter tests and formatting tests.
 
 If you want to run the code coverage yourself:
+
 ```bash
 make coverage
 cd target/coverage/html/
@@ -75,6 +71,7 @@ And visit <http://0.0.0.0:8000/ironcalc/>
 # Simple example
 
 Add the dependency to `Cargo.toml`:
+
 ```toml
 [dependencies]
 ironcalc = { git = "https://github.com/ironcalc/IronCalc", version = "0.1"}
@@ -108,7 +105,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     model.evaluate();
 
     // saves to disk
-    save_to_xlsx(&model, "hello-calc.xlsx")?;
+    save_to_xlsx(&mut model, "hello-calc.xlsx")?;
     Ok(())
 }
 ```
@@ -125,7 +122,6 @@ An early preview of the technology running entirely in your browser:
 
 https://playground.ironcalc.com
 
-
 # Collaborators needed!. Call to action
 
 We don't have a vibrant community just yet. This is the very stages of the project. But if you are passionate about code with high standards and no compromises, if you are looking for a project with high impact, if you are interested in a better, more open infrastructure for spreadsheets, whether you are a developer (rust, python, TypeScript, electron/tauri/anything else native app, React, you name it), a designer (we need a logo desperately!), an Excel power user who wants features, a business looking to integrate a MIT/Apache licensed spreadsheet in your own SaaS application join us!
@@ -136,12 +132,11 @@ Many have said it better before me:
 
 > Folks wanted for hazardous journey. Low wages, bitter cold, long hours of complete darkness. Safe return doubtful. Honour and recognition in event of success.
 
-
 # License
 
 Licensed under either of
 
-* [MIT license](LICENSE-MIT)
-* [Apache license, version 2.0](LICENSE-Apache-2.0)
+-   [MIT license](LICENSE-MIT)
+-   [Apache license, version 2.0](LICENSE-Apache-2.0)
 
 at your option.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,19 @@
 
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: https://github.com/ironcalc/IronCalc/blob/main/LICENSE-MIT
+
 [apache-badge]: https://img.shields.io/badge/License-Apache_2.0-blue.svg
 [apache-url]: https://github.com/ironcalc/IronCalc/blob/main/LICENSE-Apache-2.0
+
 [codecov-badge]: https://codecov.io/gh/ironcalc/IronCalc/graph/badge.svg?token=ASJX12CHNR
 [codecov-url]: https://codecov.io/gh/ironcalc/IronCalc
+
 [actions-badge]: https://github.com/ironcalc/ironcalc/actions/workflows/rust-build-test.yaml/badge.svg
 [actions-url]: https://github.com/ironcalc/IronCalc/actions/workflows/rust-build-test.yaml?query=workflow%3ARust+branch%3Amain
+
 [docs-url]: https://docs.rs/ironcalc
 [docs-badge]: https://img.shields.io/docsrs/ironcalc?logo=rust&style=flat-square
+
 [discord-badge]: https://img.shields.io/discord/1206947691058171904.svg?logo=discord&style=flat-square
 [discord-url]: https://discord.gg/zZYWfh3RHJ
 
@@ -47,7 +52,6 @@ make tests
 Note that this runs unit tests, integration tests, linter tests and formatting tests.
 
 If you want to run the code coverage yourself:
-
 ```bash
 make coverage
 cd target/coverage/html/
@@ -71,7 +75,6 @@ And visit <http://0.0.0.0:8000/ironcalc/>
 # Simple example
 
 Add the dependency to `Cargo.toml`:
-
 ```toml
 [dependencies]
 ironcalc = { git = "https://github.com/ironcalc/IronCalc", version = "0.1"}
@@ -122,6 +125,7 @@ An early preview of the technology running entirely in your browser:
 
 https://playground.ironcalc.com
 
+
 # Collaborators needed!. Call to action
 
 We don't have a vibrant community just yet. This is the very stages of the project. But if you are passionate about code with high standards and no compromises, if you are looking for a project with high impact, if you are interested in a better, more open infrastructure for spreadsheets, whether you are a developer (rust, python, TypeScript, electron/tauri/anything else native app, React, you name it), a designer (we need a logo desperately!), an Excel power user who wants features, a business looking to integrate a MIT/Apache licensed spreadsheet in your own SaaS application join us!
@@ -132,11 +136,12 @@ Many have said it better before me:
 
 > Folks wanted for hazardous journey. Low wages, bitter cold, long hours of complete darkness. Safe return doubtful. Honour and recognition in event of success.
 
+
 # License
 
 Licensed under either of
 
--   [MIT license](LICENSE-MIT)
--   [Apache license, version 2.0](LICENSE-Apache-2.0)
+* [MIT license](LICENSE-MIT)
+* [Apache license, version 2.0](LICENSE-Apache-2.0)
 
 at your option.

--- a/base/src/garbage_collector.rs
+++ b/base/src/garbage_collector.rs
@@ -7,19 +7,12 @@ impl Model {
     /// These include:
     /// - Shared strings that are no longer referenced by any cell
     pub fn garbage_collector(&mut self) -> Result<(), String> {
-        let cell_values = self.get_all_cell_values().unwrap();
-        let mut new_shared_strings = self.shared_strings.clone();
+        let cell_values = self.get_all_cell_values()?;
 
-        for (index, _) in self.shared_strings.iter() {
-            // A cell is referencing the string, so we continue
-            if cell_values.contains(index) {
-                continue;
-            }
-
-            new_shared_strings.remove(index);
-        }
-
-        self.shared_strings = new_shared_strings;
+        self.shared_strings.retain(|index, _| {
+            // A cell is referencing the string, so we keep it
+            cell_values.contains(index)
+        });
 
         Ok(())
     }

--- a/base/src/garbage_collector.rs
+++ b/base/src/garbage_collector.rs
@@ -1,12 +1,12 @@
 #![allow(clippy::unwrap_used)]
 
-use crate::model::Model;
+use crate::model::Model; // Add the missing error module
 
 impl Model {
     /// The garbage collector cleans up any lefover elements in the workbook that are no longer used.
     /// These include:
     /// - Shared strings that are no longer referenced by any cell
-    pub(crate) fn garbage_collector(&mut self) -> Result<(), String> {
+    pub fn garbage_collector(&mut self) -> Result<(), String> {
         let cell_values = self.get_all_cell_values().unwrap();
         let mut new_shared_strings = self.shared_strings.clone();
 
@@ -31,7 +31,7 @@ impl Model {
 
         for cell in cells {
             let cell_value = self.formatted_cell_value(cell.index, cell.row, cell.column);
-            cell_values.push(cell_value);
+            cell_values.push(cell_value?);
         }
 
         Ok(cell_values)

--- a/base/src/garbage_collector.rs
+++ b/base/src/garbage_collector.rs
@@ -30,9 +30,7 @@ impl Model {
         let mut cell_values = Vec::new();
 
         for cell in cells {
-            let cell_value = self
-                .formatted_cell_value(cell.index, cell.row, cell.column)
-                .unwrap();
+            let cell_value = self.formatted_cell_value(cell.index, cell.row, cell.column);
             cell_values.push(cell_value);
         }
 

--- a/base/src/garbage_collector.rs
+++ b/base/src/garbage_collector.rs
@@ -1,0 +1,39 @@
+use crate::model::Model;
+
+impl Model {
+    /// The garbage collector cleans up any lefover elements in the workbook that are no longer used.
+    /// These include:
+    /// - Shared strings that are no longer referenced by any cell
+    pub(crate) fn garbage_collector(&mut self) -> Result<(), String> {
+        let cell_values = self.get_all_cell_values().unwrap();
+        let mut new_shared_strings = self.shared_strings.clone();
+
+        for (index, _) in self.shared_strings.iter() {
+            // A cell is referencing the string, so we continue
+            if cell_values.contains(index) {
+                continue;
+            }
+
+            new_shared_strings.remove(index);
+        }
+
+        self.shared_strings = new_shared_strings;
+
+        Ok(())
+    }
+
+    /// Returns a vector of all formatted cell values in the workbook.
+    fn get_all_cell_values(&self) -> Result<Vec<String>, String> {
+        let cells = self.get_all_cells();
+        let mut cell_values = Vec::new();
+
+        for cell in cells {
+            let cell_value = self
+                .formatted_cell_value(cell.index, cell.row, cell.column)
+                .unwrap();
+            cell_values.push(cell_value);
+        }
+
+        Ok(cell_values)
+    }
+}

--- a/base/src/garbage_collector.rs
+++ b/base/src/garbage_collector.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use crate::model::Model;
 
 impl Model {

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -47,6 +47,7 @@ mod styles;
 mod diffs;
 mod implicit_intersection;
 
+mod garbage_collector;
 mod units;
 mod utils;
 mod workbook;

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1645,6 +1645,8 @@ impl Model {
                 column: cell.column,
             });
         }
+
+        self.garbage_collector().unwrap();
     }
 
     /// Sets cell to empty. Can be used to delete value without affecting style.

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1645,8 +1645,6 @@ impl Model {
                 column: cell.column,
             });
         }
-
-        self.garbage_collector();
     }
 
     /// Sets cell to empty. Can be used to delete value without affecting style.

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1646,7 +1646,7 @@ impl Model {
             });
         }
 
-        self.garbage_collector().unwrap();
+        self.garbage_collector();
     }
 
     /// Sets cell to empty. Can be used to delete value without affecting style.

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -53,3 +53,4 @@ mod test_frozen_rows_and_columns;
 mod test_get_cell_content;
 mod test_percentage;
 mod test_today;
+mod test_garbage_collector;

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -50,7 +50,7 @@ mod test_escape_quotes;
 mod test_extend;
 mod test_fn_type;
 mod test_frozen_rows_and_columns;
+mod test_garbage_collector;
 mod test_get_cell_content;
 mod test_percentage;
 mod test_today;
-mod test_garbage_collector;

--- a/base/src/test/test_garbage_collector.rs
+++ b/base/src/test/test_garbage_collector.rs
@@ -1,28 +1,7 @@
 use super::util::new_empty_model;
 
 #[test]
-fn shared_strings_one_reference() {
-    let mut model = new_empty_model();
-
-    // Set an arbitrary string in a cell
-    model._set("A1", "Hello");
-    assert_eq!(model.shared_strings.len(), 1);
-
-    // Calling the garbage collector should not do anything
-    model.garbage_collector().unwrap();
-    assert_eq!(model.shared_strings.len(), 1);
-
-    // Deleting the cell will leave the string in model.shared_strings
-    model.delete_cell(0, 1, 1).unwrap();
-    assert_eq!(model.shared_strings.len(), 1);
-
-    // The garbage collector should now remove the reference
-    model.garbage_collector().unwrap();
-    assert_eq!(model.shared_strings.len(), 0);
-}
-
-#[test]
-fn shared_strings_multiple_references() {
+fn shared_strings() {
     let mut model = new_empty_model();
 
     // Set an arbitrary string in a cell
@@ -30,15 +9,23 @@ fn shared_strings_multiple_references() {
     model._set("A2", "Hello");
     assert_eq!(model.shared_strings.len(), 1);
 
-    // Calling the garbage collector should not do anything
+    // Calling the garbage collector should not do anything since A1 and A2 reference the same string
     model.garbage_collector().unwrap();
     assert_eq!(model.shared_strings.len(), 1);
 
-    // Deleting the cell will leave the string in model.shared_strings
+    // Deleting a cell should leave the string in model.shared_strings because the GC hasn't run yet
     model.delete_cell(0, 1, 1).unwrap();
     assert_eq!(model.shared_strings.len(), 1);
 
-    // The garbage collector will leave the string in model.shared_strings since A2 is still referencing it
+    // The garbage collector should leave the string in model.shared_strings since A2 is still referencing it
     model.garbage_collector().unwrap();
     assert_eq!(model.shared_strings.len(), 1);
+
+    // Deleting a cell should leave the string in model.shared_strings because the GC hasn't run yet
+    model.delete_cell(0, 2, 1).unwrap();
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // The garbage collector should remove the reference now that A1 and A2 are gone
+    model.garbage_collector().unwrap();
+    assert_eq!(model.shared_strings.len(), 0);
 }

--- a/base/src/test/test_garbage_collector.rs
+++ b/base/src/test/test_garbage_collector.rs
@@ -42,3 +42,20 @@ fn shared_strings_multiple_references() {
     model.garbage_collector().unwrap();
     assert_eq!(model.shared_strings.len(), 1);
 }
+
+#[test]
+fn evaluate_runs_garbage_collector() {
+    let mut model = new_empty_model();
+
+    // Set an arbitrary string in a cell
+    model._set("A1", "Hello");
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // Deleting the cell will leave the string in model.shared_strings
+    model.delete_cell(0, 1, 1).unwrap();
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // The garbage collector (via model.evaluate) should now remove the reference
+    model.evaluate();
+    assert_eq!(model.shared_strings.len(), 0);
+}

--- a/base/src/test/test_garbage_collector.rs
+++ b/base/src/test/test_garbage_collector.rs
@@ -1,7 +1,7 @@
 use super::util::new_empty_model;
 
 #[test]
-fn test_one_reference() {
+fn shared_strings_one_reference() {
     let mut model = new_empty_model();
 
     // Set an arbitrary string in a cell
@@ -22,7 +22,7 @@ fn test_one_reference() {
 }
 
 #[test]
-fn test_multiple_references() {
+fn shared_strings_multiple_references() {
     let mut model = new_empty_model();
 
     // Set an arbitrary string in a cell

--- a/base/src/test/test_garbage_collector.rs
+++ b/base/src/test/test_garbage_collector.rs
@@ -42,20 +42,3 @@ fn shared_strings_multiple_references() {
     model.garbage_collector().unwrap();
     assert_eq!(model.shared_strings.len(), 1);
 }
-
-#[test]
-fn evaluate_runs_garbage_collector() {
-    let mut model = new_empty_model();
-
-    // Set an arbitrary string in a cell
-    model._set("A1", "Hello");
-    assert_eq!(model.shared_strings.len(), 1);
-
-    // Deleting the cell will leave the string in model.shared_strings
-    model.delete_cell(0, 1, 1).unwrap();
-    assert_eq!(model.shared_strings.len(), 1);
-
-    // The garbage collector (via model.evaluate) should now remove the reference
-    model.evaluate();
-    assert_eq!(model.shared_strings.len(), 0);
-}

--- a/base/src/test/test_garbage_collector.rs
+++ b/base/src/test/test_garbage_collector.rs
@@ -1,0 +1,44 @@
+use super::util::new_empty_model;
+
+#[test]
+fn test_one_reference() {
+    let mut model = new_empty_model();
+
+    // Set an arbitrary string in a cell
+    model._set("A1", "Hello");
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // Calling the garbage collector should not do anything
+    model.garbage_collector().unwrap();
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // Deleting the cell will leave the string in model.shared_strings
+    model.delete_cell(0, 1, 1).unwrap();
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // The garbage collector should now remove the reference
+    model.garbage_collector().unwrap();
+    assert_eq!(model.shared_strings.len(), 0);
+}
+
+#[test]
+fn test_multiple_references() {
+    let mut model = new_empty_model();
+
+    // Set an arbitrary string in a cell
+    model._set("A1", "Hello");
+    model._set("A2", "Hello");
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // Calling the garbage collector should not do anything
+    model.garbage_collector().unwrap();
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // Deleting the cell will leave the string in model.shared_strings
+    model.delete_cell(0, 1, 1).unwrap();
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // The garbage collector will leave the string in model.shared_strings since A2 is still referencing it
+    model.garbage_collector().unwrap();
+    assert_eq!(model.shared_strings.len(), 1);
+}

--- a/xlsx/examples/hello_calc.rs
+++ b/xlsx/examples/hello_calc.rs
@@ -23,6 +23,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     model.evaluate();
 
     // saves to disk
-    save_to_xlsx(&model, "hello-calc.xlsx")?;
+    save_to_xlsx(&mut model, "hello-calc.xlsx")?;
     Ok(())
 }

--- a/xlsx/examples/hello_styles.rs
+++ b/xlsx/examples/hello_styles.rs
@@ -12,6 +12,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     model.set_cell_style(sheet, row, column, &style)?;
 
     // saves to disk
-    save_to_xlsx(&model, "hello-styles.xlsx")?;
+    save_to_xlsx(&mut model, "hello-styles.xlsx")?;
     Ok(())
 }

--- a/xlsx/examples/widths_and_heights.rs
+++ b/xlsx/examples/widths_and_heights.rs
@@ -14,6 +14,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     worksheet.set_row_height(row, row_height)?;
 
     // saves to disk
-    save_to_xlsx(&model, "widths-and-heights.xlsx")?;
+    save_to_xlsx(&mut model, "widths-and-heights.xlsx")?;
     Ok(())
 }

--- a/xlsx/src/bin/test.rs
+++ b/xlsx/src/bin/test.rs
@@ -30,5 +30,5 @@ fn main() {
     let mut model = load_model_from_xlsx(file_name, "en", "UTC").unwrap();
     model.evaluate();
     println!("Saving result as: {output_file_name}. Please open with Excel and test.");
-    save_to_xlsx(&model, output_file_name).unwrap();
+    save_to_xlsx(&mut model, output_file_name).unwrap();
 }

--- a/xlsx/src/compare.rs
+++ b/xlsx/src/compare.rs
@@ -191,14 +191,14 @@ pub fn test_file(file_path: &str) -> Result<(), String> {
 
 /// Tests that file in file_path can be converted to xlsx and read again
 pub fn test_load_and_saving(file_path: &str, temp_dir_name: &Path) -> Result<(), String> {
-    let model1 = load_model_from_xlsx(file_path, "en", "UTC").unwrap();
+    let mut model1 = load_model_from_xlsx(file_path, "en", "UTC").unwrap();
 
     let base_name = Path::new(file_path).file_name().unwrap().to_str().unwrap();
 
     let temp_path_buff = temp_dir_name.join(base_name);
     let temp_file_path = &format!("{}.xlsx", temp_path_buff.to_str().unwrap());
     // test can save
-    save_to_xlsx(&model1, temp_file_path).unwrap();
+    save_to_xlsx(&mut model1, temp_file_path).unwrap();
     // test can open
     let mut model2 = load_model_from_xlsx(temp_file_path, "en", "UTC").unwrap();
     model2.evaluate();

--- a/xlsx/src/export/mod.rs
+++ b/xlsx/src/export/mod.rs
@@ -65,7 +65,7 @@ pub fn save_to_xlsx(model: &mut Model, file_name: &str) -> Result<(), XlsxError>
 
     let gc = model.garbage_collector();
     if gc.is_err() {
-        return Err(XlsxError::IO(gc.err().unwrap()));
+        return Err(XlsxError::IO("Garbage collector failed".to_string()));
     }
 
     Ok(())
@@ -129,9 +129,11 @@ pub fn save_xlsx_to_writer<W: Write + Seek>(model: &mut Model, writer: W) -> Res
         )?;
     }
 
+    let writer = zip.finish()?;
+
     let gc = model.garbage_collector();
     if gc.is_err() {
-        return Err(XlsxError::IO(gc.err().unwrap()));
+        return Err(XlsxError::IO("Garbage collector failed".to_string()));
     }
 
     Ok(writer)

--- a/xlsx/src/export/mod.rs
+++ b/xlsx/src/export/mod.rs
@@ -64,10 +64,6 @@ pub fn save_to_xlsx(model: &mut Model, file_name: &str) -> Result<(), XlsxError>
     let writer = BufWriter::new(file);
     save_xlsx_to_writer(model, writer)?;
 
-    if let Err(err) = model.garbage_collector() {
-        return Err(XlsxError::IO(err));
-    }
-
     Ok(())
 }
 

--- a/xlsx/src/export/test/test_export.rs
+++ b/xlsx/src/export/test/test_export.rs
@@ -28,7 +28,7 @@ fn test_values() {
     model.evaluate();
 
     let temp_file_name = "temp_file_test_values.xlsx";
-    save_to_xlsx(&model, temp_file_name).unwrap();
+    save_to_xlsx(&mut model, temp_file_name).unwrap();
 
     let model = load_model_from_xlsx(temp_file_name, "en", "UTC").unwrap();
     assert_eq!(model.formatted_cell_value(0, 1, 1).unwrap(), "123.456");
@@ -56,7 +56,7 @@ fn test_formulas() {
 
     model.evaluate();
     let temp_file_name = "temp_file_test_formulas.xlsx";
-    save_to_xlsx(&model, temp_file_name).unwrap();
+    save_to_xlsx(&mut model, temp_file_name).unwrap();
 
     let model = load_model_from_xlsx(temp_file_name, "en", "UTC").unwrap();
     assert_eq!(model.formatted_cell_value(0, 1, 2).unwrap(), "11");
@@ -78,7 +78,7 @@ fn test_sheets() {
     model.evaluate();
 
     let temp_file_name = "temp_file_test_sheets.xlsx";
-    save_to_xlsx(&model, temp_file_name).unwrap();
+    save_to_xlsx(&mut model, temp_file_name).unwrap();
 
     let model = load_model_from_xlsx(temp_file_name, "en", "UTC").unwrap();
     assert_eq!(
@@ -107,7 +107,7 @@ fn test_named_styles() {
     model.evaluate();
 
     let temp_file_name = "temp_file_test_named_styles.xlsx";
-    save_to_xlsx(&model, temp_file_name).unwrap();
+    save_to_xlsx(&mut model, temp_file_name).unwrap();
 
     let model = load_model_from_xlsx(temp_file_name, "en", "UTC").unwrap();
     assert!(model
@@ -124,7 +124,7 @@ fn test_existing_file() {
     fs::File::create(file_name).unwrap();
 
     assert_eq!(
-        save_to_xlsx(&new_empty_model(), file_name),
+        save_to_xlsx(&mut new_empty_model(), file_name),
         Err(XlsxError::IO(
             "file existing_file.xlsx already exists".to_string()
         )),

--- a/xlsx/src/export/test/test_export.rs
+++ b/xlsx/src/export/test/test_export.rs
@@ -132,3 +132,22 @@ fn test_existing_file() {
 
     fs::remove_file(file_name).unwrap();
 }
+
+#[test]
+fn save_to_xlsx_runs_garbage_collector() {
+    let mut model = new_empty_model();
+
+    // Set an arbitrary string in a cell
+    model.set_user_input(0, 1, 1, "Hello".to_string());
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // Deleting the cell will leave the string in model.shared_strings
+    model.delete_cell(0, 1, 1).unwrap();
+    assert_eq!(model.shared_strings.len(), 1);
+
+    // The garbage collector (via save_to_xlsx) should now remove the reference
+    let temp_file_name = "temp_file_test_sheets.xlsx";
+    save_to_xlsx(&mut model, temp_file_name).unwrap();
+    assert_eq!(model.shared_strings.len(), 0);
+    fs::remove_file(temp_file_name).unwrap();
+}

--- a/xlsx/src/export/test/test_export.rs
+++ b/xlsx/src/export/test/test_export.rs
@@ -136,6 +136,7 @@ fn test_existing_file() {
 #[test]
 fn save_to_xlsx_runs_garbage_collector() {
     let mut model = new_empty_model();
+    let temp_file_name = "temp_file_test_gc.xlsx";
 
     // Set an arbitrary string in a cell
     model.set_user_input(0, 1, 1, "Hello".to_string());
@@ -146,8 +147,8 @@ fn save_to_xlsx_runs_garbage_collector() {
     assert_eq!(model.shared_strings.len(), 1);
 
     // The garbage collector (via save_to_xlsx) should now remove the reference
-    let temp_file_name = "temp_file_test_sheets.xlsx";
     save_to_xlsx(&mut model, temp_file_name).unwrap();
     assert_eq!(model.shared_strings.len(), 0);
+
     fs::remove_file(temp_file_name).unwrap();
 }

--- a/xlsx/tests/test.rs
+++ b/xlsx/tests/test.rs
@@ -27,7 +27,7 @@ fn test_save_to_xlsx() {
     model.evaluate();
     let temp_file_name = "temp_file_example.xlsx";
     // test can safe
-    save_to_xlsx(&model, temp_file_name).unwrap();
+    save_to_xlsx(&mut model, temp_file_name).unwrap();
     // test can open
     let model = load_model_from_xlsx(temp_file_name, "en", "UTC").unwrap();
     let metadata = &model.workbook.metadata;
@@ -145,12 +145,12 @@ fn test_model_has_correct_styles(model: &Model) {
 
 #[test]
 fn test_simple_text() {
-    let model = load_model_from_xlsx("tests/basic_text.xlsx", "en", "UTC").unwrap();
+    let mut model = load_model_from_xlsx("tests/basic_text.xlsx", "en", "UTC").unwrap();
 
     test_model_has_correct_styles(&model);
 
     let temp_file_name = "temp_file_test_named_styles.xlsx";
-    save_to_xlsx(&model, temp_file_name).unwrap();
+    save_to_xlsx(&mut model, temp_file_name).unwrap();
 
     let model = load_model_from_xlsx(temp_file_name, "en", "UTC").unwrap();
     fs::remove_file(temp_file_name).unwrap();


### PR DESCRIPTION
## Background
`model.shared_strings` is an optimization for faster string look ups.  It is a mapping from a string value to a reference in memory.  Multiple cells that contain the same string value all use the same reference. 

## Change Summary
This change adds a garbage collector for `model.shared_strings`.  When cells are deleted using `model.delete_cell`, they are not removed from `model.shared_strings`.  This change cleans up unreachable string references when `model.evaluate` is run.  Before deleting a string, we must check the entire worksheet to make sure no other cells contain the deleted value before it can be deleted.

## Testing
- New tests were added in `base/src/test/test_garbage_collector.rs`
- The test suite was ran locally prior to submission using `make tests`

## Follow-Up Work
There is additional garbage collection (e.g., styles clean-up, etc.) that can be done in future PRs.

## References
- GitHub Issue: https://github.com/ironcalc/IronCalc/issues/13
- Branch with skeleton implementation: https://github.com/ironcalc/IronCalc/compare/main...feature/nicolas-garbage-collector