### PR TITLE
FIX: Replace SVG "X" icons with Lucide icons for consistency in dialogs

### DIFF
--- a/webapp/src/AppComponents/UploadFileDialog.tsx
+++ b/webapp/src/AppComponents/UploadFileDialog.tsx
@@ -114,6 +114,7 @@ function UploadFileDialog(properties: {
           style={{ marginRight: 12 }}
           onClick={handleClose}
           title="Close Dialog"
+          ref={crossRef}
           tabIndex={0}
         >
           <X />

--- a/webapp/src/AppComponents/UploadFileDialog.tsx
+++ b/webapp/src/AppComponents/UploadFileDialog.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { BookOpen, FileUp } from "lucide-react";
+import { BookOpen, FileUp, X } from "lucide-react";
 import { type DragEvent, useEffect, useRef, useState } from "react";
 
 function UploadFileDialog(properties: {
@@ -113,30 +113,11 @@ function UploadFileDialog(properties: {
         <Cross
           style={{ marginRight: 12 }}
           onClick={handleClose}
+          title="Close Dialog"
           ref={crossRef}
           tabIndex={0}
         >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>Close</title>
-            <path
-              d="M12 4.5L4 12.5"
-              stroke="#333333"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M4 4.5L12 12.5"
-              stroke="#333333"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <X />
         </Cross>
       </UploadTitle>
       {message === "" ? (
@@ -237,6 +218,11 @@ const Cross = styled("div")`
   cursor: pointer;
   align-items: center;
   justify-content: center;
+  svg {
+    width: 16px;
+    height: 16px;
+    stroke-width: 1.5;
+  }
 `;
 
 const DocLink = styled("span")`

--- a/webapp/src/AppComponents/UploadFileDialog.tsx
+++ b/webapp/src/AppComponents/UploadFileDialog.tsx
@@ -114,7 +114,6 @@ function UploadFileDialog(properties: {
           style={{ marginRight: 12 }}
           onClick={handleClose}
           title="Close Dialog"
-          ref={crossRef}
           tabIndex={0}
         >
           <X />

--- a/webapp/src/components/SheetTabBar/SheetRenameDialog.tsx
+++ b/webapp/src/components/SheetTabBar/SheetRenameDialog.tsx
@@ -1,5 +1,6 @@
 import { Dialog, TextField, styled } from "@mui/material";
-import { useState } from "react";
+import { Check, X } from "lucide-react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { theme } from "../../theme";
 
@@ -13,6 +14,7 @@ interface SheetRenameDialogProps {
 const SheetRenameDialog = (properties: SheetRenameDialogProps) => {
   const { t } = useTranslation();
   const [name, setName] = useState(properties.defaultName);
+  const crossRef = useRef<HTMLDivElement>(null);
   const handleClose = () => {
     properties.onClose();
   };
@@ -20,28 +22,14 @@ const SheetRenameDialog = (properties: SheetRenameDialogProps) => {
     <Dialog open={properties.open} onClose={properties.onClose}>
       <StyledDialogTitle>
         {t("sheet_rename.title")}
-        <Cross onClick={handleClose} onKeyDown={() => {}}>
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>Close</title>
-            <path
-              d="M12 4.5L4 12.5"
-              stroke="#333333"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M4 4.5L12 12.5"
-              stroke="#333333"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+        <Cross
+          onClick={handleClose}
+          title="Close Dialog"
+          ref={crossRef}
+          tabIndex={0}
+          onKeyDown={() => {}}
+        >
+          <X />
         </Cross>
       </StyledDialogTitle>
       <StyledDialogContent>
@@ -73,6 +61,9 @@ const SheetRenameDialog = (properties: SheetRenameDialogProps) => {
             properties.onNameChanged(name);
           }}
         >
+          <Check
+            style={{ width: "16px", height: "16px", marginRight: "8px" }}
+          />
           {t("sheet_rename.rename")}
         </StyledButton>
       </DialogFooter>
@@ -94,7 +85,7 @@ const StyledDialogTitle = styled("div")`
 
 const Cross = styled("div")`
   &:hover {
-    background-color: ${theme.palette.grey["100"]};
+    background-color: ${theme.palette.grey["50"]};
   }
   display: flex;
   border-radius: 4px;
@@ -103,6 +94,11 @@ const Cross = styled("div")`
   cursor: pointer;
   align-items: center;
   justify-content: center;
+  svg {
+    width: 16px;
+    height: 16px;
+    stroke-width: 1.5;
+  }
 `;
 
 const StyledDialogContent = styled("div")`

--- a/webapp/src/components/SheetTabBar/SheetRenameDialog.tsx
+++ b/webapp/src/components/SheetTabBar/SheetRenameDialog.tsx
@@ -23,8 +23,8 @@ const SheetRenameDialog = (properties: SheetRenameDialogProps) => {
         {t("sheet_rename.title")}
         <Cross
           onClick={handleClose}
-          title="Close Dialog"
-          tabIndex={0}
+          title={t("sheet_rename.close")}
+          tabIndex={-1}
           onKeyDown={() => {}}
         >
           <X />

--- a/webapp/src/components/SheetTabBar/SheetRenameDialog.tsx
+++ b/webapp/src/components/SheetTabBar/SheetRenameDialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog, TextField, styled } from "@mui/material";
 import { Check, X } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { theme } from "../../theme";
 
@@ -14,7 +14,6 @@ interface SheetRenameDialogProps {
 const SheetRenameDialog = (properties: SheetRenameDialogProps) => {
   const { t } = useTranslation();
   const [name, setName] = useState(properties.defaultName);
-  const crossRef = useRef<HTMLDivElement>(null);
   const handleClose = () => {
     properties.onClose();
   };
@@ -25,7 +24,6 @@ const SheetRenameDialog = (properties: SheetRenameDialogProps) => {
         <Cross
           onClick={handleClose}
           title="Close Dialog"
-          ref={crossRef}
           tabIndex={0}
           onKeyDown={() => {}}
         >

--- a/webapp/src/components/formatPicker.tsx
+++ b/webapp/src/components/formatPicker.tsx
@@ -38,7 +38,7 @@ const FormatPicker = (properties: FormatPickerProps) => {
         {t("num_fmt.title")}
         <Cross
           onClick={handleClose}
-          title="Close Dialog"
+          title={t("num_fmt.close")}
           tabIndex={0}
           onKeyDown={() => {}}
         >

--- a/webapp/src/components/formatPicker.tsx
+++ b/webapp/src/components/formatPicker.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { Dialog, TextField } from "@mui/material";
 import { Check, X } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { theme } from "../theme";
 
@@ -17,7 +17,6 @@ type FormatPickerProps = {
 const FormatPicker = (properties: FormatPickerProps) => {
   const { t } = useTranslation();
   const [formatCode, setFormatCode] = useState(properties.numFmt);
-  const crossRef = useRef<HTMLDivElement>(null);
 
   const handleClose = () => {
     properties.onClose();
@@ -40,7 +39,6 @@ const FormatPicker = (properties: FormatPickerProps) => {
         <Cross
           onClick={handleClose}
           title="Close Dialog"
-          ref={crossRef}
           tabIndex={0}
           onKeyDown={() => {}}
         >

--- a/webapp/src/components/formatPicker.tsx
+++ b/webapp/src/components/formatPicker.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { Dialog, TextField } from "@mui/material";
-import { Check } from "lucide-react";
-import { useState } from "react";
+import { Check, X } from "lucide-react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { theme } from "../theme";
 
@@ -17,6 +17,7 @@ type FormatPickerProps = {
 const FormatPicker = (properties: FormatPickerProps) => {
   const { t } = useTranslation();
   const [formatCode, setFormatCode] = useState(properties.numFmt);
+  const crossRef = useRef<HTMLDivElement>(null);
 
   const handleClose = () => {
     properties.onClose();
@@ -36,28 +37,14 @@ const FormatPicker = (properties: FormatPickerProps) => {
     >
       <StyledDialogTitle>
         {t("num_fmt.title")}
-        <Cross onClick={handleClose} onKeyDown={() => {}}>
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>Close</title>
-            <path
-              d="M12 4.5L4 12.5"
-              stroke="#333333"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M4 4.5L12 12.5"
-              stroke="#333333"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+        <Cross
+          onClick={handleClose}
+          title="Close Dialog"
+          ref={crossRef}
+          tabIndex={0}
+          onKeyDown={() => {}}
+        >
+          <X />
         </Cross>
       </StyledDialogTitle>
 
@@ -101,7 +88,7 @@ const StyledDialogTitle = styled("div")`
 
 const Cross = styled("div")`
   &:hover {
-    background-color: ${theme.palette.grey["100"]};
+    background-color: ${theme.palette.grey["50"]};
   }
   display: flex;
   border-radius: 4px;
@@ -110,6 +97,11 @@ const Cross = styled("div")`
   cursor: pointer;
   align-items: center;
   justify-content: center;
+  svg {
+    width: 16px;
+    height: 16px;
+    stroke-width: 1.5;
+  }
 `;
 
 const StyledDialogContent = styled("div")`

--- a/webapp/src/components/formatPicker.tsx
+++ b/webapp/src/components/formatPicker.tsx
@@ -36,12 +36,7 @@ const FormatPicker = (properties: FormatPickerProps) => {
     >
       <StyledDialogTitle>
         {t("num_fmt.title")}
-        <Cross
-          onClick={handleClose}
-          title={t("num_fmt.close")}
-          tabIndex={0}
-          onKeyDown={() => {}}
-        >
+        <Cross onClick={handleClose} title={t("num_fmt.close")}>
           <X />
         </Cross>
       </StyledDialogTitle>

--- a/webapp/src/locale/en_us.json
+++ b/webapp/src/locale/en_us.json
@@ -58,12 +58,14 @@
   "num_fmt": {
     "title": "Custom number format",
     "label": "Number format",
+    "close": "Close dialog",
     "save": "Save"
   },
   "sheet_rename": {
     "rename": "Save",
     "label": "New name",
-    "title": "Rename Sheet"
+    "title": "Rename Sheet",
+    "close": "Close dialog"
   },
   "formula_input": {
     "update": "Update",


### PR DESCRIPTION
Hi there,

This PR replaces the custom 'X' svg icons with the Lucide icon library in all dialogs.

Best,
D
