### PR TITLE
Exporting the Merged Cell : Exports the merged cell properly with testcase to verify the scenario

### DIFF
--- a/xlsx/src/export/test/test_export.rs
+++ b/xlsx/src/export/test/test_export.rs
@@ -78,38 +78,6 @@ fn test_values() {
     }
 }
 
-// This test verifies whether exporting the
-// merged cells functionality is happening
-// properly or not.
-
-// This test is bit unconventional from the 
-// other tests as it first loads the excell
-// having the merged cell and exports it to 
-// anothe xlsx and verifies whether merged
-// cell node is same in both of the xlsx file
-#[test]
-fn test_exporting_merged_cells(){
-    let expected_merge_cell_ref;
-    let got_merge_cell_ref;
-    let temp_file_name = "temp_file_test_export_merged_cells.xlsx";
-    {
-        // loading the xlsx file containing merged cells
-        let example_file_name = "tests/example.xlsx";
-        let mut model = load_from_xlsx(example_file_name, "en", "UTC").unwrap();
-        expected_merge_cell_ref = model.workbook.worksheets.get(0).unwrap().merge_cells.clone();
-        // exporting and saving it in another xlsx
-        model.evaluate();
-        save_to_xlsx(&model, temp_file_name).unwrap();
-    }
-    //loading the previous file back and verifying whether
-    //merged cells got exported properly or not
-    let temp_model = load_from_xlsx(temp_file_name, "en", "UTC").unwrap();
-    got_merge_cell_ref = temp_model.workbook.worksheets.get(0).unwrap().merge_cells.clone();
-    assert_eq!(expected_merge_cell_ref, got_merge_cell_ref);
-
-    fs::remove_file(temp_file_name).unwrap();
-}
-
 #[test]
 fn test_formulas() {
     let mut model = new_empty_model();

--- a/xlsx/src/export/test/test_export.rs
+++ b/xlsx/src/export/test/test_export.rs
@@ -78,6 +78,38 @@ fn test_values() {
     }
 }
 
+// This test verifies whether exporting the
+// merged cells functionality is happening
+// properly or not.
+
+// This test is bit unconventional from the 
+// other tests as it first loads the excell
+// having the merged cell and exports it to 
+// anothe xlsx and verifies whether merged
+// cell node is same in both of the xlsx file
+#[test]
+fn test_exporting_merged_cells(){
+    let expected_merge_cell_ref;
+    let got_merge_cell_ref;
+    let temp_file_name = "temp_file_test_export_merged_cells.xlsx";
+    {
+        // loading the xlsx file containing merged cells
+        let example_file_name = "tests/example.xlsx";
+        let mut model = load_from_xlsx(example_file_name, "en", "UTC").unwrap();
+        expected_merge_cell_ref = model.workbook.worksheets.get(0).unwrap().merge_cells.clone();
+        // exporting and saving it in another xlsx
+        model.evaluate();
+        save_to_xlsx(&model, temp_file_name).unwrap();
+    }
+    //loading the previous file back and verifying whether
+    //merged cells got exported properly or not
+    let temp_model = load_from_xlsx(temp_file_name, "en", "UTC").unwrap();
+    got_merge_cell_ref = temp_model.workbook.worksheets.get(0).unwrap().merge_cells.clone();
+    assert_eq!(expected_merge_cell_ref, got_merge_cell_ref);
+
+    fs::remove_file(temp_file_name).unwrap();
+}
+
 #[test]
 fn test_formulas() {
     let mut model = new_empty_model();

--- a/xlsx/src/export/worksheets.rs
+++ b/xlsx/src/export/worksheets.rs
@@ -13,7 +13,7 @@
 //!   <v>1</v>
 //! </c>
 //! Formula in F6 would then be 'A6+C6'
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::format};
 
 use itertools::Itertools;
 
@@ -59,6 +59,7 @@ pub(crate) fn get_worksheet_xml(
 ) -> String {
     let mut sheet_data_str: Vec<String> = vec![];
     let mut cols_str: Vec<String> = vec![];
+    let mut merged_cells_str: Vec<String> = vec![];
 
     for col in &worksheet.cols {
         // <col min="4" max="4" width="12" customWidth="1"/>
@@ -241,6 +242,15 @@ pub(crate) fn get_worksheet_xml(
         ))
     }
     let sheet_data = sheet_data_str.join("");
+
+    for (_ind,merge_cell_ref) in worksheet.merge_cells.iter().enumerate(){
+        merged_cells_str.push(format!(
+            "<mergeCell ref=\"{merge_cell_ref}\"/>"
+        ))
+    }
+    let merged_cells_count = merged_cells_str.len();
+    let merged_cells = merged_cells_str.join("");
+
     let cols = cols_str.join("");
     let cols = if cols.is_empty() {
         "".to_string()
@@ -295,6 +305,9 @@ xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">
   <sheetData>\
   {sheet_data}\
   </sheetData>\
+  <mergeCells count=\"{merged_cells_count}\">\
+  {merged_cells}\
+  </mergeCells>\
 </worksheet>"
     )
 }

--- a/xlsx/src/export/worksheets.rs
+++ b/xlsx/src/export/worksheets.rs
@@ -243,11 +243,10 @@ pub(crate) fn get_worksheet_xml(
     }
     let sheet_data = sheet_data_str.join("");
 
