### PR TITLE
Update: Mobile improvements

### DIFF
--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
@@ -123,6 +123,10 @@ const Container = styled("div")`
   font-family: Inter;
   background-color: ${theme.palette.common.white};
   border-top: 1px solid ${theme.palette.grey["300"]};
+  @media (max-width: 769px) {
+    padding-right: 0px;
+    padding-left: 8px;
+  }
 `;
 
 const Sheets = styled("div")`
@@ -152,7 +156,7 @@ const Advert = styled("a")`
     text-decoration: underline;
   }
   @media (max-width: 769px) {
-    height: 100%;
+    display: none;
   }
 `;
 
@@ -161,6 +165,9 @@ const LeftButtonsContainer = styled("div")`
   flex-direction: row;
   gap: 4px;
   padding-right: 12px;
+  @media (max-width: 769px) {
+    padding-right: 8px;
+  }
 `;
 
 const VerticalDivider = styled("div")`

--- a/webapp/IronCalc/src/components/formatPicker.tsx
+++ b/webapp/IronCalc/src/components/formatPicker.tsx
@@ -129,7 +129,6 @@ const StyledDialogContent = styled("div")`
 
 const StyledTextField = styled(TextField)`
   width: 100%;
-  min-width: 320px;
   border-radius: 4px;
   overflow: hidden;
   & .MuiInputBase-input {

--- a/webapp/IronCalc/src/components/formulabar.tsx
+++ b/webapp/IronCalc/src/components/formulabar.tsx
@@ -1,6 +1,7 @@
 import type { Model } from "@ironcalc/wasm";
 import { styled } from "@mui/material";
 import { Fx } from "../icons";
+import { theme } from "../theme";
 import {
   COLUMN_WIDTH_SCALE,
   ROW_HEIGH_SCALE,
@@ -127,14 +128,14 @@ const Container = styled("div")`
 
 const AddressContainer = styled("div")`
   padding-left: 16px;
-  color: #333;
+  color: ${theme.palette.common.black};
   font-style: normal;
   font-weight: normal;
-  font-size: 11px;
+  font-size: 12px;
   display: flex;
   font-weight: 600;
   flex-grow: row;
-  min-width: ${headerColumnWidth}px;
+  // min-width: ${headerColumnWidth}px;
 `;
 
 const CellBarAddress = styled("div")`

--- a/webapp/IronCalc/src/components/formulabar.tsx
+++ b/webapp/IronCalc/src/components/formulabar.tsx
@@ -135,7 +135,6 @@ const AddressContainer = styled("div")`
   display: flex;
   font-weight: 600;
   flex-grow: row;
-  // min-width: ${headerColumnWidth}px;
 `;
 
 const CellBarAddress = styled("div")`

--- a/webapp/IronCalc/src/components/formulabar.tsx
+++ b/webapp/IronCalc/src/components/formulabar.tsx
@@ -100,7 +100,7 @@ const FormulaSymbolButton = styled(StyledButton)`
 `;
 
 const Divider = styled("div")`
-  background-color: #e0e0e0;
+  background-color: ${theme.palette.grey["300"]};
   width: 1px;
   height: 20px;
   margin-left: 16px;


### PR DESCRIPTION
Hi,

I've fixed/improved a few things that were a bit annoying in the mobile view:

1. Removed ironcalc.com link: this was using too much horizontal space in the sheet container, hurting usability\
<img width="196" alt="image" src="https://github.com/user-attachments/assets/6312531f-8964-44f1-bf43-db2594937c75" />

2. Input on formatPicker was longer than dialog
<img width="341" alt="image" src="https://github.com/user-attachments/assets/b46de5cb-4799-40b7-9ea8-0492ac671fe1" />

3. On formula bar, I've reduced the excessive distance between selected cell and the divider
<img width="118" alt="image" src="https://github.com/user-attachments/assets/2bbec274-c720-4c2f-bfba-1809b4b19065" />

4. Updated hex colors to use the theme ones

Let me know if I need to change anything.

Best,
D