### PR TITLE
FIX: Add link to name manager page

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -45,6 +45,10 @@ export default defineConfig({
           { text: "About the web application", link: "/web-application/about" },
           { text: "Importing Files", link: "/web-application/importing-files" },
           { text: "Sharing Files", link: "/web-application/sharing-files" },
+          {
+            text: "Name Manager",
+            link: "/web-application/name-manager",
+          }
         ],
       },
       {

--- a/docs/src/web-application/name-manager.md
+++ b/docs/src/web-application/name-manager.md
@@ -1,0 +1,12 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# Name Manager
+
+::: warning
+**Note:** This draft page is under construction 🚧
+:::
+


### PR DESCRIPTION
This is a bit tough, there is not yet a good place to add documentation about dialogs in the widget.

We have the general documentation of the engine. All those things are valid everywhere IronCalc is used. Could be from the web or an scripting language like Python.

We have the documentation of the Web Application deployed at app.ironcalc.com. These are things like export/import and sharing features that are not related to the spreadsheet widget.

Finally we have the documentation of dialogs (like this one) in the widget. Those will be used wherever the widget is used, non necessarily in our own service.

FYI: @dg-ac , @aloifran , @stevethesleeve 