### PR TITLE
FIX: TRUE and FALSE can also be functions

### DIFF
--- a/base/src/functions/logical.rs
+++ b/base/src/functions/logical.rs
@@ -7,6 +7,22 @@ use crate::{
 use super::util::compare_values;
 
 impl Model {
+    pub(crate) fn fn_true(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
+        if args.is_empty() {
+            CalcResult::Boolean(true)
+        } else {
+            CalcResult::new_args_number_error(cell)
+        }
+    }
+
+    pub(crate) fn fn_false(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
+        if args.is_empty() {
+            CalcResult::Boolean(false)
+        } else {
+            CalcResult::new_args_number_error(cell)
+        }
+    }
+
     pub(crate) fn fn_if(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
         if args.len() == 2 || args.len() == 3 {
             let cond_result = self.get_boolean(&args[0], cell);

--- a/base/src/functions/mod.rs
+++ b/base/src/functions/mod.rs
@@ -949,7 +949,7 @@ impl Model {
         match kind {
             // Logical
             Function::And => self.fn_and(args, cell),
-            Function::False => CalcResult::Boolean(false),
+            Function::False => self.fn_false(args, cell),
             Function::If => self.fn_if(args, cell),
             Function::Iferror => self.fn_iferror(args, cell),
             Function::Ifna => self.fn_ifna(args, cell),
@@ -957,7 +957,7 @@ impl Model {
             Function::Not => self.fn_not(args, cell),
             Function::Or => self.fn_or(args, cell),
             Function::Switch => self.fn_switch(args, cell),
-            Function::True => CalcResult::Boolean(true),
+            Function::True => self.fn_true(args, cell),
             Function::Xor => self.fn_xor(args, cell),
             // Math and trigonometry
             Function::Sin => self.fn_sin(args, cell),

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -41,6 +41,7 @@ mod test_sheet_markup;
 mod test_sheets;
 mod test_styles;
 mod test_trigonometric;
+mod test_true_false;
 mod test_workbook;
 mod test_worksheet;
 pub(crate) mod util;

--- a/base/src/test/test_true_false.rs
+++ b/base/src/test/test_true_false.rs
@@ -1,0 +1,25 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+#[test]
+fn true_false_arguments() {
+    let mut model = new_empty_model();
+    model._set("A1", "=TRUE( )");
+    model._set("A2", "=FALSE( )");
+    model._set("A3", "=TRUE( 4 )");
+    model._set("A4", "=FALSE( 4 )");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"TRUE");
+    assert_eq!(model._get_text("A2"), *"FALSE");
+
+    assert_eq!(model._get_formula("A1"), *"=TRUE()");
+    assert_eq!(model._get_formula("A2"), *"=FALSE()");
+
+    assert_eq!(model._get_text("A3"), *"#ERROR!");
+    assert_eq!(model._get_text("A4"), *"#ERROR!");
+    assert_eq!(model._get_formula("A3"), *"=TRUE(4)");
+    assert_eq!(model._get_formula("A4"), *"=FALSE(4)");
+}


### PR DESCRIPTION
Previously the engine was internally transforming TRUE() to TRUE

Note that the friendly giant implements this only for compatibility reasons