### PR TITLE
FIX: Focus and button syling in name manager

### DIFF
--- a/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
+++ b/webapp/src/components/NameManagerDialog/NameManagerDialog.tsx
@@ -84,7 +84,7 @@ function NameManagerDialog(properties: NameManagerDialogProperties) {
           <StyledBox>{t("name_manager_dialog.range")}</StyledBox>
           <StyledBox>{t("name_manager_dialog.scope")}</StyledBox>
         </StyledRangesHeader>
-        <NameListWrapper>
+        <NameListWrapper tabIndex={-1}>
           {definedNameList.map((definedName, index) => {
             const scopeName = definedName.scope
               ? worksheets[definedName.scope].name
@@ -176,6 +176,7 @@ function NameManagerDialog(properties: NameManagerDialogProperties) {
           sx={{ textTransform: "none", minWidth: "fit-content" }}
           startIcon={<Plus size={16} />}
           disabled={editingNameIndex > -2}
+          tabIndex={0}
         >
           {t("name_manager_dialog.new")}
         </Button>

--- a/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeActive.tsx
@@ -92,12 +92,14 @@ function NamedRangeActive(properties: NamedRangeProperties) {
               }
             }}
             title={t("name_manager_dialog.apply")}
+            disableFocusRipple={true}
           >
             <StyledCheck size={16} />
           </StyledIconButton>
           <StyledIconButton
             onClick={onCancel}
             title={t("name_manager_dialog.discard")}
+            disableFocusRipple={true}
           >
             <X size={16} />
           </StyledIconButton>
@@ -156,6 +158,9 @@ const StyledIconButton = styled(IconButton)(({ theme }) => ({
   "&.Mui-disabled": {
     opacity: 0.6,
     color: theme.palette.error.light,
+  },
+  "&.Mui-focusVisible": {
+    boxShadow: "inset 0 0 0 2px #007AFF",
   },
 }));
 

--- a/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
+++ b/webapp/src/components/NameManagerDialog/NamedRangeInactive.tsx
@@ -32,6 +32,7 @@ function NamedRangeInactive(properties: NamedRangeInactiveProperties) {
             onClick={onEdit}
             disabled={!showOptions}
             title={t("name_manager_dialog.edit")}
+            disableFocusRipple={true}
           >
             <PencilLine size={16} />
           </StyledIconButtonBlack>
@@ -39,6 +40,7 @@ function NamedRangeInactive(properties: NamedRangeInactiveProperties) {
             onClick={onDelete}
             disabled={!showOptions}
             title={t("name_manager_dialog.delete")}
+            disableFocusRipple={true}
           >
             <Trash2 size={16} />
           </StyledIconButtonRed>
@@ -55,6 +57,12 @@ const StyledIconButtonBlack = styled(IconButton)(({ theme }) => ({
   "&:hover": {
     backgroundColor: theme.palette.grey["50"],
   },
+  "&.Mui-disabled": {
+    color: theme.palette.info.light,
+  },
+  "&.Mui-focusVisible": {
+    boxShadow: "inset 0 0 0 2px #007AFF",
+  },
 }));
 
 const StyledIconButtonRed = styled(IconButton)(({ theme }) => ({
@@ -64,8 +72,10 @@ const StyledIconButtonRed = styled(IconButton)(({ theme }) => ({
     backgroundColor: theme.palette.grey["50"],
   },
   "&.Mui-disabled": {
-    opacity: 0.6,
-    color: theme.palette.error.light,
+    color: theme.palette.info.light,
+  },
+  "&.Mui-focusVisible": {
+    boxShadow: "inset 0 0 0 2px #007AFF",
   },
 }));
 


### PR DESCRIPTION
Hey there,

I made a couple of extra small adjustments to the name manager:

- Keyboard focus works now as expected,
- and buttons styling (added the state `focusVisible` and changed `disabled` a bit)

Thanks,
D