### PR TITLE
UPDATE: API for defined names

### DIFF
--- a/base/src/calc_result.rs
+++ b/base/src/calc_result.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 
 use crate::expressions::{token::Error, types::CellReferenceIndex};
 
+#[derive(Clone)]
 pub struct Range {
     pub left: CellReferenceIndex,
     pub right: CellReferenceIndex,

--- a/base/src/expressions/parser/move_formula.rs
+++ b/base/src/expressions/parser/move_formula.rs
@@ -375,7 +375,9 @@ fn to_string_moved(node: &Node, move_context: &MoveContext) -> String {
             }
             format!("{{{}}}", arguments)
         }
-        VariableKind(value) => value.to_string(),
+        DefinedNameKind((name, _)) => name.to_string(),
+        TableNameKind(name) => name.to_string(),
+        WrongVariableKind(name) => name.to_string(),
         CompareKind { kind, left, right } => format!(
             "{}{}{}",
             to_string_moved(left, move_context),

--- a/base/src/expressions/parser/tests/test_general.rs
+++ b/base/src/expressions/parser/tests/test_general.rs
@@ -25,7 +25,7 @@ fn test_parser_reference() {
         row: 1,
         column: 1,
     };
-    let t = parser.parse("A2", &Some(cell_reference));
+    let t = parser.parse("A2", &cell_reference);
     assert_eq!(to_rc_format(&t), "R[1]C[0]");
 }
 
@@ -40,7 +40,7 @@ fn test_parser_absolute_column() {
         row: 1,
         column: 1,
     };
-    let t = parser.parse("$A1", &Some(cell_reference));
+    let t = parser.parse("$A1", &cell_reference);
     assert_eq!(to_rc_format(&t), "R[0]C1");
 }
 
@@ -55,7 +55,7 @@ fn test_parser_absolute_row_col() {
         row: 1,
         column: 1,
     };
-    let t = parser.parse("$C$5", &Some(cell_reference));
+    let t = parser.parse("$C$5", &cell_reference);
     assert_eq!(to_rc_format(&t), "R5C3");
 }
 
@@ -70,7 +70,7 @@ fn test_parser_absolute_row_col_1() {
         row: 1,
         column: 1,
     };
-    let t = parser.parse("$A$1", &Some(cell_reference));
+    let t = parser.parse("$A$1", &cell_reference);
     assert_eq!(to_rc_format(&t), "R1C1");
 }
 
@@ -86,7 +86,7 @@ fn test_parser_simple_formula() {
         column: 1,
     };
 
-    let t = parser.parse("C3+Sheet2!D4", &Some(cell_reference));
+    let t = parser.parse("C3+Sheet2!D4", &cell_reference);
     assert_eq!(to_rc_format(&t), "R[2]C[2]+Sheet2!R[3]C[3]");
 }
 
@@ -102,7 +102,7 @@ fn test_parser_boolean() {
         column: 1,
     };
 
-    let t = parser.parse("true", &Some(cell_reference));
+    let t = parser.parse("true", &cell_reference);
     assert_eq!(to_rc_format(&t), "TRUE");
 }
 
@@ -117,7 +117,7 @@ fn test_parser_bad_formula() {
         row: 1,
         column: 1,
     };
