### PR TITLE
Support csv import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +255,52 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -405,8 +506,10 @@ dependencies = [
 name = "ironcalc"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "bitcode",
  "chrono",
+ "clap",
  "ironcalc_base",
  "itertools",
  "roxmltree",
@@ -434,6 +537,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -886,6 +995,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1100,12 @@ name = "utf8-ranges"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -1130,14 +1251,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.4"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -1146,45 +1277,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zip"

--- a/base/src/test/user_model/test_paste_csv.rs
+++ b/base/src/test/user_model/test_paste_csv.rs
@@ -1,4 +1,5 @@
 use crate::{expressions::types::Area, UserModel};
+use std::io::Cursor;
 
 #[test]
 fn csv_paste() {
@@ -8,6 +9,7 @@ fn csv_paste() {
 
     // paste some numbers in B4:C7
     let csv = "1,2,3\n4,5,6";
+    let mut csv = Cursor::new(csv);
     let area = Area {
         sheet: 0,
         row: 4,
@@ -16,7 +18,7 @@ fn csv_paste() {
         height: 1,
     };
     model.set_selected_cell(4, 2).unwrap();
-    model.paste_csv_string(&area, csv).unwrap();
+    model.paste_csv_string(&area, &mut csv).unwrap();
 
     assert_eq!(
         model.get_formatted_cell_value(0, 7, 7),
@@ -32,6 +34,7 @@ fn tsv_crlf_paste() {
 
     // paste some numbers in B4:C7
     let csv = "1\t2\t3\r\n4\t5\t6";
+    let mut csv = Cursor::new(csv);
     let area = Area {
         sheet: 0,
         row: 4,
@@ -40,7 +43,7 @@ fn tsv_crlf_paste() {
         height: 1,
     };
     model.set_selected_cell(4, 2).unwrap();
-    model.paste_csv_string(&area, csv).unwrap();
+    model.paste_csv_string(&area, &mut csv).unwrap();
 
     assert_eq!(
         model.get_formatted_cell_value(0, 7, 7),

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -5,7 +5,7 @@ use types::{PySheetProperty, PyStyle};
 use xlsx::base::types::Style;
 use xlsx::base::Model;
 
-use xlsx::export::{save_to_icalc, save_to_xlsx};
+use xlsx::export::{save_to_icalc, save_to_xlsx, ModelType};
 use xlsx::import;
 
 mod types;
@@ -27,7 +27,8 @@ impl PyModel {
 
     /// Saves the model to file in the internal binary ic format
     pub fn save_to_icalc(&self, file: &str) -> PyResult<()> {
-        save_to_icalc(&self.model, file).map_err(|e| WorkbookError::new_err(e.to_string()))
+        save_to_icalc(&ModelType::ModelRef(&self.model), file)
+            .map_err(|e| WorkbookError::new_err(e.to_string()))
     }
 
     /// Evaluates the workbook

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use wasm_bindgen::{
     prelude::{wasm_bindgen, JsError},
     JsValue,
@@ -527,8 +529,9 @@ impl Model {
     pub fn paste_csv_string(&mut self, area: JsValue, csv: &str) -> Result<(), JsError> {
         let range: Area =
             serde_wasm_bindgen::from_value(area).map_err(|e| to_js_error(e.to_string()))?;
+        let mut csv_cursor = Cursor::new(csv);
         self.model
-            .paste_csv_string(&range, csv)
+            .paste_csv_string(&range, &mut csv_cursor)
             .map_err(|e| to_js_error(e.to_string()))
     }
 }

--- a/xlsx/Cargo.toml
+++ b/xlsx/Cargo.toml
@@ -24,6 +24,8 @@ ironcalc_base = { path = "../base", version = "0.2" }
 itertools = "0.12"
 chrono = "0.4"
 bitcode = "0.6.0"
+clap = { version = "4.5.20", features = ["derive"] }
+anyhow = "1.0.93"
 
 [dev-dependencies]
 uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/xlsx/src/bin/xlsx_2_icalc.rs
+++ b/xlsx/src/bin/xlsx_2_icalc.rs
@@ -1,26 +1,110 @@
 //! Tests an Excel xlsx file.
 //! Returns a list of differences in json format.
-//! Saves an IronCalc version
+//! Saves an `IronCalc` version
 //! This is primary for QA internal testing and will be superseded by an official
-//! IronCalc CLI.
+//! `IronCalc` CLI.
 //!
 //! Usage: test file.xlsx
 
-use std::path;
-
+use anyhow::{bail, Context, Result};
+use clap::Parser;
 use ironcalc::{export::save_to_icalc, import::load_from_xlsx};
+use ironcalc_base::Model;
+use std::path::{Path, PathBuf};
 
-fn main() {
-    let args: Vec<_> = std::env::args().collect();
-    if args.len() != 2 {
-        panic!("Usage: {} <file.xlsx>", args[0]);
-    }
-    // first test the file
-    let file_name = &args[1];
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    /// file to convert
+    path: PathBuf,
 
-    let file_path = path::Path::new(file_name);
-    let base_name = file_path.file_stem().unwrap().to_str().unwrap();
-    let output_file_name = &format!("{base_name}.ic");
-    let model = load_from_xlsx(file_name, "en", "UTC").unwrap();
+    /// kind of file
+    #[clap(short, value_enum)]
+    kind: Option<FileKind>,
+
+    /// output file path, will match path with `ic` extension otherwise
+    #[clap(short, long)]
+    output: Option<PathBuf>,
+}
+
+/// The kind of file that is being requested
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum FileKind {
+    Xlsx,
+    Csv,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Cli::parse();
+    let path = args.path;
+
+    let kind = match args.kind {
+        Some(kind) => kind,
+        None => get_file_kind(&path)?,
+    };
+
+    let model = match kind {
+        FileKind::Xlsx => handle_xlsx(&path),
+        FileKind::Csv => handle_csv(&path),
+    }?;
+
+    let output_path = if let Some(out) = args.output {
+        out
+    } else {
+        let base_name = path.file_stem();
+        match base_name {
+            Some(base_name) => PathBuf::from(base_name).with_extension("ic"),
+            None => {
+                bail!("Issue finding file stem of path: {}", path.display())
+            }
+        }
+    };
+
+    let output_file_name = output_path
+        .to_str()
+        .context(format!("Issue with path: {output_path:?}"))?;
+
     save_to_icalc(&model, output_file_name).unwrap();
+
+    Ok(())
+}
+
+fn get_file_kind(path: &Path) -> anyhow::Result<FileKind> {
+    use FileKind::{Csv, Xlsx};
+
+    let extension = path.extension();
+
+    let kind = if let Some(extension) = extension {
+        let extension = extension.to_str().context(format!(
+            "There was an issue with the provided path and the system string type. path: {}",
+            path.display()
+        ))?;
+        match extension.to_ascii_lowercase().as_str() {
+            "xlsx" => Xlsx,
+            "csv" => Csv,
+            _ => bail!(
+                "Unsupported auto-detected extension of: {}, found on provided path: {}",
+                extension,
+                path.display()
+            ),
+        }
+    } else {
+        bail!(
+            "Could not detect extension on provided path: {}",
+            path.display()
+        );
+    };
+
+    Ok(kind)
+}
+
+fn handle_xlsx(path: &Path) -> Result<Model> {
+    let Some(path) = path.to_str() else {
+        bail!("Could not parse provided path: {}", path.display())
+    };
+    Ok(load_from_xlsx(path, "en", "UTC")?)
+}
+
+fn handle_csv(_path: &Path) -> Result<Model> {
+    todo!("handle CSV parsing")
 }

--- a/xlsx/src/error.rs
+++ b/xlsx/src/error.rs
@@ -51,8 +51,12 @@ impl From<roxmltree::Error> for XlsxError {
     }
 }
 
-impl XlsxError {
-    pub fn user_message(&self) -> String {
+pub trait UserErrorMessage {
+    fn user_message(&self) -> String;
+}
+
+impl UserErrorMessage for XlsxError {
+    fn user_message(&self) -> String {
         match &self {
             XlsxError::IO(_) | XlsxError::Workbook(_) => self.to_string(),
             XlsxError::Zip(_) | XlsxError::Xml(_) => {
@@ -84,6 +88,33 @@ impl XlsxError {
                 workbook, and we will work with you to resolve the issue. \
                 Detailed error message:\n{error}"
             ),
+        }
+    }
+}
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum CsvError {
+    #[error("I/O Error: {0}")]
+    IO(String),
+    #[error("General CSV Error: {0}")]
+    General(String),
+    #[error("{0}")]
+    Workbook(String),
+}
+
+impl From<io::Error> for CsvError {
+    fn from(error: io::Error) -> Self {
+        CsvError::IO(error.to_string())
+    }
+}
+
+impl UserErrorMessage for CsvError {
+    fn user_message(&self) -> String {
+        use CsvError::*;
+
+        match &self {
+            IO(_) | Workbook(_) => self.to_string(),
+            General(message) => format!("General Error message for CSV: {message}"),
         }
     }
 }

--- a/xlsx/src/export/test/test_export.rs
+++ b/xlsx/src/export/test/test_export.rs
@@ -3,7 +3,7 @@ use std::fs;
 use ironcalc_base::Model;
 
 use crate::error::XlsxError;
-use crate::export::save_to_icalc;
+use crate::export::{save_to_icalc, ModelType};
 use crate::import::load_from_icalc;
 use crate::{export::save_to_xlsx, import::load_from_xlsx};
 
@@ -64,7 +64,7 @@ fn test_values() {
     }
     {
         let temp_file_name = "temp_file_test_values.ic";
-        save_to_icalc(&model, temp_file_name).unwrap();
+        save_to_icalc(&ModelType::ModelRef(&model), temp_file_name).unwrap();
 
         let model = load_from_icalc(temp_file_name).unwrap();
         assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "123.456");

--- a/xlsx/src/import/mod.rs
+++ b/xlsx/src/import/mod.rs
@@ -176,13 +176,15 @@ fn load_csv_from_reader<R: Read + std::io::Seek>(
     locale: &str,
     tz: &str,
 ) -> Result<UserModel, CsvError> {
+    println!("trying to load csv from reader");
     let model = Model::new_empty(name, locale, tz).map_err(CsvError::General)?;
     let mut model = UserModel::from_model(model);
 
+    // TODO: consider using unonzero types for indexes that are not allowed to be zero?
     let area = Area {
         sheet: 0,
-        row: 0,
-        column: 0,
+        row: 1,
+        column: 1,
         width: 1,
         height: 1,
     };

--- a/xlsx/tests/csv.rs
+++ b/xlsx/tests/csv.rs
@@ -1,0 +1,40 @@
+use std::io::Read;
+use std::{env, fs, io};
+use uuid::Uuid;
+
+use ironcalc::compare::{test_file, test_load_and_saving};
+use ironcalc::export::save_to_xlsx;
+use ironcalc::import::{load_from_icalc, load_from_xlsx, load_from_xlsx_bytes};
+use ironcalc_base::types::{HorizontalAlignment, VerticalAlignment};
+use ironcalc_base::Model;
+
+use std::process::{Command, ExitStatus};
+
+#[test]
+fn test_simple_csv() {
+    let name = "example_csv.csv";
+    let ic_name = "example_csv.ic";
+    let csv_data = "1,2,3\n4,5,6";
+
+    fs::write(name, csv_data).expect("Unable to write file");
+
+    let status = Command::new("cargo")
+        .args(["run", "--bin", "xlsx_2_icalc", "--", name])
+        .status()
+        .expect("failed to execute process");
+
+    assert!(status.success());
+
+    let model = load_from_icalc(ic_name).expect("file should exist after command is run.");
+
+    assert_eq!(model.get_cell_content(0, 1, 1), Ok("1".to_owned()));
+    assert_eq!(model.get_cell_content(0, 1, 2), Ok("2".to_owned()));
+    assert_eq!(model.get_cell_content(0, 1, 3), Ok("3".to_owned()));
+
+    assert_eq!(model.get_cell_content(0, 2, 1), Ok("4".to_owned()));
+    assert_eq!(model.get_cell_content(0, 2, 2), Ok("5".to_owned()));
+    assert_eq!(model.get_cell_content(0, 2, 3), Ok("6".to_owned()));
+
+    assert!(fs::remove_file(name).is_ok());
+    assert!(fs::remove_file(ic_name).is_ok());
+}


### PR DESCRIPTION
Implement basic changes to permit CSV files to be converted to .ic

Modified paste csv function to not use a `&str` so that the data doesn't need to be entirely in memory, hopefully permitting large CSVs to be read.

not addressed yet, but noticed while implementing:

* export to CSV
* user/programmatic selection of CSV settings
* supporting strings rather than chars for comment indicator