### PR TITLE
UPDATE: Moved Border button next to Background color button

### DIFF
--- a/webapp/src/components/toolbar.tsx
+++ b/webapp/src/components/toolbar.tsx
@@ -251,6 +251,16 @@ function Toolbar(properties: ToolbarProperties) {
       >
         <PaintBucket />
       </StyledButton>
+      <StyledButton
+        type="button"
+        $pressed={false}
+        onClick={() => setBorderPickerOpen(true)}
+        ref={borderButton}
+        disabled={!canEdit}
+        title={t("toolbar.borders.title")}
+      >
+        <Grid2X2 />
+      </StyledButton>
       <Divider />
       <StyledButton
         type="button"
@@ -318,17 +328,7 @@ function Toolbar(properties: ToolbarProperties) {
       >
         <ArrowDownToLine />
       </StyledButton>
-      <Divider />
-      <StyledButton
-        type="button"
-        $pressed={false}
-        onClick={() => setBorderPickerOpen(true)}
-        ref={borderButton}
-        disabled={!canEdit}
-        title={t("toolbar.borders.title")}
-      >
-        <Grid2X2 />
-      </StyledButton>
+
       <Divider />
       <StyledButton
         type="button"


### PR DESCRIPTION
Hey @nhatcher,

As discussed, I've moved the border button in the toolbox next to the fill background button.

Before:
<img width="779" alt="image" src="https://github.com/user-attachments/assets/c0b450f7-5ea8-4871-a594-32b2b0f9baa1">

After:
<img width="769" alt="image" src="https://github.com/user-attachments/assets/60650364-981c-403c-a627-a5374d8081f0">

Thanks!

D