-    let t = parser.parse("#Value", &Some(cell_reference));
+    let t = parser.parse("#Value", &cell_reference);
     match &t {
         Node::ParseErrorKind {
             formula,
@@ -146,7 +146,7 @@ fn test_parser_bad_formula_1() {
         row: 1,
         column: 1,
     };
-    let t = parser.parse("<5", &Some(cell_reference));
+    let t = parser.parse("<5", &cell_reference);
     match &t {
         Node::ParseErrorKind {
             formula,
@@ -175,7 +175,7 @@ fn test_parser_bad_formula_2() {
         row: 1,
         column: 1,
     };
-    let t = parser.parse("*5", &Some(cell_reference));
+    let t = parser.parse("*5", &cell_reference);
     match &t {
         Node::ParseErrorKind {
             formula,
@@ -204,7 +204,7 @@ fn test_parser_bad_formula_3() {
         row: 1,
         column: 1,
     };
-    let t = parser.parse("SUM(#VALVE!)", &Some(cell_reference));
+    let t = parser.parse("SUM(#VALVE!)", &cell_reference);
     match &t {
         Node::ParseErrorKind {
             formula,
@@ -259,11 +259,11 @@ fn test_parser_formulas() {
     for formula in formulas {
         let t = parser.parse(
             formula.initial,
-            &Some(CellReferenceRC {
+            &CellReferenceRC {
                 sheet: "Sheet1".to_string(),
                 row: 1,
                 column: 1,
-            }),
+            },
         );
         assert_eq!(to_rc_format(&t), formula.expected);
         assert_eq!(to_string(&t, &cell_reference), formula.initial);
@@ -324,11 +324,11 @@ fn test_parser_r1c1_formulas() {
     for formula in formulas {
         let t = parser.parse(
             formula.initial,
-            &Some(CellReferenceRC {
+            &CellReferenceRC {
                 sheet: "Sheet1".to_string(),
                 row: 1,
                 column: 1,
-            }),
+            },
         );
         assert_eq!(to_string(&t, &cell_reference), formula.expected);
         assert_eq!(to_rc_format(&t), formula.initial);
@@ -347,7 +347,7 @@ fn test_parser_quotes() {
         column: 1,
     };
 
-    let t = parser.parse("C3+'Second Sheet'!D4", &Some(cell_reference));
+    let t = parser.parse("C3+'Second Sheet'!D4", &cell_reference);
     assert_eq!(to_rc_format(&t), "R[2]C[2]+'Second Sheet'!R[3]C[3]");
 }
 
@@ -363,7 +363,7 @@ fn test_parser_escape_quotes() {
         column: 1,
     };
 
-    let t = parser.parse("C3+'Second ''2'' Sheet'!D4", &Some(cell_reference));
+    let t = parser.parse("C3+'Second ''2'' Sheet'!D4", &cell_reference);
     assert_eq!(to_rc_format(&t), "R[2]C[2]+'Second ''2'' Sheet'!R[3]C[3]");
 }
 
@@ -379,7 +379,7 @@ fn test_parser_parenthesis() {
         column: 1,
     };
 
-    let t = parser.parse("(C3=\"Yes\")*5", &Some(cell_reference));
+    let t = parser.parse("(C3=\"Yes\")*5", &cell_reference);
     assert_eq!(to_rc_format(&t), "(R[2]C[2]=\"Yes\")*5");
 }
 
@@ -395,7 +395,7 @@ fn test_parser_excel_xlfn() {
         column: 1,
     };
 
-    let t = parser.parse("_xlfn.CONCAT(C3)", &Some(cell_reference));
+    let t = parser.parse("_xlfn.CONCAT(C3)", &cell_reference);
     assert_eq!(to_rc_format(&t), "CONCAT(R[2]C[2])");
 }
 
@@ -409,7 +409,7 @@ fn test_to_string_displaced() {
     let worksheets = vec!["Sheet1".to_string()];
     let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
-    let node = parser.parse("C3", &Some(context.clone()));
+    let node = parser.parse("C3", context);
     let displace_data = DisplaceData::Column {
         sheet: 0,
         column: 1,
@@ -429,7 +429,7 @@ fn test_to_string_displaced_full_ranges() {
     let worksheets = vec!["Sheet1".to_string()];
     let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
-    let node = parser.parse("SUM(3:3)", &Some(context.clone()));
+    let node = parser.parse("SUM(3:3)", context);
     let displace_data = DisplaceData::Column {
         sheet: 0,
         column: 1,
@@ -440,7 +440,7 @@ fn test_to_string_displaced_full_ranges() {
         "SUM(3:3)".to_string()
     );
 
-    let node = parser.parse("SUM(D:D)", &Some(context.clone()));
+    let node = parser.parse("SUM(D:D)", context);
     let displace_data = DisplaceData::Row {
         sheet: 0,
         row: 3,
@@ -462,7 +462,7 @@ fn test_to_string_displaced_too_low() {
     let worksheets = vec!["Sheet1".to_string()];
     let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
-    let node = parser.parse("C3", &Some(context.clone()));
+    let node = parser.parse("C3", context);
     let displace_data = DisplaceData::Column {
         sheet: 0,
         column: 1,
@@ -482,7 +482,7 @@ fn test_to_string_displaced_too_high() {
     let worksheets = vec!["Sheet1".to_string()];
     let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
-    let node = parser.parse("C3", &Some(context.clone()));
+    let node = parser.parse("C3", context);
     let displace_data = DisplaceData::Column {
         sheet: 0,
         column: 1,

--- a/base/src/expressions/parser/tests/test_general.rs
+++ b/base/src/expressions/parser/tests/test_general.rs
@@ -17,7 +17,7 @@ struct Formula<'a> {
 #[test]
 fn test_parser_reference() {
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -32,7 +32,7 @@ fn test_parser_reference() {
 #[test]
 fn test_parser_absolute_column() {
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -47,7 +47,7 @@ fn test_parser_absolute_column() {
 #[test]
 fn test_parser_absolute_row_col() {
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -62,7 +62,7 @@ fn test_parser_absolute_row_col() {
 #[test]
 fn test_parser_absolute_row_col_1() {
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -77,7 +77,7 @@ fn test_parser_absolute_row_col_1() {
 #[test]
 fn test_parser_simple_formula() {
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -93,7 +93,7 @@ fn test_parser_simple_formula() {
 #[test]
 fn test_parser_boolean() {
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -109,7 +109,7 @@ fn test_parser_boolean() {
 #[test]
 fn test_parser_bad_formula() {
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -138,7 +138,7 @@ fn test_parser_bad_formula() {
 #[test]
 fn test_parser_bad_formula_1() {
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -167,7 +167,7 @@ fn test_parser_bad_formula_1() {
 #[test]
 fn test_parser_bad_formula_2() {
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -196,7 +196,7 @@ fn test_parser_bad_formula_2() {
 #[test]
 fn test_parser_bad_formula_3() {
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -225,7 +225,7 @@ fn test_parser_bad_formula_3() {
 #[test]
 fn test_parser_formulas() {
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     let formulas = vec![
         Formula {
@@ -273,7 +273,7 @@ fn test_parser_formulas() {
 #[test]
 fn test_parser_r1c1_formulas() {
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
     parser.set_lexer_mode(LexerMode::R1C1);
 
     let formulas = vec![
@@ -338,7 +338,7 @@ fn test_parser_r1c1_formulas() {
 #[test]
 fn test_parser_quotes() {
     let worksheets = vec!["Sheet1".to_string(), "Second Sheet".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -354,7 +354,7 @@ fn test_parser_quotes() {
 #[test]
 fn test_parser_escape_quotes() {
     let worksheets = vec!["Sheet1".to_string(), "Second '2' Sheet".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -370,7 +370,7 @@ fn test_parser_escape_quotes() {
 #[test]
 fn test_parser_parenthesis() {
     let worksheets = vec!["Sheet1".to_string(), "Second2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -386,7 +386,7 @@ fn test_parser_parenthesis() {
 #[test]
 fn test_parser_excel_xlfn() {
     let worksheets = vec!["Sheet1".to_string(), "Second2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -407,7 +407,7 @@ fn test_to_string_displaced() {
         column: 1,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     let node = parser.parse("C3", &Some(context.clone()));
     let displace_data = DisplaceData::Column {
@@ -427,7 +427,7 @@ fn test_to_string_displaced_full_ranges() {
         column: 1,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     let node = parser.parse("SUM(3:3)", &Some(context.clone()));
     let displace_data = DisplaceData::Column {
@@ -460,7 +460,7 @@ fn test_to_string_displaced_too_low() {
         column: 1,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     let node = parser.parse("C3", &Some(context.clone()));
     let displace_data = DisplaceData::Column {
@@ -480,7 +480,7 @@ fn test_to_string_displaced_too_high() {
         column: 1,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     let node = parser.parse("C3", &Some(context.clone()));
     let displace_data = DisplaceData::Column {

--- a/base/src/expressions/parser/tests/test_issue_155.rs
+++ b/base/src/expressions/parser/tests/test_issue_155.rs
@@ -17,7 +17,7 @@ fn issue_155_parser() {
         row: 2,
         column: 2,
     };
-    let t = parser.parse("A$1:A2", &Some(cell_reference.clone()));
+    let t = parser.parse("A$1:A2", &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "A$1:A2");
 }
 
@@ -32,7 +32,7 @@ fn issue_155_parser_case_2() {
         row: 20,
         column: 20,
     };
-    let t = parser.parse("C$1:D2", &Some(cell_reference.clone()));
+    let t = parser.parse("C$1:D2", &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "C$1:D2");
 }
 
@@ -48,7 +48,7 @@ fn issue_155_parser_only_row() {
         column: 20,
     };
     // This is tricky, I am not sure what to do in these cases
-    let t = parser.parse("A$2:B1", &Some(cell_reference.clone()));
+    let t = parser.parse("A$2:B1", &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "A1:B$2");
 }
 
@@ -64,6 +64,6 @@ fn issue_155_parser_only_column() {
         column: 20,
     };
     // This is tricky, I am not sure what to do in these cases
-    let t = parser.parse("D1:$A3", &Some(cell_reference.clone()));
+    let t = parser.parse("D1:$A3", &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "$A1:D3");
 }

--- a/base/src/expressions/parser/tests/test_issue_155.rs
+++ b/base/src/expressions/parser/tests/test_issue_155.rs
@@ -9,7 +9,7 @@ use crate::expressions::types::CellReferenceRC;
 #[test]
 fn issue_155_parser() {
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -24,7 +24,7 @@ fn issue_155_parser() {
 #[test]
 fn issue_155_parser_case_2() {
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -39,7 +39,7 @@ fn issue_155_parser_case_2() {
 #[test]
 fn issue_155_parser_only_row() {
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {
@@ -55,7 +55,7 @@ fn issue_155_parser_only_row() {
 #[test]
 fn issue_155_parser_only_column() {
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {

--- a/base/src/expressions/parser/tests/test_move_formula.rs
+++ b/base/src/expressions/parser/tests/test_move_formula.rs
@@ -27,7 +27,7 @@ fn test_move_formula() {
     };
 
     // formula AB31 will not change
-    let node = parser.parse("AB31", &Some(context.clone()));
+    let node = parser.parse("AB31", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -43,7 +43,7 @@ fn test_move_formula() {
     assert_eq!(t, "AB31");
 
     // formula $AB$31 will not change
-    let node = parser.parse("AB31", &Some(context.clone()));
+    let node = parser.parse("AB31", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -59,7 +59,7 @@ fn test_move_formula() {
     assert_eq!(t, "AB31");
 
     // but formula D5 will change to N15  (N = D + 10)
-    let node = parser.parse("D5", &Some(context.clone()));
+    let node = parser.parse("D5", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -75,7 +75,7 @@ fn test_move_formula() {
     assert_eq!(t, "N15");
 
     // Also formula $D$5 will change to N15  (N = D + 10)
-    let node = parser.parse("$D$5", &Some(context.clone()));
+    let node = parser.parse("$D$5", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -113,7 +113,7 @@ fn test_move_formula_context_offset() {
         height: 5,
     };
 
-    let node = parser.parse("-X9+C2%", &Some(context.clone()));
+    let node = parser.parse("-X9+C2%", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -152,7 +152,7 @@ fn test_move_formula_area_limits() {
     };
 
     // Outside of the area. Not moved
-    let node = parser.parse("B2+B3+C1+G6+H5", &Some(context.clone()));
+    let node = parser.parse("B2+B3+C1+G6+H5", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -168,7 +168,7 @@ fn test_move_formula_area_limits() {
     assert_eq!(t, "B2+B3+C1+G6+H5");
 
     // In the area. Moved
-    let node = parser.parse("C2+F4+F5+F6", &Some(context.clone()));
+    let node = parser.parse("C2+F4+F5+F6", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -205,7 +205,7 @@ fn test_move_formula_ranges() {
         height: 5,
     };
     // Ranges inside the area are fully displaced (absolute or not)
-    let node = parser.parse("SUM(C2:F5)", &Some(context.clone()));
+    let node = parser.parse("SUM(C2:F5)", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -220,7 +220,7 @@ fn test_move_formula_ranges() {
     );
     assert_eq!(t, "SUM(M12:P15)");
 
-    let node = parser.parse("SUM($C$2:$F$5)", &Some(context.clone()));
+    let node = parser.parse("SUM($C$2:$F$5)", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -236,7 +236,7 @@ fn test_move_formula_ranges() {
     assert_eq!(t, "SUM($M$12:$P$15)");
 
     // Ranges completely outside of the area are not touched
-    let node = parser.parse("SUM(A1:B3)", &Some(context.clone()));
+    let node = parser.parse("SUM(A1:B3)", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -251,7 +251,7 @@ fn test_move_formula_ranges() {
     );
     assert_eq!(t, "SUM(A1:B3)");
 
-    let node = parser.parse("SUM($A$1:$B$3)", &Some(context.clone()));
+    let node = parser.parse("SUM($A$1:$B$3)", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -267,7 +267,7 @@ fn test_move_formula_ranges() {
     assert_eq!(t, "SUM($A$1:$B$3)");
 
     // Ranges that overlap with the area are also NOT displaced
-    let node = parser.parse("SUM(A1:F5)", &Some(context.clone()));
+    let node = parser.parse("SUM(A1:F5)", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -283,7 +283,7 @@ fn test_move_formula_ranges() {
     assert_eq!(t, "SUM(A1:F5)");
 
     // Ranges that contain the area are also NOT displaced
-    let node = parser.parse("SUM(A1:X50)", &Some(context.clone()));
+    let node = parser.parse("SUM(A1:X50)", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -321,7 +321,7 @@ fn test_move_formula_wrong_reference() {
     let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Wrong formulas will NOT be displaced
-    let node = parser.parse("Sheet3!AB31", &Some(context.clone()));
+    let node = parser.parse("Sheet3!AB31", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -335,7 +335,7 @@ fn test_move_formula_wrong_reference() {
         },
     );
     assert_eq!(t, "Sheet3!AB31");
-    let node = parser.parse("Sheet3!$X$9", &Some(context.clone()));
+    let node = parser.parse("Sheet3!$X$9", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -350,7 +350,7 @@ fn test_move_formula_wrong_reference() {
     );
     assert_eq!(t, "Sheet3!$X$9");
 
-    let node = parser.parse("SUM(Sheet3!D2:D3)", &Some(context.clone()));
+    let node = parser.parse("SUM(Sheet3!D2:D3)", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -387,7 +387,7 @@ fn test_move_formula_misc() {
         width: 4,
         height: 5,
     };
-    let node = parser.parse("X9^C2-F4*H2", &Some(context.clone()));
+    let node = parser.parse("X9^C2-F4*H2", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -402,7 +402,7 @@ fn test_move_formula_misc() {
     );
     assert_eq!(t, "X9^M12-P14*H2");
 
-    let node = parser.parse("F5*(-D5)*SUM(A1, X9, $D$5)", &Some(context.clone()));
+    let node = parser.parse("F5*(-D5)*SUM(A1, X9, $D$5)", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -417,7 +417,7 @@ fn test_move_formula_misc() {
     );
     assert_eq!(t, "P15*(-N15)*SUM(A1,X9,$N$15)");
 
-    let node = parser.parse("IF(F5 < -D5, X9 & F5, FALSE)", &Some(context.clone()));
+    let node = parser.parse("IF(F5 < -D5, X9 & F5, FALSE)", context);
     let t = move_formula(
         &node,
         &MoveContext {
@@ -457,10 +457,7 @@ fn test_move_formula_another_sheet() {
     };
 
     // Formula AB31 and JJ3:JJ4 refers to original Sheet1!AB31 and Sheet1!JJ3:JJ4
-    let node = parser.parse(
-        "AB31*SUM(JJ3:JJ4)+SUM(Sheet2!C2:F6)*SUM(C2:F6)",
-        &Some(context.clone()),
-    );
+    let node = parser.parse("AB31*SUM(JJ3:JJ4)+SUM(Sheet2!C2:F6)*SUM(C2:F6)", context);
     let t = move_formula(
         &node,
         &MoveContext {

--- a/base/src/expressions/parser/tests/test_move_formula.rs
+++ b/base/src/expressions/parser/tests/test_move_formula.rs
@@ -15,7 +15,7 @@ fn test_move_formula() {
         column,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Area is C2:F6
     let area = &Area {
@@ -102,7 +102,7 @@ fn test_move_formula_context_offset() {
         column,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Area is C2:F6
     let area = &Area {
@@ -140,7 +140,7 @@ fn test_move_formula_area_limits() {
         column,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Area is C2:F6
     let area = &Area {
@@ -195,7 +195,7 @@ fn test_move_formula_ranges() {
         column,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     let area = &Area {
         sheet: 0,
@@ -318,7 +318,7 @@ fn test_move_formula_wrong_reference() {
         height: 5,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Wrong formulas will NOT be displaced
     let node = parser.parse("Sheet3!AB31", &Some(context.clone()));
@@ -377,7 +377,7 @@ fn test_move_formula_misc() {
         column,
     };
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Area is C2:F6
     let area = &Area {
@@ -445,7 +445,7 @@ fn test_move_formula_another_sheet() {
     };
     // we add two sheets and we cut/paste from Sheet1 to Sheet2
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Area is C2:F6
     let area = &Area {

--- a/base/src/expressions/parser/tests/test_ranges.rs
+++ b/base/src/expressions/parser/tests/test_ranges.rs
@@ -52,11 +52,11 @@ fn test_parser_formulas_with_full_ranges() {
     for formula in &formulas {
         let t = parser.parse(
             formula.formula_a1,
-            &Some(CellReferenceRC {
+            &CellReferenceRC {
                 sheet: "Sheet1".to_string(),
                 row: 1,
                 column: 1,
-            }),
+            },
         );
         assert_eq!(to_rc_format(&t), formula.formula_r1c1);
         assert_eq!(to_string(&t, &cell_reference), formula.formula_a1);
@@ -67,11 +67,11 @@ fn test_parser_formulas_with_full_ranges() {
     for formula in &formulas {
         let t = parser.parse(
             formula.formula_r1c1,
-            &Some(CellReferenceRC {
+            &CellReferenceRC {
                 sheet: "Sheet1".to_string(),
                 row: 1,
                 column: 1,
-            }),
+            },
         );
         assert_eq!(to_rc_format(&t), formula.formula_r1c1);
         assert_eq!(to_string(&t, &cell_reference), formula.formula_a1);
@@ -93,7 +93,7 @@ fn test_range_inverse_order() {
     // D4:C2 => C2:D4
     let t = parser.parse(
         "SUM(D4:C2)*SUM(Sheet2!D4:C20)*SUM($C$20:D4)",
-        &Some(cell_reference.clone()),
+        &cell_reference,
     );
     assert_eq!(
         to_string(&t, &cell_reference),

--- a/base/src/expressions/parser/tests/test_ranges.rs
+++ b/base/src/expressions/parser/tests/test_ranges.rs
@@ -14,7 +14,7 @@ struct Formula<'a> {
 #[test]
 fn test_parser_formulas_with_full_ranges() {
     let worksheets = vec!["Sheet1".to_string(), "Second Sheet".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     let formulas = vec![
         Formula {
@@ -81,7 +81,7 @@ fn test_parser_formulas_with_full_ranges() {
 #[test]
 fn test_range_inverse_order() {
     let worksheets = vec!["Sheet1".to_string(), "Sheet2".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {

--- a/base/src/expressions/parser/tests/test_stringify.rs
+++ b/base/src/expressions/parser/tests/test_stringify.rs
@@ -9,7 +9,7 @@ use crate::expressions::types::CellReferenceRC;
 #[test]
 fn exp_order() {
     let worksheets = vec!["Sheet1".to_string()];
-    let mut parser = Parser::new(worksheets, HashMap::new());
+    let mut parser = Parser::new(worksheets, vec![], HashMap::new());
 
     // Reference cell is Sheet1!A1
     let cell_reference = CellReferenceRC {

--- a/base/src/expressions/parser/tests/test_stringify.rs
+++ b/base/src/expressions/parser/tests/test_stringify.rs
@@ -17,18 +17,18 @@ fn exp_order() {
         row: 1,
         column: 1,
     };
-    let t = parser.parse("(1 + 2)^3  + 4", &Some(cell_reference.clone()));
+    let t = parser.parse("(1 + 2)^3  + 4", &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "(1+2)^3+4");
 
-    let t = parser.parse("(C5 + 3)^R4", &Some(cell_reference.clone()));
+    let t = parser.parse("(C5 + 3)^R4", &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "(C5+3)^R4");
 
-    let t = parser.parse("(C5 + 3)^(R4*6)", &Some(cell_reference.clone()));
+    let t = parser.parse("(C5 + 3)^(R4*6)", &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "(C5+3)^(R4*6)");
 
-    let t = parser.parse("(C5)^(R4)", &Some(cell_reference.clone()));
+    let t = parser.parse("(C5)^(R4)", &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "C5^R4");
 
-    let t = parser.parse("(5)^(4)", &Some(cell_reference.clone()));
+    let t = parser.parse("(5)^(4)", &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "5^4");
 }

--- a/base/src/expressions/parser/tests/test_tables.rs
+++ b/base/src/expressions/parser/tests/test_tables.rs
@@ -63,7 +63,7 @@ fn simple_table() {
     let row_count = 3;
     let tables = create_test_table("tblIncome", &column_names, "A1", row_count);
 
-    let mut parser = Parser::new(worksheets, tables);
+    let mut parser = Parser::new(worksheets, vec![], tables);
     // Reference cell is 'Sheet One'!F2
     let cell_reference = CellReferenceRC {
         sheet: "Sheet One".to_string(),

--- a/base/src/expressions/parser/tests/test_tables.rs
+++ b/base/src/expressions/parser/tests/test_tables.rs
@@ -72,7 +72,7 @@ fn simple_table() {
     };
 
     let formula = "SUM(tblIncome[[#This Row],[Jan]:[Dec]])";
-    let t = parser.parse(formula, &Some(cell_reference.clone()));
+    let t = parser.parse(formula, &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "SUM($A$2:$E$2)");
 
     // Cell A3
@@ -82,7 +82,7 @@ fn simple_table() {
         column: 1,
     };
     let formula = "SUBTOTAL(109, tblIncome[Jan])";
-    let t = parser.parse(formula, &Some(cell_reference.clone()));
+    let t = parser.parse(formula, &cell_reference);
     assert_eq!(to_string(&t, &cell_reference), "SUBTOTAL(109,$A$2:$A$3)");
 
     // Cell A3 in 'Second Sheet'
@@ -92,7 +92,7 @@ fn simple_table() {
         column: 1,
     };
     let formula = "SUBTOTAL(109, tblIncome[Jan])";
-    let t = parser.parse(formula, &Some(cell_reference.clone()));
+    let t = parser.parse(formula, &cell_reference);
     assert_eq!(
         to_string(&t, &cell_reference),
         "SUBTOTAL(109,'Sheet One'!$A$2:$A$3)"

--- a/base/src/expressions/parser/walk.rs
+++ b/base/src/expressions/parser/walk.rs
@@ -263,7 +263,9 @@ pub(crate) fn forward_references(
         // TODO: Not implemented
         Node::ArrayKind(_) => {}
         // Do nothing. Note: we could do a blanket _ => {}
-        Node::VariableKind(_) => {}
+        Node::DefinedNameKind(_) => {}
+        Node::TableNameKind(_) => {}
+        Node::WrongVariableKind(_) => {}
         Node::ErrorKind(_) => {}
         Node::ParseErrorKind { .. } => {}
         Node::EmptyArgKind => {}

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -25,6 +25,8 @@
 #![doc = include_str!("../examples/formulas_and_errors.rs")]
 //! ```
 
+#![warn(clippy::print_stdout)]
+
 pub mod calc_result;
 pub mod cell;
 pub mod expressions;

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         token::{get_error_by_name, Error, OpCompare, OpProduct, OpSum, OpUnary},
         types::*,
-        utils::{self, is_valid_column_number, is_valid_row},
+        utils::{self, is_valid_column_number, is_valid_identifier, is_valid_row},
     },
     formatter::{
         format::{format_number, parse_formatted_number},
@@ -2039,6 +2039,9 @@ impl Model {
         scope: Option<u32>,
         formula: &str,
     ) -> Result<(), String> {
+        if !is_valid_identifier(name) {
+            return Err("Invalid defined name".to_string());
+        };
         let name_upper = name.to_uppercase();
         let defined_names = &self.workbook.defined_names;
         let sheet_id = match scope {
@@ -2093,7 +2096,19 @@ impl Model {
         new_scope: Option<u32>,
         new_formula: &str,
     ) -> Result<(), String> {
+        if !is_valid_identifier(new_name) {
+            return Err("Invalid defined name".to_string());
+        };
         let name_upper = name.to_uppercase();
+        let new_name_upper = new_name.to_uppercase();
+
+        if name_upper != new_name_upper || scope != new_scope {
+            for key in self.parsed_defined_names.keys() {
+                if key.1.to_uppercase() == new_name_upper && key.0 == new_scope {
+                    return Err("Defined name already exists".to_string());
+                }
+            }
+        }
         let defined_names = &self.workbook.defined_names;
         let sheet_id = match scope {
             Some(index) => Some(self.workbook.worksheet(index)?.sheet_id),

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1040,7 +1040,7 @@ impl Model {
                 column: source.column,
             };
             let formula_str = move_formula(
-                &self.parser.parse(formula, &Some(cell_reference)),
+                &self.parser.parse(formula, &cell_reference),
                 &MoveContext {
                     source_sheet_name: &source_sheet_name,
                     row: source.row,
@@ -1148,7 +1148,7 @@ impl Model {
                 row: source.row,
                 column: source.column,
             };
-            let formula = &self.parser.parse(formula_str, &Some(cell_reference));
+            let formula = &self.parser.parse(formula_str, &cell_reference);
             let cell_reference = CellReferenceRC {
                 sheet: target_sheet_name,
                 row: target.row,
@@ -1524,13 +1524,11 @@ impl Model {
             column,
         };
         let shared_formulas = &mut worksheet.shared_formulas;
-        let mut parsed_formula = self.parser.parse(formula, &Some(cell_reference.clone()));
+        let mut parsed_formula = self.parser.parse(formula, &cell_reference);
         // If the formula fails to parse try adding a parenthesis
         // SUM(A1:A3  => SUM(A1:A3)
         if let Node::ParseErrorKind { .. } = parsed_formula {
-            let new_parsed_formula = self
-                .parser
-                .parse(&format!("{})", formula), &Some(cell_reference));
+            let new_parsed_formula = self.parser.parse(&format!("{})", formula), &cell_reference);
             match new_parsed_formula {
                 Node::ParseErrorKind { .. } => {}
                 _ => parsed_formula = new_parsed_formula,
@@ -2140,14 +2138,14 @@ impl Model {
                     self.parser.set_lexer_mode(LexerMode::R1C1);
                     let worksheets = &mut self.workbook.worksheets;
                     for worksheet in worksheets {
-                        let cell_reference = &Some(CellReferenceRC {
+                        let cell_reference = CellReferenceRC {
                             sheet: worksheet.get_name(),
                             row: 1,
                             column: 1,
-                        });
+                        };
                         let mut formulas = Vec::new();
                         for formula in &worksheet.shared_formulas {
-                            let mut t = self.parser.parse(formula, cell_reference);
+                            let mut t = self.parser.parse(formula, &cell_reference);
                             rename_defined_name_in_node(&mut t, name, scope, new_name);
                             formulas.push(to_rc_format(&t));
                         }

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -865,7 +865,11 @@ impl Model {
 
         let worksheet_names = worksheets.iter().map(|s| s.get_name()).collect();
 
-        let defined_names = workbook.get_defined_names_with_scope();
+        let defined_names = workbook
+            .get_defined_names_with_scope()
+            .iter()
+            .map(|s| (s.0.to_owned(), s.1))
+            .collect();
         // add all tables
         // let mut tables = Vec::new();
         // for worksheet in worksheets {

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -144,7 +144,12 @@ impl Model {
 
     /// Reparses all formulas and defined names
     pub(crate) fn reset_parsed_structures(&mut self) {
-        let defined_names = self.workbook.get_defined_names_with_scope();
+        let defined_names = self
+            .workbook
+            .get_defined_names_with_scope()
+            .iter()
+            .map(|s| (s.0.to_owned(), s.1))
+            .collect();
         self.parser
             .set_worksheets_and_names(self.workbook.get_worksheet_names(), defined_names);
         self.parsed_formulas = vec![];

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -85,14 +85,14 @@ impl Model {
         let worksheets = &self.workbook.worksheets;
         for worksheet in worksheets {
             let shared_formulas = &worksheet.shared_formulas;
-            let cell_reference = &Some(CellReferenceRC {
+            let cell_reference = CellReferenceRC {
                 sheet: worksheet.get_name(),
                 row: 1,
                 column: 1,
-            });
+            };
             let mut parse_formula = Vec::new();
             for formula in shared_formulas {
-                let t = self.parser.parse(formula, cell_reference);
+                let t = self.parser.parse(formula, &cell_reference);
                 parse_formula.push(t);
             }
             self.parsed_formulas.push(parse_formula);
@@ -268,11 +268,11 @@ impl Model {
         // We use iter because the default would be a mut_iter and we don't need a mutable reference
         let worksheets = &mut self.workbook.worksheets;
         for worksheet in worksheets {
-            let cell_reference = &Some(CellReferenceRC {
+            let cell_reference = &CellReferenceRC {
                 sheet: worksheet.get_name(),
                 row: 1,
                 column: 1,
-            });
+            };
             let mut formulas = Vec::new();
             for formula in &worksheet.shared_formulas {
                 let mut t = self.parser.parse(formula, cell_reference);

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -144,8 +144,9 @@ impl Model {
 
     /// Reparses all formulas and defined names
     pub(crate) fn reset_parsed_structures(&mut self) {
+        let defined_names = self.workbook.get_defined_names_with_scope();
         self.parser
-            .set_worksheets(self.workbook.get_worksheet_names());
+            .set_worksheets_and_names(self.workbook.get_worksheet_names(), defined_names);
         self.parsed_formulas = vec![];
         self.parse_formulas();
         self.parsed_defined_names = HashMap::new();
@@ -388,7 +389,7 @@ impl Model {
         let parsed_formulas = Vec::new();
         let worksheets = &workbook.worksheets;
         let worksheet_names = worksheets.iter().map(|s| s.get_name()).collect();
-        let parser = Parser::new(worksheet_names, HashMap::new());
+        let parser = Parser::new(worksheet_names, vec![], HashMap::new());
         let cells = HashMap::new();
 
         // FIXME: Add support for display languages

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -3,6 +3,7 @@ mod test_autofill_columns;
 mod test_autofill_rows;
 mod test_border;
 mod test_clear_cells;
+mod test_defined_names;
 mod test_diff_queue;
 mod test_evaluation;
 mod test_general;

--- a/base/src/test/user_model/test_defined_names.rs
+++ b/base/src/test/user_model/test_defined_names.rs
@@ -1,0 +1,167 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::UserModel;
+
+#[test]
+fn create_defined_name() {
+    let mut model = UserModel::new_empty("model", "en", "UTC").unwrap();
+    model.set_user_input(0, 1, 1, "42").unwrap();
+    model
+        .new_defined_name("myName", None, "Sheet1!$A$1")
+        .unwrap();
+    model.set_user_input(0, 5, 7, "=myName").unwrap();
+    assert_eq!(
+        model.get_formatted_cell_value(0, 5, 7),
+        Ok("42".to_string())
+    );
+
+    // delete it
+    model.delete_defined_name("myName", None).unwrap();
+    assert_eq!(
+        model.get_formatted_cell_value(0, 5, 7),
+        Ok("#NAME?".to_string())
+    );
+
+    model.undo().unwrap();
+    assert_eq!(
+        model.get_formatted_cell_value(0, 5, 7),
+        Ok("42".to_string())
+    );
+}
+
+#[test]
+fn scopes() {
+    let mut model = UserModel::new_empty("model", "en", "UTC").unwrap();
+    model.set_user_input(0, 1, 1, "42").unwrap();
+
+    // Global
+    model
+        .new_defined_name("myName", None, "Sheet1!$A$1")
+        .unwrap();
+    model.set_user_input(0, 5, 7, "=myName").unwrap();
+
+    // Local to Sheet2
+    model.new_sheet().unwrap();
+    model.set_user_input(1, 2, 1, "145").unwrap();
+    model
+        .new_defined_name("myName", Some(1), "Sheet2!$A$2")
+        .unwrap();
+    model.set_user_input(1, 8, 8, "=myName").unwrap();
+
+    // Sheet 3
+    model.new_sheet().unwrap();
+    model.set_user_input(2, 2, 2, "=myName").unwrap();
+
+    // Global
+    assert_eq!(
+        model.get_formatted_cell_value(0, 5, 7),
+        Ok("42".to_string())
+    );
+
+    assert_eq!(
+        model.get_formatted_cell_value(1, 8, 8),
+        Ok("145".to_string())
+    );
+
+    assert_eq!(
+        model.get_formatted_cell_value(2, 2, 2),
+        Ok("42".to_string())
+    );
+}
+
+#[test]
+fn delete_sheet() {
+    let mut model = UserModel::new_empty("model", "en", "UTC").unwrap();
+    model.set_user_input(0, 1, 1, "Hello").unwrap();
+    model
+        .set_user_input(0, 2, 1, r#"=CONCATENATE(MyName, " world!")"#)
+        .unwrap();
+    model.new_sheet().unwrap();
+    model
+        .new_defined_name("myName", Some(1), "Sheet1!$A$1")
+        .unwrap();
+    model
+        .set_user_input(1, 2, 1, r#"=CONCATENATE(MyName, " my world!")"#)
+        .unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("#NAME?".to_string())
+    );
+
+    assert_eq!(
+        model.get_formatted_cell_value(1, 2, 1),
+        Ok("Hello my world!".to_string())
+    );
+
+    model.delete_sheet(0).unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("#NAME?".to_string())
+    );
+
+    assert_eq!(
+        model.get_cell_content(0, 2, 1),
+        Ok(r#"=CONCATENATE(MyName," my world!")"#.to_string())
+    );
+}
+
+#[test]
+fn change_scope() {
+    let mut model = UserModel::new_empty("model", "en", "UTC").unwrap();
+    model.set_user_input(0, 1, 1, "Hello").unwrap();
+    model
+        .set_user_input(0, 2, 1, r#"=CONCATENATE(MyName, " world!")"#)
+        .unwrap();
+    model.new_sheet().unwrap();
+    model
+        .new_defined_name("myName", Some(1), "Sheet1!$A$1")
+        .unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("#NAME?".to_string())
+    );
+
+    model
+        .update_defined_name("myName", Some(1), "myName", None, "Sheet1!$A$1")
+        .unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("Hello world!".to_string())
+    );
+}
+
+#[test]
+fn rename_defined_name() {
+    let mut model = UserModel::new_empty("model", "en", "UTC").unwrap();
+    model.set_user_input(0, 1, 1, "Hello").unwrap();
+    model
+        .set_user_input(0, 2, 1, r#"=CONCATENATE(MyName, " world!")"#)
+        .unwrap();
+    model.new_sheet().unwrap();
+    model
+        .new_defined_name("myName", None, "Sheet1!$A$1")
+        .unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("Hello world!".to_string())
+    );
+
+    model
+        .update_defined_name("myName", None, "newName", None, "Sheet1!$A$1")
+        .unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("Hello world!".to_string())
+    );
+
+    assert_eq!(
+        model.get_cell_content(0, 2, 1),
+        Ok(r#"=CONCATENATE(newName," world!")"#.to_string())
+    );
+}

--- a/base/src/test/user_model/test_defined_names.rs
+++ b/base/src/test/user_model/test_defined_names.rs
@@ -15,12 +15,19 @@ fn create_defined_name() {
         Ok("42".to_string())
     );
 
+    assert_eq!(
+        model.get_defined_name_list(),
+        vec![("myName".to_string(), None, "Sheet1!$A$1".to_string())]
+    );
+
     // delete it
     model.delete_defined_name("myName", None).unwrap();
     assert_eq!(
         model.get_formatted_cell_value(0, 5, 7),
         Ok("#NAME?".to_string())
     );
+
+    assert_eq!(model.get_defined_name_list().len(), 0);
 
     model.undo().unwrap();
     assert_eq!(
@@ -322,5 +329,70 @@ fn invalid_formula() {
     assert_eq!(
         model.get_formatted_cell_value(0, 1, 2),
         Ok("#NAME?".to_string())
+    );
+}
+
+#[test]
+fn undo_redo() {
+    let mut model = UserModel::new_empty("model", "en", "UTC").unwrap();
+    model.set_user_input(0, 1, 1, "Hello").unwrap();
+    model.set_user_input(0, 2, 1, "Hola").unwrap();
+    model.set_user_input(0, 1, 2, r#"=MyName&"!""#).unwrap();
+
+    model
+        .new_defined_name("MyName", None, "Sheet1!$A$1")
+        .unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 2),
+        Ok("Hello!".to_string())
+    );
+    model.undo().unwrap();
+    assert_eq!(model.get_defined_name_list().len(), 0);
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 2),
+        Ok("#NAME?".to_string())
+    );
+    model.redo().unwrap();
+
+    assert_eq!(model.get_defined_name_list().len(), 1);
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 2),
+        Ok("Hello!".to_string())
+    );
+
+    model
+        .update_defined_name("MyName", None, "MyName", None, "Sheet1!$A$2")
+        .unwrap();
+    assert_eq!(model.get_defined_name_list().len(), 1);
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 2),
+        Ok("Hola!".to_string())
+    );
+    model.undo().unwrap();
+
+    assert_eq!(model.get_defined_name_list().len(), 1);
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 2),
+        Ok("Hello!".to_string())
+    );
+
+    model.redo().unwrap();
+
+    assert_eq!(model.get_defined_name_list().len(), 1);
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 2),
+        Ok("Hola!".to_string())
+    );
+
+    let send_queue = model.flush_send_queue();
+
+    let mut model2 = UserModel::new_empty("model", "en", "UTC").unwrap();
+    model2.apply_external_diffs(&send_queue).unwrap();
+
+    assert_eq!(model2.get_defined_name_list().len(), 1);
+    assert_eq!(
+        model2.get_formatted_cell_value(0, 1, 2),
+        Ok("Hola!".to_string())
     );
 }

--- a/base/src/test/user_model/test_general.rs
+++ b/base/src/test/user_model/test_general.rs
@@ -91,7 +91,6 @@ fn insert_remove_columns() {
     let mut model = UserModel::from_model(model);
     // column E
     let column_width = model.get_column_width(0, 5).unwrap();
-    println!("{column_width}");
 
     // Insert some data in row 5 (and change the style) in E1
     assert!(model.set_user_input(0, 1, 5, "100$").is_ok());

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -293,7 +293,9 @@ impl Model {
             Node::EmptyArgKind => None,
             Node::InvalidFunctionKind { .. } => None,
             Node::ArrayKind(_) => None,
-            Node::VariableKind(_) => None,
+            Node::DefinedNameKind(_) => None,
+            Node::TableNameKind(_) => None,
+            Node::WrongVariableKind(_) => None,
             Node::CompareKind { .. } => None,
             Node::OpPowerKind { .. } => None,
         }

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -13,8 +13,8 @@ use crate::{
     },
     model::Model,
     types::{
-        Alignment, BorderItem, CellType, Col, DefinedName, HorizontalAlignment, SheetProperties,
-        SheetState, Style, VerticalAlignment,
+        Alignment, BorderItem, CellType, Col, HorizontalAlignment, SheetProperties, SheetState,
+        Style, VerticalAlignment,
     },
     utils::is_valid_hex_color,
 };
@@ -1735,8 +1735,8 @@ impl UserModel {
     }
 
     /// Returns the list of defined names
-    pub fn get_defined_name_list(&self) -> Vec<DefinedName> {
-        self.model.workbook.defined_names.clone()
+    pub fn get_defined_name_list(&self) -> Vec<(String, Option<u32>, String)> {
+        self.model.workbook.get_defined_names_with_scope()
     }
 
     /// Delete an existing defined name

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -13,8 +13,8 @@ use crate::{
     },
     model::Model,
     types::{
-        Alignment, BorderItem, CellType, Col, HorizontalAlignment, SheetProperties, SheetState,
-        Style, VerticalAlignment,
+        Alignment, BorderItem, CellType, Col, DefinedName, HorizontalAlignment, SheetProperties,
+        SheetState, Style, VerticalAlignment,
     },
     utils::is_valid_hex_color,
 };
@@ -1734,6 +1734,68 @@ impl UserModel {
         Ok(())
     }
 
+    /// Returns the list of defined names
+    pub fn get_defined_name_list(&self) -> Vec<DefinedName> {
+        self.model.workbook.defined_names.clone()
+    }
+
+    /// Delete an existing defined name
+    pub fn delete_defined_name(&mut self, name: &str, scope: Option<u32>) -> Result<(), String> {
+        let old_value = self.model.get_defined_name_formula(name, scope)?;
+        let diff_list = vec![Diff::DeleteDefinedName {
+            name: name.to_string(),
+            scope,
+            old_value,
+        }];
+        self.push_diff_list(diff_list);
+        self.model.delete_defined_name(name, scope)?;
+        self.evaluate_if_not_paused();
+        Ok(())
+    }
+
+    /// Create a new defined name
+    pub fn new_defined_name(
+        &mut self,
+        name: &str,
+        scope: Option<u32>,
+        formula: &str,
+    ) -> Result<(), String> {
+        self.model.new_defined_name(name, scope, formula)?;
+        let diff_list = vec![Diff::CreateDefinedName {
+            name: name.to_string(),
+            scope,
+            value: formula.to_string(),
+        }];
+        self.push_diff_list(diff_list);
+        self.evaluate_if_not_paused();
+        Ok(())
+    }
+
+    /// Updates a defined name
+    pub fn update_defined_name(
+        &mut self,
+        name: &str,
+        scope: Option<u32>,
+        new_name: &str,
+        new_scope: Option<u32>,
+        new_formula: &str,
+    ) -> Result<(), String> {
+        let old_formula = self.model.get_defined_name_formula(name, scope)?;
+        let diff_list = vec![Diff::UpdateDefinedName {
+            name: name.to_string(),
+            scope,
+            old_formula: old_formula.to_string(),
+            new_name: new_name.to_string(),
+            new_scope,
+            new_formula: new_formula.to_string(),
+        }];
+        self.push_diff_list(diff_list);
+        self.model
+            .update_defined_name(name, scope, new_name, new_scope, new_formula)?;
+        self.evaluate_if_not_paused();
+        Ok(())
+    }
+
     // **** Private methods ****** //
 
     fn push_diff_list(&mut self, diff_list: DiffList) {
@@ -1904,6 +1966,36 @@ impl UserModel {
                 } => {
                     self.model.set_show_grid_lines(*sheet, *old_value)?;
                 }
+                Diff::CreateDefinedName {
+                    name,
+                    scope,
+                    value: _,
+                } => {
+                    self.model.delete_defined_name(name, *scope)?;
+                }
+                Diff::DeleteDefinedName {
+                    name,
+                    scope,
+                    old_value,
+                } => {
+                    self.model.new_defined_name(name, *scope, old_value)?;
+                }
+                Diff::UpdateDefinedName {
+                    name,
+                    scope,
+                    old_formula,
+                    new_name,
+                    new_scope,
+                    new_formula: _,
+                } => {
+                    self.model.update_defined_name(
+                        new_name,
+                        *new_scope,
+                        name,
+                        *scope,
+                        old_formula,
+                    )?;
+                }
                 Diff::SetSheetState {
                     index,
                     old_value,
@@ -2036,6 +2128,28 @@ impl UserModel {
                 } => {
                     self.model.set_show_grid_lines(*sheet, *new_value)?;
                 }
+                Diff::CreateDefinedName { name, scope, value } => {
+                    self.model.new_defined_name(name, *scope, value)?
+                }
+                Diff::DeleteDefinedName {
+                    name,
+                    scope,
+                    old_value: _,
+                } => self.model.delete_defined_name(name, *scope)?,
+                Diff::UpdateDefinedName {
+                    name,
+                    scope,
+                    old_formula: _,
+                    new_name,
+                    new_scope,
+                    new_formula,
+                } => self.model.update_defined_name(
+                    name,
+                    *scope,
+                    new_name,
+                    *new_scope,
+                    new_formula,
+                )?,
                 Diff::SetSheetState {
                     index,
                     old_value: _,

--- a/base/src/user_model/history.rs
+++ b/base/src/user_model/history.rs
@@ -113,7 +113,26 @@ pub(crate) enum Diff {
         sheet: u32,
         old_value: bool,
         new_value: bool,
-    }, // FIXME: we are missing SetViewDiffs
+    },
+    CreateDefinedName {
+        name: String,
+        scope: Option<u32>,
+        value: String,
+    },
+    DeleteDefinedName {
+        name: String,
+        scope: Option<u32>,
+        old_value: String,
+    },
+    UpdateDefinedName {
+        name: String,
+        scope: Option<u32>,
+        old_formula: String,
+        new_name: String,
+        new_scope: Option<u32>,
+        new_formula: String,
+    },
+    // FIXME: we are missing SetViewDiffs
 }
 
 pub(crate) type DiffList = Vec<Diff>;

--- a/base/src/workbook.rs
+++ b/base/src/workbook.rs
@@ -29,7 +29,7 @@ impl Workbook {
     }
 
     /// Returns the a list of defined names in the workbook with their scope
-    pub(crate) fn get_defined_names_with_scope(&self) -> Vec<(String, Option<u32>)> {
+    pub(crate) fn get_defined_names_with_scope(&self) -> Vec<(String, Option<u32>, String)> {
         let sheet_id_index: Vec<u32> = self.worksheets.iter().map(|s| s.sheet_id).collect();
 
         let defined_names = self
@@ -45,7 +45,7 @@ impl Workbook {
                     // convert Option<usize> to Option<u32>
                     .map(|pos| pos as u32);
 
-                (dn.name.clone(), index)
+                (dn.name.clone(), index, dn.formula.clone())
             })
             .collect::<Vec<_>>();
         defined_names

--- a/base/src/workbook.rs
+++ b/base/src/workbook.rs
@@ -27,4 +27,27 @@ impl Workbook {
             .get_mut(worksheet_index as usize)
             .ok_or_else(|| "Invalid sheet index".to_string())
     }
+
+    /// Returns the a list of defined names in the workbook with their scope
+    pub(crate) fn get_defined_names_with_scope(&self) -> Vec<(String, Option<u32>)> {
+        let sheet_id_index: Vec<u32> = self.worksheets.iter().map(|s| s.sheet_id).collect();
+
+        let defined_names = self
+            .defined_names
+            .iter()
+            .map(|dn| {
+                let index = dn
+                    .sheet_id
+                    .and_then(|sheet_id| {
+                        // returns an Option<usize>
+                        sheet_id_index.iter().position(|&x| x == sheet_id)
+                    })
+                    // convert Option<usize> to Option<u32>
+                    .map(|pos| pos as u32);
+
+                (dn.name.clone(), index)
+            })
+            .collect::<Vec<_>>();
+        defined_names
+    }
 }

--- a/bindings/wasm/fix_types.py
+++ b/bindings/wasm/fix_types.py
@@ -187,6 +187,20 @@ paste_from_clipboard_types = r"""
   pasteFromClipboard(source_sheet: number, source_range: [number, number, number, number], clipboard: ClipboardData, is_cut: boolean): void;
 """
 
+defined_name_list = r"""
+/**
+* @returns {any}
+*/
+  getDefinedNameList(): any;
+"""
+
+defined_name_list_types = r"""
+/**
+* @returns {DefinedName[]}
+*/
+  getDefinedNameList(): DefinedName[];
+"""
+
 def fix_types(text):
     text = text.replace(get_tokens_str, get_tokens_str_types)
     text = text.replace(update_style_str, update_style_str_types)
@@ -200,6 +214,7 @@ def fix_types(text):
     text = text.replace(paste_csv_string, paste_csv_string_types)
     text = text.replace(clipboard, clipboard_types)
     text = text.replace(paste_from_clipboard, paste_from_clipboard_types)
+    text = text.replace(defined_name_list, defined_name_list_types)
     with open("types.ts") as f:
         types_str = f.read()
         header_types = "{}\n\n{}".format(header, types_str)

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use wasm_bindgen::{
     prelude::{wasm_bindgen, JsError},
     JsValue,
@@ -27,6 +28,13 @@ pub fn column_name_from_number(column: i32) -> Result<String, JsError> {
         Some(c) => Ok(c),
         None => Err(JsError::new("Invalid column number")),
     }
+}
+
+#[derive(Serialize)]
+struct DefinedName {
+    name: String,
+    scope: Option<u32>,
+    formula: String,
 }
 
 #[wasm_bindgen]
@@ -550,6 +558,55 @@ impl Model {
             serde_wasm_bindgen::from_value(area).map_err(|e| to_js_error(e.to_string()))?;
         self.model
             .paste_csv_string(&range, csv)
+            .map_err(|e| to_js_error(e.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = "getDefinedNameList")]
+    pub fn get_defined_name_list(&self) -> Result<JsValue, JsError> {
+        let data: Vec<DefinedName> = self
+            .model
+            .get_defined_name_list()
+            .iter()
+            .map(|s| DefinedName {
+                name: s.name.to_string(),
+                scope: s.sheet_id,
+                formula: s.formula.to_string(),
+            })
+            .collect();
+        // Ok(data)
+        serde_wasm_bindgen::to_value(&data).map_err(|e| to_js_error(e.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = "newDefinedName")]
+    pub fn new_defined_name(
+        &mut self,
+        name: &str,
+        scope: Option<u32>,
+        formula: &str,
+    ) -> Result<(), JsError> {
+        self.model
+            .new_defined_name(name, scope, formula)
+            .map_err(|e| to_js_error(e.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = "updateDefinedName")]
+    pub fn update_defined_name(
+        &mut self,
+        name: &str,
+        scope: Option<u32>,
+        new_name: &str,
+        new_scope: Option<u32>,
+        new_formula: &str,
+    ) -> Result<(), JsError> {
+        self.model
+            .update_defined_name(name, scope, new_name, new_scope, new_formula)
+            .map_err(|e| to_js_error(e.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = "deleteDefinedName")]
+    pub fn delete_definedname(&mut self, name: &str, scope: Option<u32>) -> Result<(), JsError> {
+        self.model
+            .delete_defined_name(name, scope)
             .map_err(|e| to_js_error(e.to_string()))
     }
 }

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -568,12 +568,11 @@ impl Model {
             .get_defined_name_list()
             .iter()
             .map(|s| DefinedName {
-                name: s.name.to_string(),
-                scope: s.sheet_id,
-                formula: s.formula.to_string(),
+                name: s.0.to_owned(),
+                scope: s.1,
+                formula: s.2.to_owned(),
             })
             .collect();
-        // Ok(data)
         serde_wasm_bindgen::to_value(&data).map_err(|e| to_js_error(e.to_string()))
     }
 

--- a/bindings/wasm/types.ts
+++ b/bindings/wasm/types.ts
@@ -228,3 +228,9 @@ export interface Clipboard {
   data: ClipboardData;
   range: [number, number, number, number];
 }
+
+export interface DefinedName {
+  name: string;
+  scope?: number;
+  formula: string;
+}

--- a/xlsx/src/import/worksheets.rs
+++ b/xlsx/src/import/worksheets.rs
@@ -309,7 +309,7 @@ fn from_a1_to_rc(
     let mut parser = Parser::new(worksheets.to_owned(), defined_names, tables);
     let cell_reference =
         parse_reference(&context).map_err(|error| XlsxError::Xml(error.to_string()))?;
-    let t = parser.parse(&formula, &Some(cell_reference));
+    let t = parser.parse(&formula, &cell_reference);
     Ok(to_rc_format(&t))
 }
 


### PR DESCRIPTION
This adds a 'user'  API for defined names (Add/Delete/Update) with undo/redo history support.

In the AST (Abstract Syntax Tree) I split the VariableKind node into three different nodes:

* DefinedNameKind that holds also the scope of the defined name
* TableNameKind
* WrongVariableKind

So at parse time we have much more information.

Also renaming a defined name is a bit tricky so there is a bit of code for that following suit of the rename_sheet method

