### PR TITLE
FIX: Made menu on SheetTab consistent with Figmas

### DIFF
--- a/webapp/src/components/SheetTabBar/SheetTab.tsx
+++ b/webapp/src/components/SheetTabBar/SheetTab.tsx
@@ -124,10 +124,38 @@ function SheetTab(props: SheetTabProps) {
   );
 }
 
-const StyledMenu = styled(Menu)``;
+const StyledMenu = styled(Menu)`
+  & .MuiPaper-root {
+    border-radius: 8px;
+    padding: 4px 0px;
+    margin-left: -4px;
+  }
+  & .MuiList-root {
+    padding: 0;
+  }
+`;
 
 const StyledMenuItem = styled(MenuItem)`
+  display: flex;
+  justify-content: space-between;
   font-size: 12px;
+  width: calc(100% - 8px);
+  margin: 0px 4px;
+  border-radius: 4px;
+  padding: 8px;
+  height: 32px;
+`;
+
+const MenuItemWrapper = styled(MenuItem)`
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  width: calc(100% - 8px);
+  min-width: 172px;
+  margin: 0px 4px;
+  border-radius: 4px;
+  padding: 8px;
+  height: 32px;
 `;
 
 const StyledButton = styled(Button)`


### PR DESCRIPTION
Hi there,

Changed another menu so all look the same. Find below the change:

Before:
<img width="163" alt="image" src="https://github.com/user-attachments/assets/f5295181-fdc5-4b73-beba-2afd0a5b2c36" />

After:
<img width="162" alt="image" src="https://github.com/user-attachments/assets/7965afbe-1129-429e-b0c4-7df270c0033e" />

Best,
D