### PR TITLE
Style: fix typo tat to that

### DIFF
--- a/docs/src/programming/about.md
+++ b/docs/src/programming/about.md
@@ -6,6 +6,6 @@ lang: en-US
 
 # Programming IronCalc
 
-IronCal is a spreadsheet _engine_ first. This means you can load the engine from a myriad of places. The very same computational engine tat you use in the [browser](https://app.ironcalc.com) you can use from your favourite programming language.
+IronCal is a spreadsheet _engine_ first. This means you can load the engine from a myriad of places. The very same computational engine that you use in the [browser](https://app.ironcalc.com) you can use from your favourite programming language.
 
 Using IronCalc programmatically means you can create spreadsheets on the fly. Maybe you want to create reports for your users or maybe you want to run the spreadsheet with a series of inputs and use the outputs.


### PR DESCRIPTION
Um. Needs no explanation. That "tat" should be that "that" you see. 