### PR TITLE
FIX: Name Manager cosmetics and responsiveness

### DIFF
--- a/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
+++ b/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
@@ -196,27 +196,31 @@ const StyledDialogTitle = styled(DialogTitle)`
 
 const NameListWrapper = styled(Stack)`
   overflow-y: auto;
-  gap: 12px;
 `;
 
 const StyledBox = styled(Box)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   width: 161.67px;
 `;
 
 const StyledDialogContent = styled(DialogContent)`
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 20px 12px 20px 20px;
+  padding: 0px;
 `;
 
 const StyledRangesHeader = styled(Stack)(({ theme }) => ({
   flexDirection: "row",
-  padding: "0 8px",
-  gap: "12px",
+  minHeight: "32px",
+  padding: "0px 84px 0px 12px",
+  gap: "8px",
   fontFamily: theme.typography.fontFamily,
   fontSize: "12px",
   fontWeight: "700",
+  borderBottom: `1px solid ${theme.palette.info.light}`,
+  backgroundColor: theme.palette.grey["50"],
   color: theme.palette.info.main,
 }));
 

--- a/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
+++ b/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
@@ -173,7 +173,7 @@ function NameManagerDialog(properties: NameManagerDialogProperties) {
           onClick={() => setEditingNameIndex(-1)}
           variant="contained"
           disableElevation
-          sx={{ textTransform: "none" }}
+          sx={{ textTransform: "none", minWidth: "fit-content" }}
           startIcon={<Plus size={16} />}
           disabled={editingNameIndex > -2}
         >
@@ -184,11 +184,15 @@ function NameManagerDialog(properties: NameManagerDialogProperties) {
   );
 }
 
