### PR TITLE
Fix clippy lint

### DIFF
--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -342,7 +342,7 @@ impl UserModel {
             old_value: Box::new(old_value),
         }];
 
-        let line_count = value.split("\n").count();
+        let line_count = value.split('\n').count();
         let row_height = self.model.get_row_height(sheet, row)?;
         let cell_height = (line_count as f64) * DEFAULT_ROW_HEIGHT;
         if cell_height > row_height {


### PR DESCRIPTION
Running `make test` fails on a clippy lint:

![image](https://github.com/user-attachments/assets/770fbef3-8ed5-421b-a6c5-de0d7a533bae)

Rectify the lint as suggested by clippy.
