### PR TITLE
FIX: Wrong Discord invite link

### DIFF
--- a/docs/src/contributing/how-to-contribute.md
+++ b/docs/src/contributing/how-to-contribute.md
@@ -6,4 +6,4 @@ lang: en-US
 
 # How to Contribute
 
-If you want to give us a hand, take a look at our [GitHub repository](https://github.com/ironcalc/IronCalc?tab=readme-ov-file#collaborators-needed-call-to-action), join our [Discord Channel](https://discord.gg/sjaefMWE) or send us an email to [hello@ironcalc.com](mailto:hello@ironcalc.com).
+If you want to give us a hand, take a look at our [GitHub repository](https://github.com/ironcalc/IronCalc?tab=readme-ov-file#collaborators-needed-call-to-action), join our [Discord Channel](https://discord.com/invite/zZYWfh3RHJ) or send us an email to [hello@ironcalc.com](mailto:hello@ironcalc.com).


### PR DESCRIPTION
This PR fixes the Discord invite link we had in the '[How to Contribute](https://docs.ironcalc.com/contributing/how-to-contribute.html)', in the Documentation, which was broken.