### PR TITLE
Fixing failing test: `test_complex.fn_imcos`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/*
+.DS_Store

--- a/base/src/test/engineering/test_complex.rs
+++ b/base/src/test/engineering/test_complex.rs
@@ -82,7 +82,7 @@ fn fn_imcos() {
     assert_complex_eq(
         &model._get_text("A1"),
         "-6.58066304055116+7.58155274274654i",
-        1e-14,
+        Some(1e-14),
     );
 }
 

--- a/base/src/test/engineering/test_complex.rs
+++ b/base/src/test/engineering/test_complex.rs
@@ -75,40 +75,20 @@ fn fn_imconjugate() {
 #[test]
 fn fn_imcos() {
     let mut model = new_empty_model();
-    model._set("A1", r#"=IMCOS("4+3i")"#);
+    model._set("A1", r#"0.11212+1.234523I"#);
+    model._set("A2", r#"=IMABS(IMCOS(3)-A1)"#);
 
     model.evaluate();
 
-    let cell_value = model._get_text("A1");
-    let (real_part, imag_part) =
-        parse_complex_number(&cell_value).expect("Failed to parse complex number");
+    let result_str = model._get_text("A2");
+    let float_value = match result_str.parse::<f64>() {
+        Ok(value) => value,
+        Err(err) => {
+            panic!("{}", err);
+        }
+    };
 
-    let expected_real = -6.58066304055116;
-    let expected_imag = 7.58155274274654;
-    let tolerance = 1e-14;
-
-    assert!(
-        (real_part - expected_real).abs() < tolerance
-            && (imag_part - expected_imag).abs() < tolerance,
-        "Expected approximately ({}, {}), got ({}, {})",
-        expected_real,
-        expected_imag,
-        real_part,
-        imag_part
-    );
-}
-
-fn parse_complex_number(s: &str) -> Result<(f64, f64), &'static str> {
-    let parts: Vec<&str> = s.split('+').collect();
-    let real_part = parts[0].parse().map_err(|_| "Invalid real part")?;
-    let imag_part = parts[1]
-        .split('i')
-        .next()
-        .unwrap()
-        .parse()
-        .map_err(|_| "Invalid imaginary part")?;
-
-    Ok((real_part, imag_part))
+    assert!(float_value < f64::EPSILON);
 }
 
 #[test]

--- a/base/src/test/engineering/test_complex.rs
+++ b/base/src/test/engineering/test_complex.rs
@@ -1,3 +1,4 @@
+use crate::test::util::assert_complex_eq;
 use crate::test::util::new_empty_model;
 
 #[test]
@@ -75,20 +76,15 @@ fn fn_imconjugate() {
 #[test]
 fn fn_imcos() {
     let mut model = new_empty_model();
-    model._set("A1", r#"0.11212+1.234523I"#);
-    model._set("A2", r#"=IMABS(IMCOS(3)-A1)"#);
+    model._set("A1", r#"=IMCOS("4+3i")"#);
 
     model.evaluate();
 
-    let result_str = model._get_text("A2");
-    let float_value = match result_str.parse::<f64>() {
-        Ok(value) => value,
-        Err(err) => {
-            panic!("{}", err);
-        }
-    };
-
-    assert!(float_value < f64::EPSILON);
+    assert_complex_eq(
+        &model._get_text("A1"),
+        "-6.58066304055116+7.58155274274654i",
+        1e-14,
+    );
 }
 
 #[test]

--- a/base/src/test/engineering/test_complex.rs
+++ b/base/src/test/engineering/test_complex.rs
@@ -79,11 +79,36 @@ fn fn_imcos() {
 
     model.evaluate();
 
-    let value = model._get_text("A1");
+    let cell_value = model._get_text("A1");
+    let (real_part, imag_part) =
+        parse_complex_number(&cell_value).expect("Failed to parse complex number");
+
+    let expected_real = -6.58066304055116;
+    let expected_imag = 7.58155274274654;
+    let tolerance = 1e-14;
+
     assert!(
-        value == "-6.58066304055116+7.58155274274654i"
-            || value == "-6.58066304055116+7.58155274274655i"
+        (real_part - expected_real).abs() < tolerance
+            && (imag_part - expected_imag).abs() < tolerance,
+        "Expected approximately ({}, {}), got ({}, {})",
+        expected_real,
+        expected_imag,
+        real_part,
+        imag_part
     );
+}
+
+fn parse_complex_number(s: &str) -> Result<(f64, f64), &'static str> {
+    let parts: Vec<&str> = s.split('+').collect();
+    let real_part = parts[0].parse().map_err(|_| "Invalid real part")?;
+    let imag_part = parts[1]
+        .split('i')
+        .next()
+        .unwrap()
+        .parse()
+        .map_err(|_| "Invalid imaginary part")?;
+
+    Ok((real_part, imag_part))
 }
 
 #[test]

--- a/base/src/test/engineering/test_complex.rs
+++ b/base/src/test/engineering/test_complex.rs
@@ -1,5 +1,4 @@
-use crate::test::util::assert_complex_eq;
-use crate::test::util::new_empty_model;
+use crate::test::util::{assert_complex_eq, new_empty_model};
 
 #[test]
 fn fn_complex() {

--- a/base/src/test/engineering/test_complex.rs
+++ b/base/src/test/engineering/test_complex.rs
@@ -79,7 +79,11 @@ fn fn_imcos() {
 
     model.evaluate();
 
-    assert_eq!(model._get_text("A1"), "-6.58066304055116+7.58155274274654i");
+    let value = model._get_text("A1");
+    assert!(
+        value == "-6.58066304055116+7.58155274274654i"
+            || value == "-6.58066304055116+7.58155274274655i"
+    );
 }
 
 #[test]

--- a/base/src/test/util.rs
+++ b/base/src/test/util.rs
@@ -51,7 +51,9 @@ impl Model {
     }
 }
 
-pub fn assert_complex_eq(a: &str, b: &str, epsilon: f64) {
+pub fn assert_complex_eq(a: &str, b: &str, epsilon: Option<f64>) {
+    let epsilon = epsilon.unwrap_or(1e-14);
+
     let re_a = a.split('+').next().unwrap().parse::<f64>().unwrap();
     let im_a = a
         .split('+')
@@ -72,5 +74,6 @@ pub fn assert_complex_eq(a: &str, b: &str, epsilon: f64) {
 
     let diff_re = (re_a - re_b).abs();
     let diff_im = (im_a - im_b).abs();
+
     assert!(diff_re < epsilon && diff_im < epsilon, "{} != {}", a, b);
 }

--- a/base/src/test/util.rs
+++ b/base/src/test/util.rs
@@ -51,12 +51,6 @@ impl Model {
     }
 }
 
-// pub fn assert_float_eq(a: &str, b: &str, epsilon: f64) {
-//     let a_float = a.parse::<f64>().unwrap();
-//     let b_float = b.parse::<f64>().unwrap();
-//     assert!((a_float - b_float).abs() < epsilon, "{} != {}", a, b);
-// }
-
 pub fn assert_complex_eq(a: &str, b: &str, epsilon: f64) {
     let re_a = a.split('+').next().unwrap().parse::<f64>().unwrap();
     let im_a = a

--- a/base/src/test/util.rs
+++ b/base/src/test/util.rs
@@ -50,3 +50,33 @@ impl Model {
             .unwrap()
     }
 }
+
+// pub fn assert_float_eq(a: &str, b: &str, epsilon: f64) {
+//     let a_float = a.parse::<f64>().unwrap();
+//     let b_float = b.parse::<f64>().unwrap();
+//     assert!((a_float - b_float).abs() < epsilon, "{} != {}", a, b);
+// }
+
+pub fn assert_complex_eq(a: &str, b: &str, epsilon: f64) {
+    let re_a = a.split('+').next().unwrap().parse::<f64>().unwrap();
+    let im_a = a
+        .split('+')
+        .last()
+        .unwrap()
+        .trim_end_matches('i')
+        .parse::<f64>()
+        .unwrap();
+
+    let re_b = b.split('+').next().unwrap().parse::<f64>().unwrap();
+    let im_b = b
+        .split('+')
+        .last()
+        .unwrap()
+        .trim_end_matches('i')
+        .parse::<f64>()
+        .unwrap();
+
+    let diff_re = (re_a - re_b).abs();
+    let diff_im = (im_a - im_b).abs();
+    assert!(diff_re < epsilon && diff_im < epsilon, "{} != {}", a, b);
+}


### PR DESCRIPTION
## Summary
This test was failing locally due to what looks to be a rounding error.  This fix changes the test to allow either value.

```
failures:

---- test::engineering::test_complex::fn_imcos stdout ----
thread 'test::engineering::test_complex::fn_imcos' panicked at base/src/test/engineering/test_complex.rs:82:5:
assertion `left == right` failed
  left: "-6.58066304055116+7.58155274274655i"
 right: "-6.58066304055116+7.58155274274654i"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test::engineering::test_complex::fn_imcos

test result: FAILED. 450 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.15s
```