-const StyledDialog = styled(Dialog)(() => ({
+const StyledDialog = styled(Dialog)(({ theme }) => ({
   "& .MuiPaper-root": {
     height: "400px",
     minHeight: "200px",
     minWidth: "620px",
+    maxWidth: "90%",
+    [theme.breakpoints.down("sm")]: {
+      minWidth: "90%",
+    },
   },
 }));
 

--- a/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
+++ b/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
@@ -189,7 +189,7 @@ const StyledDialog = styled(Dialog)(({ theme }) => ({
     height: "400px",
     minHeight: "200px",
     minWidth: "620px",
-    maxWidth: "90%",
+    maxWidth: "620px",
     [theme.breakpoints.down("sm")]: {
       minWidth: "90%",
     },

--- a/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
+++ b/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
@@ -186,7 +186,7 @@ function NameManagerDialog(properties: NameManagerDialogProperties) {
 
 const StyledDialog = styled(Dialog)(() => ({
   "& .MuiPaper-root": {
-    height: "380px",
+    height: "400px",
     minHeight: "200px",
     minWidth: "620px",
   },
@@ -260,14 +260,15 @@ const StyledDialogActions = styled(DialogActions)`
   align-items: center;
   justify-content: space-between;
   font-size: 12px;
-  color: #757575;
+  color: ${theme.palette.grey["600"]};
+  border-top: 1px solid ${theme.palette.grey["300"]};
 `;
 
 const UploadFooterLink = styled("a")`
   font-size: 12px;
   font-weight: 400;
   font-family: "Inter";
-  color: #757575;
+  color: ${theme.palette.grey["600"]};
   text-decoration: none;
   &:hover {
     text-decoration: underline;

--- a/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
+++ b/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
@@ -6,13 +6,13 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  IconButton,
   Stack,
   styled,
 } from "@mui/material";
 import { t } from "i18next";
 import { BookOpen, Plus, X } from "lucide-react";
 import { useEffect, useState } from "react";
+import { theme } from "../../theme";
 import NamedRangeActive from "./NamedRangeActive";
 import NamedRangeInactive from "./NamedRangeInactive";
 
@@ -61,16 +61,24 @@ function NameManagerDialog(properties: NameManagerDialogProperties) {
       setEditingNameIndex(-2);
     }
   }, [open]);
+  const handleClose = () => {
+    properties.onClose();
+  };
 
   return (
     <StyledDialog open={open} onClose={onClose} maxWidth={false} scroll="paper">
       <StyledDialogTitle>
         {t("name_manager_dialog.title")}
-        <IconButton onClick={onClose}>
-          <X size={16} />
-        </IconButton>
+        <Cross
+          onClick={handleClose}
+          title={t("name_manager_dialog.close")}
+          tabIndex={0}
+          onKeyDown={(event) => event.key === "Enter" && properties.onClose()}
+        >
+          <X />
+        </Cross>
       </StyledDialogTitle>
-      <StyledDialogContent dividers>
+      <StyledDialogContent>
         <StyledRangesHeader>
           <StyledBox>{t("name_manager_dialog.name")}</StyledBox>
           <StyledBox>{t("name_manager_dialog.range")}</StyledBox>
@@ -185,13 +193,33 @@ const StyledDialog = styled(Dialog)(() => ({
 }));
 
 const StyledDialogTitle = styled(DialogTitle)`
-  padding: 12px 20px;
-  height: 20px;
-  font-size: 14px;
-  font-weight: 600;
   display: flex;
   align-items: center;
+  height: 44px;
+  font-size: 14px;
+  font-weight: 500;
+  font-family: Inter;
+  padding: 0px 12px;
   justify-content: space-between;
+  border-bottom: 1px solid ${theme.palette.grey["300"]};
+`;
+
+const Cross = styled("div")`
+  &:hover {
+    background-color: ${theme.palette.grey["50"]};
+  }
+  display: flex;
+  border-radius: 4px;
+  height: 24px;
+  width: 24px;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  svg {
+    width: 16px;
+    height: 16px;
+    stroke-width: 1.5;
+  }
 `;
 
 const NameListWrapper = styled(Stack)`
@@ -226,7 +254,7 @@ const StyledRangesHeader = styled(Stack)(({ theme }) => ({
 }));
 
 const StyledDialogActions = styled(DialogActions)`
-  padding: 12px 20px;
+  padding: 12px;
   height: 40px;
   display: flex;
   align-items: center;

--- a/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
+++ b/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
@@ -202,7 +202,8 @@ const StyledBox = styled(Box)`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  width: 161.67px;
+  width: 100%;
+  padding-left: 8px;
 `;
 
 const StyledDialogContent = styled(DialogContent)`
@@ -214,8 +215,8 @@ const StyledDialogContent = styled(DialogContent)`
 const StyledRangesHeader = styled(Stack)(({ theme }) => ({
   flexDirection: "row",
   minHeight: "32px",
-  padding: "0px 84px 0px 12px",
-  gap: "8px",
+  padding: "0px 96px 0px 12px",
+  gap: "12px",
   fontFamily: theme.typography.fontFamily,
   fontSize: "12px",
   fontWeight: "700",

--- a/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
@@ -122,7 +122,7 @@ const StyledBox = styled(Box)`
   align-items: center;
   gap: 12px;
   width: auto;
-  padding: 12px 20px 12px 4px;
+  padding: 12px 20px 12px 12px;
   box-shadow: 0 -1px 0 ${theme.palette.grey[300]};
 `;
 

--- a/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
@@ -128,12 +128,16 @@ const StyledBox = styled(Box)`
   width: auto;
   padding: 10px 20px 10px 12px;
   box-shadow: 0 -1px 0 ${theme.palette.grey[300]};
+
+  @media (max-width: 600px) {
+    padding: 12px;
+  }
 `;
 
 const StyledTextField = styled(TextField)(() => ({
   "& .MuiInputBase-root": {
     height: "36px",
-    width: "161.67px",
+    width: "100%",
     margin: 0,
     fontFamily: "Inter",
     fontSize: "12px",

--- a/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
@@ -122,13 +122,13 @@ const StyledBox = styled(Box)`
   align-items: center;
   gap: 12px;
   width: auto;
-  padding: 12px 20px 12px 12px;
+  padding: 10px 20px 10px 12px;
   box-shadow: 0 -1px 0 ${theme.palette.grey[300]};
 `;
 
 const StyledTextField = styled(TextField)(() => ({
   "& .MuiInputBase-root": {
-    height: "28px",
+    height: "36px",
     width: "161.67px",
     margin: 0,
     fontFamily: "Inter",

--- a/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
@@ -84,17 +84,21 @@ function NamedRangeActive(properties: NamedRangeProperties) {
           onClick={(event) => event.stopPropagation()}
         />
         <IconsWrapper>
-          <IconButton
+          <StyledIconButton
             onClick={() => {
               const error = onSave(name, scope, formula);
               if (error) {
                 setFormulaError(true);
               }
             }}
+            title={t("name_manager_dialog.apply")}
           >
             <StyledCheck size={16} />
-          </IconButton>
-          <StyledIconButton onClick={onCancel}>
+          </StyledIconButton>
+          <StyledIconButton
+            onClick={onCancel}
+            title={t("name_manager_dialog.discard")}
+          >
             <X size={16} />
           </StyledIconButton>
         </IconsWrapper>
@@ -141,6 +145,10 @@ const StyledTextField = styled(TextField)(() => ({
 
 const StyledIconButton = styled(IconButton)(({ theme }) => ({
   color: theme.palette.error.main,
+  borderRadius: "8px",
+  "&:hover": {
+    backgroundColor: theme.palette.grey["50"],
+  },
   "&.Mui-disabled": {
     opacity: 0.6,
     color: theme.palette.error.light,

--- a/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
@@ -92,10 +92,10 @@ function NamedRangeActive(properties: NamedRangeProperties) {
               }
             }}
           >
-            <StyledCheck size={12} />
+            <StyledCheck size={16} />
           </IconButton>
           <StyledIconButton onClick={onCancel}>
-            <X size={12} />
+            <X size={16} />
           </StyledIconButton>
         </IconsWrapper>
       </StyledBox>
@@ -118,8 +118,12 @@ const MenuSpanGrey = styled("span")`
 
 const StyledBox = styled(Box)`
   display: flex;
+  flex-direction: row;
+  align-items: center;
   gap: 12px;
-  width: 577px;
+  width: auto;
+  padding: 12px 20px 12px 4px;
+  box-shadow: 0 -1px 0 ${theme.palette.grey[300]};
 `;
 
 const StyledTextField = styled(TextField)(() => ({

--- a/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
@@ -29,10 +29,10 @@ function NamedRangeInactive(properties: NamedRangeInactiveProperties) {
         <StyledDiv>{formula}</StyledDiv>
         <IconsWrapper>
           <StyledIconButtonBlack onClick={onEdit} disabled={!showOptions}>
-            <PencilLine size={12} />
+            <PencilLine size={16} />
           </StyledIconButtonBlack>
           <StyledIconButtonRed onClick={onDelete} disabled={!showOptions}>
-            <Trash2 size={12} />
+            <Trash2 size={16} />
           </StyledIconButtonRed>
         </IconsWrapper>
       </WrappedLine>
@@ -55,9 +55,11 @@ const StyledIconButtonRed = styled(IconButton)(({ theme }) => ({
 
 const WrappedLine = styled(Box)({
   display: "flex",
-  height: "28px",
+  flexDirection: "row",
+  maxHeight: "52px",
   alignItems: "center",
   gap: "12px",
+  padding: "12px 20px 12px 4px",
 });
 
 const StyledDiv = styled("div")(({ theme }) => ({
@@ -65,7 +67,7 @@ const StyledDiv = styled("div")(({ theme }) => ({
   fontSize: "12px",
   fontWeight: "400",
   color: theme.palette.common.black,
-  width: "153.67px",
+  width: "100%",
   paddingLeft: "8px",
 }));
 

--- a/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
@@ -59,7 +59,7 @@ const WrappedLine = styled(Box)({
   maxHeight: "52px",
   alignItems: "center",
   gap: "12px",
-  padding: "12px 20px 12px 4px",
+  padding: "12px 20px 12px 12px",
 });
 
 const StyledDiv = styled("div")(({ theme }) => ({

--- a/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
@@ -28,10 +28,18 @@ function NamedRangeInactive(properties: NamedRangeInactiveProperties) {
         <StyledDiv>{scopeName}</StyledDiv>
         <StyledDiv>{formula}</StyledDiv>
         <IconsWrapper>
-          <StyledIconButtonBlack onClick={onEdit} disabled={!showOptions}>
+          <StyledIconButtonBlack
+            onClick={onEdit}
+            disabled={!showOptions}
+            title={t("name_manager_dialog.edit")}
+          >
             <PencilLine size={16} />
           </StyledIconButtonBlack>
-          <StyledIconButtonRed onClick={onDelete} disabled={!showOptions}>
+          <StyledIconButtonRed
+            onClick={onDelete}
+            disabled={!showOptions}
+            title={t("name_manager_dialog.delete")}
+          >
             <Trash2 size={16} />
           </StyledIconButtonRed>
         </IconsWrapper>
@@ -43,10 +51,18 @@ function NamedRangeInactive(properties: NamedRangeInactiveProperties) {
 
 const StyledIconButtonBlack = styled(IconButton)(({ theme }) => ({
   color: theme.palette.common.black,
+  borderRadius: "8px",
+  "&:hover": {
+    backgroundColor: theme.palette.grey["50"],
+  },
 }));
 
 const StyledIconButtonRed = styled(IconButton)(({ theme }) => ({
   color: theme.palette.error.main,
+  borderRadius: "8px",
+  "&:hover": {
+    backgroundColor: theme.palette.grey["50"],
+  },
   "&.Mui-disabled": {
     opacity: 0.6,
     color: theme.palette.error.light,

--- a/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
@@ -56,7 +56,6 @@ const StyledIconButtonRed = styled(IconButton)(({ theme }) => ({
 const WrappedLine = styled(Box)({
   display: "flex",
   flexDirection: "row",
-  maxHeight: "52px",
   alignItems: "center",
   gap: "12px",
   padding: "12px 20px 12px 12px",

--- a/webapp/src/locale/en_us.json
+++ b/webapp/src/locale/en_us.json
@@ -85,6 +85,11 @@
     "help": "Learn more about Named Ranges",
     "new": "Add new",
     "workbook": "Workbook",
-    "global": "(Global)"
+    "global": "(Global)",
+    "close": "Close dialog",
+    "delete": "Delete Range",
+    "edit": "Edit Range",
+    "apply": "Apply changes",
+    "discard": "Discard changes"
   }
 }


### PR DESCRIPTION
Hi there,

I've been making a few cosmetic adjustments to the new Name Manager. What we have is great as a first version and works quite well, however I thought some design adjustments were needed. Besides, now it can be used on mobile devices. 

So, in summary, I have:

1. Changed a bunch of borders, margins, paddings, etc to improve the layout
2. Improved accessibility on action buttons by increasing icon sizes, adding hover style and tooltips
3. Adjusted header and footer to make it consistent with the other dialogs
4. Adjusted the dialog so it can be used on mobile devices

Before:
<img width="653" alt="image" src="https://github.com/user-attachments/assets/bc620673-c9a1-4c99-964d-69f79dfc4036" />

After:
<img width="644" alt="image" src="https://github.com/user-attachments/assets/9965f16b-5bad-46d1-85cb-86db0771a742" />

Regarding the mobile view, it still needs to improve a lot, but at least is usable. Next step here would be to get back to Figma and design a proper mobile version of this dialog.

I would also like to work on focus styles, and maybe add new features.

Thanks,
D