### PR TITLE
FIX: make grid header colors consistent

### DIFF
--- a/webapp/src/components/WorksheetCanvas/constants.ts
+++ b/webapp/src/components/WorksheetCanvas/constants.ts
@@ -5,10 +5,10 @@ export const headerGlobalSelectorColor = "#EAECF4";
 export const headerSelectedBackground = "#EEEEEE";
 export const headerFullSelectedBackground = "#D3D6E9";
 export const headerSelectedColor = "#333";
-export const headerBorderColor = "#DEE0EF";
+export const headerBorderColor = "#E0E0E0";
 
 export const gridColor = "#E0E0E0";
-export const gridSeparatorColor = "#D3D6E9";
+export const gridSeparatorColor = "#E0E0E0";
 export const defaultTextColor = "#2E414D";
 
 export const outlineColor = "#F2994A";


### PR DESCRIPTION
### **Description**
Column headers in IronCalc were using the wrong color (a shade of blue instead of a shade of grey).

Before:
<img width="781" alt="image" src="https://github.com/user-attachments/assets/a98780a6-9732-4160-9144-eb77ae81edb3" />

After:
<img width="783" alt="image" src="https://github.com/user-attachments/assets/caed7569-9ef9-4dca-9617-37f5ed87dd3f" />


### **Motivation**
I know this is super hard to notice for some people and in some displays but as it's a small change I thought it'd be good to get it done now 🙂.

Best,
D