### PR TITLE
FIX: Makes footer/navigator scrollable when there are too many sheets

### DIFF
--- a/webapp/src/components/navigation/navigation.tsx
+++ b/webapp/src/components/navigation/navigation.tsx
@@ -2,6 +2,7 @@ import { styled } from "@mui/material";
 import { Menu, Plus } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { theme } from "../../theme";
 import { NAVIGATION_HEIGH } from "../constants";
 import { StyledButton } from "../toolbar";
 import type { WorkbookState } from "../workbookState";
@@ -101,12 +102,19 @@ const Container = styled("div")`
   padding-left: 12px;
   font-family: Inter;
   background-color: #fff;
-  border-top: 1px solid #E0E0E0;
+  border-top: 1px solid #e0e0e0;
 `;
 
 const Sheets = styled("div")`
   flex-grow: 2;
   overflow: hidden;
+  overflow-x: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-scroll: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 `;
 
 const SheetInner = styled("div")`
@@ -114,10 +122,20 @@ const SheetInner = styled("div")`
 `;
 
 const Advert = styled("a")`
+  display: flex;
+  align-items: center;
   color: #f2994a;
-  margin-right: 12px;
+  padding: 0px 12px;
   font-size: 12px;
   text-decoration: none;
+  border-left: 1px solid ${theme.palette.grey["300"]};
+  transition: color 0.2s ease-in-out;
+  &:hover {
+    text-decoration: underline;
+  }
+  @media (max-width: 769px) {
+    height: 100%;
+  }
 `;
 
 export default Navigation;


### PR DESCRIPTION
Hi!

Last PR today. I've added some horizontal scrolling to the spreadsheet navigator. Until now it was impossible to reach all sheets when the screen gets too narrow and/or there are way too many sheets. See below the difference:

Before (sorry, for some reason the video is uploaded as attachment):
https://github.com/user-attachments/assets/b1ab681d-b671-4d73-9cdc-927a75e58d23

After:
https://github.com/user-attachments/assets/df8ef324-de0a-4045-af24-d6ad54a35156

Best,
D