-    for (_ind, merge_cell_ref) in worksheet.merge_cells.iter().enumerate() {
+    for merge_cell_ref in worksheet.merge_cells.clone() {
         merged_cells_str.push(format!("<mergeCell ref=\"{merge_cell_ref}\"/>"))
     }
     let merged_cells_count = merged_cells_str.len();
-    let merged_cells = merged_cells_str.join("");
 
     let cols = cols_str.join("");
     let cols = if cols.is_empty() {
@@ -290,12 +289,12 @@ pub(crate) fn get_worksheet_xml(
 
     let merge_cells_section = if merged_cells_count > 0 {
         format!(
-            "<mergeCells count=\"{merged_cells_count}\">{merged_cells}</mergeCells>",
-            merged_cells_count = merged_cells_count,
-            merged_cells = merged_cells
+            "<mergeCells count=\"{}\">{}</mergeCells>",
+            merged_cells_count,
+            merged_cells_str.join("")
         )
     } else {
-        String::new()
+        "".to_string()
     };
 
     format!(

--- a/xlsx/src/export/worksheets.rs
+++ b/xlsx/src/export/worksheets.rs
@@ -243,7 +243,7 @@ pub(crate) fn get_worksheet_xml(
     }
     let sheet_data = sheet_data_str.join("");
 
-    for merge_cell_ref in worksheet.merge_cells.clone() {
+    for merge_cell_ref in &worksheet.merge_cells {
         merged_cells_str.push(format!("<mergeCell ref=\"{merge_cell_ref}\"/>"))
     }
     let merged_cells_count = merged_cells_str.len();

--- a/xlsx/src/export/worksheets.rs
+++ b/xlsx/src/export/worksheets.rs
@@ -13,7 +13,7 @@
 //!   <v>1</v>
 //! </c>
 //! Formula in F6 would then be 'A6+C6'
-use std::{collections::HashMap, fmt::format};
+use std::collections::HashMap;
 
 use itertools::Itertools;
 
@@ -243,10 +243,8 @@ pub(crate) fn get_worksheet_xml(
     }
     let sheet_data = sheet_data_str.join("");
 
-    for (_ind,merge_cell_ref) in worksheet.merge_cells.iter().enumerate(){
-        merged_cells_str.push(format!(
-            "<mergeCell ref=\"{merge_cell_ref}\"/>"
-        ))
+    for (_ind, merge_cell_ref) in worksheet.merge_cells.iter().enumerate() {
+        merged_cells_str.push(format!("<mergeCell ref=\"{merge_cell_ref}\"/>"))
     }
     let merged_cells_count = merged_cells_str.len();
     let merged_cells = merged_cells_str.join("");
@@ -290,6 +288,16 @@ pub(crate) fn get_worksheet_xml(
         }
     }
 
+    let merge_cells_section = if merged_cells_count > 0 {
+        format!(
+            "<mergeCells count=\"{merged_cells_count}\">{merged_cells}</mergeCells>",
+            merged_cells_count = merged_cells_count,
+            merged_cells = merged_cells
+        )
+    } else {
+        String::new()
+    };
+
     format!(
         "{XML_DECLARATION}
 <worksheet \
@@ -305,9 +313,7 @@ xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">
   <sheetData>\
   {sheet_data}\
   </sheetData>\
-  <mergeCells count=\"{merged_cells_count}\">\
-  {merged_cells}\
-  </mergeCells>\
+  {merge_cells_section}\
 </worksheet>"
     )
 }

--- a/xlsx/tests/test.rs
+++ b/xlsx/tests/test.rs
@@ -335,13 +335,9 @@ fn no_export() {
     fs::remove_dir_all(&dir).unwrap();
 }
 
-// This test verifies whether exporting the
-// merged cells functionality is happening
-// properly or not.
-// it first loads the excell
-// having the merged cell and exports it to
-// anothe xlsx and verifies whether merged
-// cell node is same in both of the xlsx file
+// This test verifies whether exporting the merged cells functionality is happening properly or not.
+// It first loads the excell having the merged cell and exports it to another xlsx and verifies whether merged
+// cell node is same in both of the xlsx file or not.
 #[test]
 fn test_exporting_merged_cells() {
     let temp_file_name = "temp_file_test_export_merged_cells.xlsx";
@@ -352,7 +348,7 @@ fn test_exporting_merged_cells() {
         let expected_merge_cell_ref = model
             .workbook
             .worksheets
-            .get(0)
+            .first()
             .unwrap()
             .merge_cells
             .clone();
@@ -364,12 +360,12 @@ fn test_exporting_merged_cells() {
     {
         let mut temp_model = load_from_xlsx(temp_file_name, "en", "UTC").unwrap();
         {
-            //loading the previous file back and verifying whether
-            //merged cells got exported properly or not
+            // loading the previous file back and verifying whether
+            // merged cells got exported properly or not
             let got_merge_cell_ref = &temp_model
                 .workbook
                 .worksheets
-                .get(0)
+                .first()
                 .unwrap()
                 .merge_cells
                 .clone();
@@ -393,7 +389,7 @@ fn test_exporting_merged_cells() {
             let got_merge_cell_ref_cnt = &temp_model2
                 .workbook
                 .worksheets
-                .get(0)
+                .first()
                 .unwrap()
                 .merge_cells
                 .len();


### PR DESCRIPTION
What is the enhancement ?

>> Currently the project can only load the merged cells from xlsx file, exporting the merged cells was not supported. This PR addresses this issue.


How it has been done ?

>> Small patch of code has been added to _get_worksheet_xml_ function where we export the merged cells in xml.

What is the UT ?

>> Testcase covers the basic scenario where, we load the already existed xlsx file ( containing the merged cell ) and we export the same file to different name. Later we compare the xml block of each files and validate.