### PR TITLE
FIX[UI]: Rename modal dialog fixes

### DIFF
--- a/webapp/src/components/SheetTabBar/SheetRenameDialog.tsx
+++ b/webapp/src/components/SheetTabBar/SheetRenameDialog.tsx
@@ -54,6 +54,8 @@ const SheetRenameDialog = (properties: SheetRenameDialogProps) => {
             if (event.key === "Enter") {
               properties.onNameChanged(name);
               properties.onClose();
+            } else if (event.key === "Escape") {
+              properties.onClose();
             }
           }}
           onChange={(event) => {
@@ -61,6 +63,8 @@ const SheetRenameDialog = (properties: SheetRenameDialogProps) => {
           }}
           spellCheck="false"
           onPaste={(event) => event.stopPropagation()}
+          onCopy={(event) => event.stopPropagation()}
+          onCut={(event) => event.stopPropagation()}
         />
       </StyledDialogContent>
       <DialogFooter>


### PR DESCRIPTION
This will be a standard "Prompt" widget

* ESC closes the dialog without changes
* Can copy/cut paste