### PR TITLE
FIX: Use the right icon for paste format action

### DIFF
--- a/webapp/src/components/workbook.tsx
+++ b/webapp/src/components/workbook.tsx
@@ -5,7 +5,9 @@ import type {
   WorksheetProperties,
 } from "@ironcalc/wasm";
 import { styled } from "@mui/material/styles";
+import { PaintRoller } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import ReactDOMServer from "react-dom/server";
 import SheetTabBar from "./SheetTabBar/SheetTabBar";
 import {
   COLUMN_WIDTH_SCALE,
@@ -136,7 +138,15 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
     const el = rootRef.current?.getElementsByClassName("sheet-container")[0];
     if (el) {
       (el as HTMLElement).style.cursor =
-        `url('data:image/svg+xml;utf8,<svg data-v-56bd7dfc="" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-paintbrush-vertical"><path d="M10 2v2"></path><path d="M14 2v4"></path><path d="M17 2a1 1 0 0 1 1 1v9H6V3a1 1 0 0 1 1-1z"></path><path d="M6 12a1 1 0 0 0-1 1v1a2 2 0 0 0 2 2h2a1 1 0 0 1 1 1v2.9a2 2 0 1 0 4 0V17a1 1 0 0 1 1-1h2a2 2 0 0 0 2-2v-1a1 1 0 0 0-1-1"></path></svg>'), auto`;
+        `url('data:image/svg+xml;utf8,${encodeURIComponent(
+          ReactDOMServer.renderToString(
+            <PaintRoller
+              width={24}
+              height={24}
+              style={{ transform: "rotate(-8deg)" }}
+            />,
+          ),
+        )}'), auto`;
     }
   };
 


### PR DESCRIPTION
Hi @nhatcher,

We recently updated the 'Copy/Paste Format' icon in the toolbar but we still had the old one as a cursor, after clicking the button. So here's my attempt to fix that. 

In the video below you can see the before/after:


https://github.com/user-attachments/assets/c4656abc-0112-4095-8e98-d068921a78a0


Let me know if this is the right way of doing it, of if there's maybe a 'cleaner' way.

Thanks!

D