### PR TITLE
UPDATE: Add a drawer to store user's workbooks

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/App.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/App.tsx
@@ -136,13 +136,14 @@ function App() {
             const newModel = Model.from_bytes(bytes);
             saveModelToStorage(newModel);
             setModel(newModel);
-            refreshModelsData(); // Refresh after model change
+            refreshModelsData();
           }}
           newModel={handleNewModel}
           setModel={handleSetModel}
           onDelete={handleDeleteModel}
           isDrawerOpen={isDrawerOpen}
           setIsDrawerOpen={setIsDrawerOpen}
+          refreshModelsData={refreshModelsData}
         />
         <IronCalc model={model} />
       </MainContent>

--- a/webapp/app.ironcalc.com/frontend/src/App.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/App.tsx
@@ -125,6 +125,7 @@ function App() {
         setModel={handleSetModel}
         models={modelsMetadata}
         selectedUuid={selectedUuid}
+        setDeleteDialogOpen={() => {}}
       />
 
       <MainContent isDrawerOpen={isDrawerOpen}>

--- a/webapp/app.ironcalc.com/frontend/src/App.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import "./App.css";
 import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
 import { FileBar } from "./components/FileBar";
+import LeftDrawer from "./components/LeftDrawer";
 import {
   get_documentation_model,
   get_model,
@@ -21,6 +22,7 @@ import { IronCalc, IronCalcIcon, Model, init } from "@ironcalc/workbook";
 
 function App() {
   const [model, setModel] = useState<Model | null>(null);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   useEffect(() => {
     async function start() {
@@ -80,47 +82,70 @@ function App() {
   // Passing the property down makes sure it is always defined.
 
   return (
-    <Wrapper>
-      <FileBar
-        model={model}
-        onModelUpload={async (arrayBuffer: ArrayBuffer, fileName: string) => {
-          const blob = await uploadFile(arrayBuffer, fileName);
-
-          const bytes = new Uint8Array(await blob.arrayBuffer());
-          const newModel = Model.from_bytes(bytes);
-          saveModelToStorage(newModel);
-
-          setModel(newModel);
-        }}
-        newModel={() => {
-          setModel(createNewModel());
-        }}
-        setModel={(uuid: string) => {
+    <AppContainer>
+      <LeftDrawer
+        open={isDrawerOpen}
+        onClose={() => setIsDrawerOpen(false)}
+        newModel={createNewModel}
+        setModel={(uuid) => {
           const newModel = selectModelFromStorage(uuid);
           if (newModel) {
             setModel(newModel);
           }
         }}
-        onDelete={() => {
-          const newModel = deleteSelectedModel();
-          if (newModel) {
-            setModel(newModel);
-          }
-        }}
+        models={{}} // Pass actual models here
+        selectedUuid={null} // Pass actual selectedUuid here
       />
-      <IronCalc model={model} />
-    </Wrapper>
+
+      <MainContent isDrawerOpen={isDrawerOpen}>
+        <FileBar
+          model={model}
+          onModelUpload={async (arrayBuffer: ArrayBuffer, fileName: string) => {
+            const blob = await uploadFile(arrayBuffer, fileName);
+            const bytes = new Uint8Array(await blob.arrayBuffer());
+            const newModel = Model.from_bytes(bytes);
+            saveModelToStorage(newModel);
+            setModel(newModel);
+          }}
+          newModel={() => {
+            setModel(createNewModel());
+          }}
+          setModel={(uuid: string) => {
+            const newModel = selectModelFromStorage(uuid);
+            if (newModel) {
+              setModel(newModel);
+            }
+          }}
+          onDelete={() => {
+            const newModel = deleteSelectedModel();
+            if (newModel) {
+              setModel(newModel);
+            }
+          }}
+          isDrawerOpen={isDrawerOpen}
+          setIsDrawerOpen={setIsDrawerOpen}
+        />
+        <IronCalc model={model} />
+      </MainContent>
+    </AppContainer>
   );
 }
 
-const Wrapper = styled("div")`
-  margin: 0px;
-  padding: 0px;
+const AppContainer = styled("div")`
+  display: flex;
   width: 100%;
   height: 100%;
+  position: relative;
+  overflow: hidden;
+`;
+
+const MainContent = styled("div")<{ isDrawerOpen: boolean }>`
+  margin-left: ${({ isDrawerOpen }) => (isDrawerOpen ? "0px" : "-264px")};
+  transition: margin-left 0.3s ease;
+  width: ${({ isDrawerOpen }) =>
+    isDrawerOpen ? "calc(100% - 264px)" : "100%"};
   display: flex;
   flex-direction: column;
-  position: absolute;
 `;
 
 const Loading = styled("div")`

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -56,6 +56,7 @@ export function FileBar(properties: {
       >
         {properties.isDrawerOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
       </DrawerButton>
+      <Spacer ref={spacerRef} />
       <WorkbookTitleWrapper>
         <WorkbookTitle
           name={properties.model.getName()}

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import type { Model } from "@ironcalc/workbook";
-import { IconButton } from "@mui/material";
+import { Button, IconButton } from "@mui/material";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
-import { ParentMenu } from "./FileMenu";
+import { DesktopMenu, MobileMenu } from "./FileMenu";
 import { ShareButton } from "./ShareButton";
 import ShareWorkbookDialog from "./ShareWorkbookDialog";
 import { WorkbookTitle } from "./WorkbookTitle";
@@ -38,6 +38,7 @@ export function FileBar(properties: {
   const spacerRef = useRef<HTMLDivElement>(null);
   const [maxTitleWidth, setMaxTitleWidth] = useState(0);
   const width = useWindowWidth();
+  const fileButtonRef = useRef<HTMLButtonElement>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We need to update the maxTitleWidth when the width changes
   useLayoutEffect(() => {
@@ -48,6 +49,14 @@ export function FileBar(properties: {
     }
   }, [width]);
 
+  // Common handler functions for both menu types
+  const handleDownload = async () => {
+    const model = properties.model;
+    const bytes = model.toBytes();
+    const fileName = model.getName();
+    await downloadModel(bytes, fileName);
+  };
+
   return (
     <FileBarWrapper>
       <DrawerButton
@@ -56,6 +65,30 @@ export function FileBar(properties: {
       >
         {properties.isDrawerOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
       </DrawerButton>
+      <DesktopButtonsWrapper>
+        <DesktopMenu
+          newModel={properties.newModel}
+          setModel={properties.setModel}
+          onModelUpload={properties.onModelUpload}
+          onDownload={handleDownload}
+          onDelete={properties.onDelete}
+        />
+        <FileBarButton
+          disableRipple
+          onClick={() => window.open("https://docs.ironcalc.com", "_blank")}
+        >
+          Help
+        </FileBarButton>
+      </DesktopButtonsWrapper>
+      <MobileButtonsWrapper>
+        <MobileMenu
+          newModel={properties.newModel}
+          setModel={properties.setModel}
+          onModelUpload={properties.onModelUpload}
+          onDownload={handleDownload}
+          onDelete={properties.onDelete}
+        />
+      </MobileButtonsWrapper>
       <Spacer ref={spacerRef} />
       <WorkbookTitleWrapper>
         <WorkbookTitle
@@ -68,20 +101,6 @@ export function FileBar(properties: {
           maxWidth={maxTitleWidth}
         />
       </WorkbookTitleWrapper>
-
-      <ParentMenu
-        newModel={properties.newModel}
-        setModel={properties.setModel}
-        onModelUpload={properties.onModelUpload}
-        onDownload={async () => {
-          const model = properties.model;
-          const bytes = model.toBytes();
-          const fileName = model.getName();
-          await downloadModel(bytes, fileName);
-        }}
-        onDelete={properties.onDelete}
-      />
-
       <Spacer ref={spacerRef} />
       <DialogContainer>
         <ShareButton onClick={() => setIsDialogOpen(true)} />
@@ -118,6 +137,12 @@ const DrawerButton = styled(IconButton)`
     width: 16px;
     height: 16px;
   }
+  &:hover {
+    background-color: #f2f2f2;
+  }
+  &:active {
+    background-color: #e0e0e0;
+  }
 `;
 
 // The container must be relative positioned so we can position the title absolutely
@@ -132,6 +157,51 @@ const FileBarWrapper = styled("div")`
   border-bottom: 1px solid #e0e0e0;
   justify-content: space-between;
   box-sizing: border-box;
+`;
+
+const DesktopButtonsWrapper = styled("div")`
+  display: flex;
+  gap: 4px;
+  margin-left: 8px;
+  @media (max-width: 600px) {
+    display: none;
+  }
+`;
+
+const MobileButtonsWrapper = styled("div")`
+  display: flex;
+  gap: 4px;
+  @media (min-width: 601px) {
+    display: none;
+  }
+  @media (max-width: 600px) {
+    display: flex;
+  }
+`;
+
+const FileBarButtonContainer = styled("div")`
+  position: relative;
+  display: inline-block;
+`;
+
+const FileBarButton = styled(Button)`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-size: 12px;
+  height: 32px;
+  width: auto;
+  padding: 4px 8px;
+  font-weight: 400;
+  min-width: 0px;
+  text-transform: capitalize;
+  color: #333333;
+  &:hover {
+    background-color: #f2f2f2;
+  }
+  &:active {
+    background-color: #e0e0e0;
+  }
 `;
 
 const DialogContainer = styled("div")`

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -32,6 +32,7 @@ export function FileBar(properties: {
   onDelete: () => void;
   isDrawerOpen: boolean;
   setIsDrawerOpen: (open: boolean) => void;
+  refreshModelsData: () => void; // Add this new prop
 }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const spacerRef = useRef<HTMLDivElement>(null);
@@ -60,6 +61,7 @@ export function FileBar(properties: {
           onNameChange={(name) => {
             properties.model.setName(name);
             updateNameSelectedWorkbook(properties.model, name);
+            properties.refreshModelsData();
           }}
           maxWidth={maxTitleWidth}
         />
@@ -108,10 +110,15 @@ const Spacer = styled("div")`
 
 const DrawerButton = styled(IconButton)`
   margin-left: 8px;
-  height: 24px;
-  width: 24px;
-  padding: 4px;
+  height: 32px;
+  width: 32px;
+  padding: 8px;
   border-radius: 4px;
+  svg {
+    stroke: #757575;
+    width: 16px;
+    height: 16px;
+  }
 `;
 
 const HelpButton = styled("div")`

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -3,7 +3,7 @@ import type { Model } from "@ironcalc/workbook";
 import { IconButton } from "@mui/material";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
-import { FileMenu } from "./FileMenu";
+import { ParentMenu } from "./FileMenu";
 import { ShareButton } from "./ShareButton";
 import ShareWorkbookDialog from "./ShareWorkbookDialog";
 import { WorkbookTitle } from "./WorkbookTitle";
@@ -35,9 +35,11 @@ export function FileBar(properties: {
   refreshModelsData: () => void; // Add this new prop
 }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false); // Add state for menu visibility
   const spacerRef = useRef<HTMLDivElement>(null);
   const [maxTitleWidth, setMaxTitleWidth] = useState(0);
   const width = useWindowWidth();
+  const menuAnchorRef = useRef<HTMLButtonElement>(null); // Add ref for menu anchor
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We need to update the maxTitleWidth when the width changes
   useLayoutEffect(() => {
@@ -66,8 +68,8 @@ export function FileBar(properties: {
           maxWidth={maxTitleWidth}
         />
       </WorkbookTitleWrapper>
-      <Divider />
-      <FileMenu
+
+      <ParentMenu
         newModel={properties.newModel}
         setModel={properties.setModel}
         onModelUpload={properties.onModelUpload}
@@ -79,11 +81,7 @@ export function FileBar(properties: {
         }}
         onDelete={properties.onDelete}
       />
-      <HelpButton
-        onClick={() => window.open("https://docs.ironcalc.com", "_blank")}
-      >
-        Help
-      </HelpButton>
+
       <Spacer ref={spacerRef} />
       <DialogContainer>
         <ShareButton onClick={() => setIsDialogOpen(true)} />
@@ -115,29 +113,11 @@ const DrawerButton = styled(IconButton)`
   padding: 8px;
   border-radius: 4px;
   svg {
+    stroke-width: 2px;
     stroke: #757575;
     width: 16px;
     height: 16px;
   }
-`;
-
-const HelpButton = styled("div")`
-  display: flex;
-  align-items: center;
-  font-size: 12px;
-  font-family: Inter;
-  padding: 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  &:hover {
-    background-color: #f2f2f2;
-  }
-`;
-
-const Divider = styled("div")`
-  margin: 0px 8px 0px 16px;
-  height: 12px;
-  border-left: 1px solid #e0e0e0;
 `;
 
 // The container must be relative positioned so we can position the title absolutely
@@ -151,6 +131,7 @@ const FileBarWrapper = styled("div")`
   align-items: center;
   border-bottom: 1px solid #e0e0e0;
   justify-content: space-between;
+  box-sizing: border-box;
 `;
 
 const DialogContainer = styled("div")`

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import type { Model } from "@ironcalc/workbook";
-import { IronCalcIcon, IronCalcLogo } from "@ironcalc/workbook";
 import { IconButton } from "@mui/material";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
@@ -98,8 +97,6 @@ export function FileBar(properties: {
   );
 }
 
-// We want the workbook title to be exactly an the center of the page,
-// so we need an absolute position
 const WorkbookTitleWrapper = styled("div")`
   position: relative;
 `;
@@ -107,22 +104,6 @@ const WorkbookTitleWrapper = styled("div")`
 // The "Spacer" component occupies as much space as possible between the menu and the share button
 const Spacer = styled("div")`
   flex-grow: 1;
-`;
-
-const StyledDesktopLogo = styled(IronCalcLogo)`
-  width: 120px;
-  margin-left: 12px;
-  @media (max-width: 769px) {
-    display: none;
-  }
-`;
-
-const StyledIronCalcIcon = styled(IronCalcIcon)`
-  width: 36px;
-  margin-left: 10px;
-  @media (min-width: 769px) {
-    display: none;
-  }
 `;
 
 const DrawerButton = styled(IconButton)`

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -55,8 +55,16 @@ export function FileBar(properties: {
       >
         {properties.isDrawerOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
       </DrawerButton>
-      <StyledDesktopLogo />
-      <StyledIronCalcIcon />
+      <WorkbookTitleWrapper>
+        <WorkbookTitle
+          name={properties.model.getName()}
+          onNameChange={(name) => {
+            properties.model.setName(name);
+            updateNameSelectedWorkbook(properties.model, name);
+          }}
+          maxWidth={maxTitleWidth}
+        />
+      </WorkbookTitleWrapper>
       <Divider />
       <FileMenu
         newModel={properties.newModel}
@@ -75,16 +83,6 @@ export function FileBar(properties: {
       >
         Help
       </HelpButton>
-      <WorkbookTitleWrapper>
-        <WorkbookTitle
-          name={properties.model.getName()}
-          onNameChange={(name) => {
-            properties.model.setName(name);
-            updateNameSelectedWorkbook(properties.model, name);
-          }}
-          maxWidth={maxTitleWidth}
-        />
-      </WorkbookTitleWrapper>
       <Spacer ref={spacerRef} />
       <DialogContainer>
         <ShareButton onClick={() => setIsDialogOpen(true)} />
@@ -103,9 +101,7 @@ export function FileBar(properties: {
 // We want the workbook title to be exactly an the center of the page,
 // so we need an absolute position
 const WorkbookTitleWrapper = styled("div")`
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  position: relative;
 `;
 
 // The "Spacer" component occupies as much space as possible between the menu and the share button
@@ -160,6 +156,7 @@ const Divider = styled("div")`
 const FileBarWrapper = styled("div")`
   position: relative;
   height: 60px;
+  min-height: 60px;
   width: 100%;
   background: #fff;
   display: flex;

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -35,11 +35,9 @@ export function FileBar(properties: {
   refreshModelsData: () => void; // Add this new prop
 }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [isMenuOpen, setIsMenuOpen] = useState(false); // Add state for menu visibility
   const spacerRef = useRef<HTMLDivElement>(null);
   const [maxTitleWidth, setMaxTitleWidth] = useState(0);
   const width = useWindowWidth();
-  const menuAnchorRef = useRef<HTMLButtonElement>(null); // Add ref for menu anchor
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We need to update the maxTitleWidth when the width changes
   useLayoutEffect(() => {
@@ -54,6 +52,7 @@ export function FileBar(properties: {
     <FileBarWrapper>
       <DrawerButton
         onClick={() => properties.setIsDrawerOpen(!properties.isDrawerOpen)}
+        disableRipple
       >
         {properties.isDrawerOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
       </DrawerButton>

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
 import type { Model } from "@ironcalc/workbook";
 import { IronCalcIcon, IronCalcLogo } from "@ironcalc/workbook";
+import { IconButton } from "@mui/material";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
 import { FileMenu } from "./FileMenu";
 import { ShareButton } from "./ShareButton";
@@ -29,6 +31,8 @@ export function FileBar(properties: {
   setModel: (key: string) => void;
   onModelUpload: (blob: ArrayBuffer, fileName: string) => Promise<void>;
   onDelete: () => void;
+  isDrawerOpen: boolean;
+  setIsDrawerOpen: (open: boolean) => void;
 }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const spacerRef = useRef<HTMLDivElement>(null);
@@ -46,6 +50,11 @@ export function FileBar(properties: {
 
   return (
     <FileBarWrapper>
+      <DrawerButton
+        onClick={() => properties.setIsDrawerOpen(!properties.isDrawerOpen)}
+      >
+        {properties.isDrawerOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
+      </DrawerButton>
       <StyledDesktopLogo />
       <StyledIronCalcIcon />
       <Divider />
@@ -118,6 +127,14 @@ const StyledIronCalcIcon = styled(IronCalcIcon)`
   @media (min-width: 769px) {
     display: none;
   }
+`;
+
+const DrawerButton = styled(IconButton)`
+  margin-left: 8px;
+  height: 24px;
+  width: 24px;
+  padding: 4px;
+  border-radius: 4px;
 `;
 
 const HelpButton = styled("div")`

--- a/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
@@ -23,10 +23,10 @@ export function ParentMenu(props: {
   const [isParentMenuOpen, setParentMenuOpen] = useState(false);
   const [isFileMenuOpen, setFileMenuOpen] = useState(false);
   const anchorElement = useRef<HTMLButtonElement>(
-    null as unknown as HTMLButtonElement,
+    null as unknown as HTMLButtonElement
   );
   const [fileMenuAnchorEl, setFileMenuAnchorEl] = useState<HTMLElement | null>(
-    null,
+    null
   );
 
   return (
@@ -34,6 +34,7 @@ export function ParentMenu(props: {
       <MenuButton
         onClick={(): void => setParentMenuOpen(true)}
         ref={anchorElement}
+        disableRipple
       >
         <Ellipsis />
       </MenuButton>
@@ -52,12 +53,16 @@ export function ParentMenu(props: {
             setFileMenuAnchorEl(event.currentTarget);
           }}
           onClick={(event) => {
-            // Keep current click behavior as fallback
             setFileMenuOpen(true);
             setFileMenuAnchorEl(event.currentTarget);
           }}
+          disableRipple
         >
           <MenuItemText>File</MenuItemText>
+          <ChevronRight />
+        </MenuItemWrapper>
+        <MenuItemWrapper>
+          <MenuItemText>Edit</MenuItemText>
           <ChevronRight />
         </MenuItemWrapper>
         <MenuDivider />
@@ -66,6 +71,7 @@ export function ParentMenu(props: {
             window.open("https://docs.ironcalc.com", "_blank");
             setParentMenuOpen(false);
           }}
+          disableRipple
         >
           <MenuItemText>Help</MenuItemText>
         </MenuItemWrapper>
@@ -124,7 +130,12 @@ export function FileMenu(props: {
           }
         }}
         sx={{
-          "& .MuiPaper-root": { borderRadius: "8px", padding: "4px 0px" },
+          "& .MuiPaper-root": {
+            borderRadius: "8px",
+            padding: "4px 0px",
+            marginTop: "-4px",
+            marginLeft: "4px",
+          },
           "& .MuiList-root": { padding: "0" },
         }}
       >
@@ -134,6 +145,7 @@ export function FileMenu(props: {
             props.setFileMenuOpen(false);
             props.setParentMenuOpen(false);
           }}
+          disableRipple
         >
           <StyledPlus />
           <MenuItemText>New</MenuItemText>
@@ -144,6 +156,7 @@ export function FileMenu(props: {
             props.setFileMenuOpen(false);
             props.setParentMenuOpen(false);
           }}
+          disableRipple
         >
           <StyledFileUp />
           <MenuItemText>Import</MenuItemText>
@@ -153,6 +166,7 @@ export function FileMenu(props: {
             props.onDownload();
             props.setParentMenuOpen(false);
           }}
+          disableRipple
         >
           <StyledFileDown />
           <MenuItemText>Download (.xlsx)</MenuItemText>
@@ -164,6 +178,7 @@ export function FileMenu(props: {
             props.setFileMenuOpen(false);
             props.setParentMenuOpen(false);
           }}
+          disableRipple
         >
           <StyledTrash />
           <MenuItemText>Delete workbook</MenuItemText>

--- a/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
-import { IconButton, Menu, MenuItem, Modal } from "@mui/material";
+import { Button, IconButton, Menu, MenuItem, Modal } from "@mui/material";
 import {
   ChevronRight,
-  Ellipsis,
+  EllipsisVertical,
   FileDown,
   FileUp,
   Plus,
@@ -13,45 +13,74 @@ import DeleteWorkbookDialog from "./DeleteWorkbookDialog";
 import UploadFileDialog from "./UploadFileDialog";
 import { getModelsMetadata, getSelectedUuid } from "./storage";
 
-export function ParentMenu(props: {
+export function DesktopMenu(props: {
   newModel: () => void;
   setModel: (key: string) => void;
   onDownload: () => void;
   onModelUpload: (blob: ArrayBuffer, fileName: string) => Promise<void>;
   onDelete: () => void;
 }) {
-  const [isParentMenuOpen, setParentMenuOpen] = useState(false);
   const [isFileMenuOpen, setFileMenuOpen] = useState(false);
   const anchorElement = useRef<HTMLButtonElement>(
-    null as unknown as HTMLButtonElement
+    null as unknown as HTMLButtonElement,
+  );
+
+  return (
+    <>
+      <FileBarButton
+        onClick={(): void => setFileMenuOpen(!isFileMenuOpen)}
+        ref={anchorElement}
+        disableRipple
+        isOpen={isFileMenuOpen}
+      >
+        File
+      </FileBarButton>
+      <FileMenu
+        newModel={props.newModel}
+        setModel={props.setModel}
+        onDownload={props.onDownload}
+        onModelUpload={props.onModelUpload}
+        onDelete={props.onDelete}
+        isFileMenuOpen={isFileMenuOpen}
+        setFileMenuOpen={setFileMenuOpen}
+        setMobileMenuOpen={() => {}}
+        anchorElement={anchorElement}
+      />
+    </>
+  );
+}
+
+export function MobileMenu(props: {
+  newModel: () => void;
+  setModel: (key: string) => void;
+  onDownload: () => void;
+  onModelUpload: (blob: ArrayBuffer, fileName: string) => Promise<void>;
+  onDelete: () => void;
+}) {
+  const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [isFileMenuOpen, setFileMenuOpen] = useState(false);
+  const anchorElement = useRef<HTMLButtonElement>(
+    null as unknown as HTMLButtonElement,
   );
   const [fileMenuAnchorEl, setFileMenuAnchorEl] = useState<HTMLElement | null>(
-    null
+    null,
   );
 
   return (
     <>
       <MenuButton
-        onClick={(): void => setParentMenuOpen(true)}
+        onClick={(): void => setMobileMenuOpen(true)}
         ref={anchorElement}
         disableRipple
       >
-        <Ellipsis />
+        <EllipsisVertical />
       </MenuButton>
-      <Menu
-        open={isParentMenuOpen}
-        onClose={(): void => setParentMenuOpen(false)}
+      <StyledMenu
+        open={isMobileMenuOpen}
+        onClose={(): void => setMobileMenuOpen(false)}
         anchorEl={anchorElement.current}
-        sx={{
-          "& .MuiPaper-root": { borderRadius: "8px", padding: "4px 0px" },
-          "& .MuiList-root": { padding: "0" },
-        }}
       >
         <MenuItemWrapper
-          onMouseEnter={(event) => {
-            setFileMenuOpen(true);
-            setFileMenuAnchorEl(event.currentTarget);
-          }}
           onClick={(event) => {
             setFileMenuOpen(true);
             setFileMenuAnchorEl(event.currentTarget);
@@ -61,21 +90,17 @@ export function ParentMenu(props: {
           <MenuItemText>File</MenuItemText>
           <ChevronRight />
         </MenuItemWrapper>
-        <MenuItemWrapper>
-          <MenuItemText>Edit</MenuItemText>
-          <ChevronRight />
-        </MenuItemWrapper>
         <MenuDivider />
         <MenuItemWrapper
           onClick={() => {
             window.open("https://docs.ironcalc.com", "_blank");
-            setParentMenuOpen(false);
+            setMobileMenuOpen(false);
           }}
           disableRipple
         >
           <MenuItemText>Help</MenuItemText>
         </MenuItemWrapper>
-      </Menu>
+      </StyledMenu>
       <FileMenu
         newModel={props.newModel}
         setModel={props.setModel}
@@ -84,9 +109,8 @@ export function ParentMenu(props: {
         onDelete={props.onDelete}
         isFileMenuOpen={isFileMenuOpen}
         setFileMenuOpen={setFileMenuOpen}
-        setParentMenuOpen={setParentMenuOpen} // Pass setParentMenuOpen as a prop
+        setMobileMenuOpen={setMobileMenuOpen}
         anchorElement={anchorElement}
-        fileMenuAnchorEl={fileMenuAnchorEl}
       />
     </>
   );
@@ -100,9 +124,8 @@ export function FileMenu(props: {
   onDelete: () => void;
   isFileMenuOpen: boolean;
   setFileMenuOpen: (open: boolean) => void;
-  setParentMenuOpen: (open: boolean) => void; // Add setParentMenuOpen to props
+  setMobileMenuOpen: (open: boolean) => void;
   anchorElement: React.RefObject<HTMLButtonElement>;
-  fileMenuAnchorEl: HTMLElement | null;
 }) {
   const [isImportMenuOpen, setImportMenuOpen] = useState(false);
   const models = getModelsMetadata();
@@ -111,13 +134,13 @@ export function FileMenu(props: {
 
   return (
     <>
-      <Menu
+      <StyledMenu
         open={props.isFileMenuOpen}
         onClose={(): void => props.setFileMenuOpen(false)}
-        anchorEl={props.fileMenuAnchorEl || props.anchorElement.current}
+        anchorEl={props.anchorElement.current}
         anchorOrigin={{
-          vertical: "top",
-          horizontal: "right",
+          vertical: "bottom",
+          horizontal: "left",
         }}
         transformOrigin={{
           vertical: "top",
@@ -129,21 +152,12 @@ export function FileMenu(props: {
             props.setFileMenuOpen(false);
           }
         }}
-        sx={{
-          "& .MuiPaper-root": {
-            borderRadius: "8px",
-            padding: "4px 0px",
-            marginTop: "-4px",
-            marginLeft: "4px",
-          },
-          "& .MuiList-root": { padding: "0" },
-        }}
       >
         <MenuItemWrapper
           onClick={() => {
             props.newModel();
             props.setFileMenuOpen(false);
-            props.setParentMenuOpen(false);
+            props.setMobileMenuOpen(false);
           }}
           disableRipple
         >
@@ -154,7 +168,7 @@ export function FileMenu(props: {
           onClick={() => {
             setImportMenuOpen(true);
             props.setFileMenuOpen(false);
-            props.setParentMenuOpen(false);
+            props.setMobileMenuOpen(false);
           }}
           disableRipple
         >
@@ -164,7 +178,7 @@ export function FileMenu(props: {
         <MenuItemWrapper
           onClick={() => {
             props.onDownload();
-            props.setParentMenuOpen(false);
+            props.setMobileMenuOpen(false);
           }}
           disableRipple
         >
@@ -176,14 +190,14 @@ export function FileMenu(props: {
           onClick={() => {
             setDeleteDialogOpen(true);
             props.setFileMenuOpen(false);
-            props.setParentMenuOpen(false);
+            props.setMobileMenuOpen(false);
           }}
           disableRipple
         >
           <StyledTrash />
           <MenuItemText>Delete workbook</MenuItemText>
         </MenuItemWrapper>
-      </Menu>
+      </StyledMenu>
       <Modal
         open={isImportMenuOpen}
         onClose={() => {
@@ -216,7 +230,6 @@ export function FileMenu(props: {
 }
 
 const MenuButton = styled(IconButton)`
-  margin-left: 8px;
   height: 32px;
   width: 32px;
   padding: 8px;
@@ -226,6 +239,33 @@ const MenuButton = styled(IconButton)`
     stroke: #757575;
     width: 16px;
     height: 16px;
+  }
+  &:hover {
+    background-color: #f2f2f2;
+  }
+  &:active {
+    background-color: #e0e0e0;
+  }
+`;
+
+const FileBarButton = styled(Button)<{ isOpen: boolean }>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font-size: 12px;
+  height: 32px;
+  width: auto;
+  padding: 4px 8px;
+  font-weight: 400;
+  min-width: 0px;
+  text-transform: capitalize;
+  color: #333333;
+  background-color: ${({ isOpen }) => (isOpen ? "#f2f2f2" : "none")};
+  &:hover {
+    background-color: #f2f2f2;
+  }
+  &:active {
+    background-color: #e0e0e0;
   }
 `;
 
@@ -281,8 +321,19 @@ const MenuItemWrapper = styled(MenuItem)`
   border-radius: 4px;
   padding: 8px;
   height: 32px;
+  min-height: 32px;
   svg {
     width: 16px;
     height: 16px;
   }
+`;
+
+const StyledMenu = styled(Menu)`
+  .MuiPaper-root {
+    border-radius: 8px;
+    padding: 4px 0px;
+  },
+  .MuiList-root {
+    padding: 0;
+  },
 `;

--- a/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
@@ -1,10 +1,90 @@
 import styled from "@emotion/styled";
-import { Menu, MenuItem, Modal } from "@mui/material";
-import { Check, FileDown, FileUp, Plus, Trash2 } from "lucide-react";
+import { IconButton, Menu, MenuItem, Modal } from "@mui/material";
+import {
+  ChevronRight,
+  Ellipsis,
+  FileDown,
+  FileUp,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { useRef, useState } from "react";
 import DeleteWorkbookDialog from "./DeleteWorkbookDialog";
 import UploadFileDialog from "./UploadFileDialog";
 import { getModelsMetadata, getSelectedUuid } from "./storage";
+
+export function ParentMenu(props: {
+  newModel: () => void;
+  setModel: (key: string) => void;
+  onDownload: () => void;
+  onModelUpload: (blob: ArrayBuffer, fileName: string) => Promise<void>;
+  onDelete: () => void;
+}) {
+  const [isParentMenuOpen, setParentMenuOpen] = useState(false);
+  const [isFileMenuOpen, setFileMenuOpen] = useState(false);
+  const anchorElement = useRef<HTMLButtonElement>(
+    null as unknown as HTMLButtonElement,
+  );
+  const [fileMenuAnchorEl, setFileMenuAnchorEl] = useState<HTMLElement | null>(
+    null,
+  );
+
+  return (
+    <>
+      <MenuButton
+        onClick={(): void => setParentMenuOpen(true)}
+        ref={anchorElement}
+      >
+        <Ellipsis />
+      </MenuButton>
+      <Menu
+        open={isParentMenuOpen}
+        onClose={(): void => setParentMenuOpen(false)}
+        anchorEl={anchorElement.current}
+        sx={{
+          "& .MuiPaper-root": { borderRadius: "8px", padding: "4px 0px" },
+          "& .MuiList-root": { padding: "0" },
+        }}
+      >
+        <MenuItemWrapper
+          onMouseEnter={(event) => {
+            setFileMenuOpen(true);
+            setFileMenuAnchorEl(event.currentTarget);
+          }}
+          onClick={(event) => {
+            // Keep current click behavior as fallback
+            setFileMenuOpen(true);
+            setFileMenuAnchorEl(event.currentTarget);
+          }}
+        >
+          <MenuItemText>File</MenuItemText>
+          <ChevronRight />
+        </MenuItemWrapper>
+        <MenuDivider />
+        <MenuItemWrapper
+          onClick={() => {
+            window.open("https://docs.ironcalc.com", "_blank");
+            setParentMenuOpen(false);
+          }}
+        >
+          <MenuItemText>Help</MenuItemText>
+        </MenuItemWrapper>
+      </Menu>
+      <FileMenu
+        newModel={props.newModel}
+        setModel={props.setModel}
+        onDownload={props.onDownload}
+        onModelUpload={props.onModelUpload}
+        onDelete={props.onDelete}
+        isFileMenuOpen={isFileMenuOpen}
+        setFileMenuOpen={setFileMenuOpen}
+        setParentMenuOpen={setParentMenuOpen} // Pass setParentMenuOpen as a prop
+        anchorElement={anchorElement}
+        fileMenuAnchorEl={fileMenuAnchorEl}
+      />
+    </>
+  );
+}
 
 export function FileMenu(props: {
   newModel: () => void;
@@ -12,64 +92,47 @@ export function FileMenu(props: {
   onDownload: () => void;
   onModelUpload: (blob: ArrayBuffer, fileName: string) => Promise<void>;
   onDelete: () => void;
+  isFileMenuOpen: boolean;
+  setFileMenuOpen: (open: boolean) => void;
+  setParentMenuOpen: (open: boolean) => void; // Add setParentMenuOpen to props
+  anchorElement: React.RefObject<HTMLButtonElement>;
+  fileMenuAnchorEl: HTMLElement | null;
 }) {
-  const [isMenuOpen, setMenuOpen] = useState(false);
   const [isImportMenuOpen, setImportMenuOpen] = useState(false);
-  const anchorElement = useRef<HTMLDivElement>(null);
   const models = getModelsMetadata();
-  const uuids = Object.keys(models);
   const selectedUuid = getSelectedUuid();
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-  const elements = [];
-  for (const uuid of uuids) {
-    elements.push(
-      <MenuItemWrapper
-        key={uuid}
-        onClick={() => {
-          props.setModel(uuid);
-          setMenuOpen(false);
-        }}
-      >
-        <CheckIndicator>
-          {uuid === selectedUuid ? <StyledCheck /> : ""}
-        </CheckIndicator>
-        <MenuItemText
-          style={{
-            maxWidth: "240px",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-          }}
-        >
-          {models[uuid]}
-        </MenuItemText>
-      </MenuItemWrapper>,
-    );
-  }
-
   return (
     <>
-      <FileMenuWrapper
-        onClick={(): void => setMenuOpen(true)}
-        ref={anchorElement}
-      >
-        File
-      </FileMenuWrapper>
       <Menu
-        open={isMenuOpen}
-        onClose={(): void => setMenuOpen(false)}
-        anchorEl={anchorElement.current}
+        open={props.isFileMenuOpen}
+        onClose={(): void => props.setFileMenuOpen(false)}
+        anchorEl={props.fileMenuAnchorEl || props.anchorElement.current}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+        // To prevent closing parent menu when interacting with submenu
+        onMouseLeave={() => {
+          if (!isImportMenuOpen && !isDeleteDialogOpen) {
+            props.setFileMenuOpen(false);
+          }
+        }}
         sx={{
           "& .MuiPaper-root": { borderRadius: "8px", padding: "4px 0px" },
           "& .MuiList-root": { padding: "0" },
         }}
-
-        // anchorOrigin={properties.anchorOrigin}
       >
         <MenuItemWrapper
           onClick={() => {
             props.newModel();
-            setMenuOpen(false);
+            props.setFileMenuOpen(false);
+            props.setParentMenuOpen(false);
           }}
         >
           <StyledPlus />
@@ -78,23 +141,28 @@ export function FileMenu(props: {
         <MenuItemWrapper
           onClick={() => {
             setImportMenuOpen(true);
-            setMenuOpen(false);
+            props.setFileMenuOpen(false);
+            props.setParentMenuOpen(false);
           }}
         >
           <StyledFileUp />
           <MenuItemText>Import</MenuItemText>
         </MenuItemWrapper>
-        <MenuItemWrapper>
+        <MenuItemWrapper
+          onClick={() => {
+            props.onDownload();
+            props.setParentMenuOpen(false);
+          }}
+        >
           <StyledFileDown />
-          <MenuItemText onClick={props.onDownload}>
-            Download (.xlsx)
-          </MenuItemText>
+          <MenuItemText>Download (.xlsx)</MenuItemText>
         </MenuItemWrapper>
         <MenuDivider />
         <MenuItemWrapper
           onClick={() => {
             setDeleteDialogOpen(true);
-            setMenuOpen(false);
+            props.setFileMenuOpen(false);
+            props.setParentMenuOpen(false);
           }}
         >
           <StyledTrash />
@@ -132,6 +200,20 @@ export function FileMenu(props: {
   );
 }
 
+const MenuButton = styled(IconButton)`
+  margin-left: 8px;
+  height: 32px;
+  width: 32px;
+  padding: 8px;
+  border-radius: 4px;
+  svg {
+    stroke-width: 2px;
+    stroke: #757575;
+    width: 16px;
+    height: 16px;
+  }
+`;
+
 const StyledPlus = styled(Plus)`
   width: 16px;
   height: 16px;
@@ -160,13 +242,6 @@ const StyledTrash = styled(Trash2)`
   padding-right: 10px;
 `;
 
-const StyledCheck = styled(Check)`
-  width: 16px;
-  height: 16px;
-  color: #333333;
-  padding-right: 10px;
-`;
-
 const MenuDivider = styled("div")`
   width: 100%;
   margin: auto;
@@ -178,6 +253,7 @@ const MenuDivider = styled("div")`
 const MenuItemText = styled("div")`
   color: #000;
   font-size: 12px;
+  flex-grow: 1;
 `;
 
 const MenuItemWrapper = styled(MenuItem)`
@@ -190,23 +266,8 @@ const MenuItemWrapper = styled(MenuItem)`
   border-radius: 4px;
   padding: 8px;
   height: 32px;
-`;
-
-const FileMenuWrapper = styled("div")`
-  display: flex;
-  align-items: center;
-  font-size: 12px;
-  font-family: Inter;
-  padding: 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  &:hover {
-    background-color: #f2f2f2;
+  svg {
+    width: 16px;
+    height: 16px;
   }
-`;
-
-const CheckIndicator = styled("span")`
-  display: flex;
-  justify-content: center;
-  min-width: 26px;
 `;

--- a/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
@@ -90,6 +90,7 @@ export function FileMenu(props: {
             Download (.xlsx)
           </MenuItemText>
         </MenuItemWrapper>
+        <MenuDivider />
         <MenuItemWrapper
           onClick={() => {
             setDeleteDialogOpen(true);
@@ -99,8 +100,6 @@ export function FileMenu(props: {
           <StyledTrash />
           <MenuItemText>Delete workbook</MenuItemText>
         </MenuItemWrapper>
-        <MenuDivider />
-        {elements}
       </Menu>
       <Modal
         open={isImportMenuOpen}

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { IronCalcLogo } from "@ironcalc/workbook";
 import { Avatar, Drawer, IconButton, MenuItem } from "@mui/material";
-import { Check, EllipsisVertical, Plus } from "lucide-react";
+import { EllipsisVertical, HardDrive, Plus } from "lucide-react";
 import type React from "react";
 
 interface LeftDrawerProps {
@@ -29,9 +29,9 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
       }}
       selected={uuid === selectedUuid}
     >
-      <CheckIndicator>
-        {uuid === selectedUuid ? <StyledCheck /> : ""}
-      </CheckIndicator>
+      <StorageIndicator>
+        <HardDrive />
+      </StorageIndicator>
       <MenuItemText
         style={{
           maxWidth: "240px",
@@ -79,18 +79,6 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
     </DrawerWrapper>
   );
 };
-
-const StyledCheck = styled(Check)`
-  width: 16px;
-  height: 16px;
-  color: #333333;
-`;
-
-const CheckIndicator = styled("span")`
-  display: flex;
-  justify-content: center;
-  min-width: 26px;
-`;
 
 const DrawerWrapper = styled(Drawer)`
   width: 264px;
@@ -152,9 +140,19 @@ const DrawerContent = styled("div")`
   overflow: scroll;
 `;
 
+const StorageIndicator = styled("div")`
+  height: 16px;
+  width: 16px;
+  svg {
+    height: 16px;
+    width: 16px;
+    stroke: #757575;
+  }
+`;
+
 const MenuItemWrapper = styled(MenuItem)<{ selected: boolean }>`
   display: flex;
-  gap: 0px;
+  gap: 8px;
   justify-content: flex-start;
   font-size: 14px;
   width: 100%;
@@ -166,7 +164,7 @@ const MenuItemWrapper = styled(MenuItem)<{ selected: boolean }>`
   background-color: ${({ selected }) =>
     selected ? "#e0e0e0 !important" : "transparent"};
   &:hover {
-    gap: 4px;
+    gap: 12px;
     transition: gap 0.1s;
   }
 `;
@@ -220,7 +218,7 @@ const StyledAvatar = styled(Avatar)`
 `;
 
 const Username = styled("div")`
-  font-size: 14px;
+  font-size: 12px;
   flex-grow: 1;
 `;
 

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
@@ -102,12 +102,14 @@ const DrawerHeader = styled("div")`
   padding: 12px 8px 12px 16px;
   justify-content: space-between;
   max-height: 60px;
+  min-height: 60px;
   border-bottom: 1px solid #e0e0e0;
+  box-sizing: border-box;
 `;
 
 const StyledDesktopLogo = styled(IronCalcLogo)`
   width: 120px;
-  height: 36px;
+  height: 28px;
 `;
 
 const AddButton = styled(IconButton)`
@@ -138,13 +140,13 @@ const DrawerContent = styled("div")`
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 20px 16px;
+  padding: 16px 12px;
   height: 100%;
   overflow: scroll;
+  font-size: 12px;
 `;
 
 const DrawerContentTitle = styled("div")`
-  font-size: 12px;
   font-weight: 600;
   color: #9e9e9e;
   margin-bottom: 8px;
@@ -182,7 +184,7 @@ const MenuItemWrapper = styled(MenuItem)<{ selected: boolean }>`
 
 const MenuItemText = styled("div")`
   color: #000;
-  font-size: 13px;
+  font-size: 12px;
   width: 100%;
 `;
 

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
@@ -1,0 +1,179 @@
+import styled from "@emotion/styled";
+import { IronCalcLogo } from "@ironcalc/workbook";
+import { Drawer, IconButton, MenuItem } from "@mui/material";
+import { EllipsisVertical, Plus } from "lucide-react";
+import type React from "react";
+
+interface LeftDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  newModel: () => void;
+  setModel: (key: string) => void;
+  models: { [key: string]: string };
+  selectedUuid: string | null;
+}
+
+const LeftDrawer: React.FC<LeftDrawerProps> = ({
+  open,
+  onClose,
+  newModel,
+  setModel,
+  models,
+  selectedUuid,
+}) => {
+  const elements = Object.keys(models).map((uuid) => (
+    <MenuItemWrapper
+      key={uuid}
+      onClick={() => {
+        setModel(uuid);
+      }}
+      selected={uuid === selectedUuid}
+    >
+      <MenuItemText
+        style={{
+          maxWidth: "240px",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {models[uuid]}
+      </MenuItemText>
+      <EllipsisButton
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        size="small"
+      >
+        <EllipsisVertical />
+      </EllipsisButton>
+    </MenuItemWrapper>
+  ));
+
+  return (
+    <DrawerWrapper
+      variant="persistent"
+      anchor="left"
+      open={open}
+      onClose={onClose}
+      sx={{ width: 264, height: "100%" }}
+    >
+      <DrawerHeader>
+        <StyledDesktopLogo />
+        <AddButton
+          onClick={() => {
+            newModel();
+          }}
+        >
+          <PlusIcon />
+        </AddButton>
+      </DrawerHeader>
+      <DrawerContent>{elements}</DrawerContent>
+    </DrawerWrapper>
+  );
+};
+
+const DrawerWrapper = styled(Drawer)`
+  width: 264px;
+  flex-shrink: 0;
+
+  .MuiDrawer-paper {
+    width: 264px;
+    background-color: #f5f5f5;
+    overflow: hidden;
+    border-right: 1px solid #e0e0e0;
+  }
+`;
+
+const DrawerHeader = styled("div")`
+  display: flex;
+  align-items: center;
+  padding: 12px 8px 12px 16px;
+  justify-content: space-between;
+  max-height: 60px;
+  border-bottom: 1px solid #e0e0e0;
+`;
+
+const StyledDesktopLogo = styled(IronCalcLogo)`
+  width: 120px;
+  height: 36px;
+`;
+
+const AddButton = styled(IconButton)`
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  height: 36px;
+  width: 36px;
+  border-radius: 8px;
+  margin-left: 10px;
+  color: #333333;
+  stroke-width: 2px;
+  &:hover {
+    background-color: #e0e0e0;
+  }
+`;
+
+const PlusIcon = styled(Plus)`
+  width: 16px;
+  height: 16px;
+`;
+
+const DrawerContent = styled("div")`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  height: 100%;
+  overflow: scroll;
+`;
+
+const MenuItemWrapper = styled(MenuItem)<{ selected: boolean }>`
+  display: flex;
+  gap: 0px;
+  justify-content: flex-start;
+  font-size: 14px;
+  width: 100%;
+  min-width: 172px;
+  border-radius: 8px;
+  padding: 8px 4px 8px 8px;
+  height: 32px;
+  transition: padding-left 0.5s;
+  background-color: ${({ selected }) =>
+    selected ? "#e0e0e0 !important" : "transparent"};
+  &:hover {
+    padding-left: 12px;
+    transition: padding-left 0.1s;
+  }
+`;
+
+const MenuItemText = styled("div")`
+  color: #000;
+  font-size: 13px;
+  width: 100%;
+`;
+
+const EllipsisButton = styled(IconButton)`
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  height: 24px;
+  width: 24px;
+  border-radius: 8px;
+  color: #333333;
+  stroke-width: 2px;
+  opacity: 0.4;
+  &:hover {
+    background: none;
+    opacity: 1;
+  }
+`;
+
+export default LeftDrawer;

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
@@ -62,7 +62,10 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
           <PlusIcon />
         </AddButton>
       </DrawerHeader>
-      <DrawerContent>{elements}</DrawerContent>
+      <DrawerContent>
+        <DrawerContentTitle>Your workbooks</DrawerContentTitle>
+        {elements}
+      </DrawerContent>
       <DrawerFooter>
         <UserWrapper>
           <StyledAvatar
@@ -135,9 +138,17 @@ const DrawerContent = styled("div")`
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 16px;
+  padding: 20px 16px;
   height: 100%;
   overflow: scroll;
+`;
+
+const DrawerContentTitle = styled("div")`
+  font-size: 12px;
+  font-weight: 600;
+  color: #9e9e9e;
+  margin-bottom: 8px;
+  padding: 0px 8px;
 `;
 
 const StorageIndicator = styled("div")`

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
@@ -4,6 +4,7 @@ import { IronCalcLogo } from "@ironcalc/workbook";
 import { Avatar, Drawer, IconButton, MenuItem, Menu } from "@mui/material";
 import { EllipsisVertical, HardDrive, Plus, Trash2 } from "lucide-react";
 import DeleteWorkbookDialog from "./DeleteWorkbookDialog";
+import UserMenu from "./UserMenu";
 
 interface LeftDrawerProps {
   open: boolean;
@@ -30,6 +31,9 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
     string | null
   >(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [userMenuAnchorEl, setUserMenuAnchorEl] = useState<null | HTMLElement>(
+    null
+  );
 
   const handleMenuOpen = (
     event: React.MouseEvent<HTMLButtonElement>,
@@ -43,6 +47,14 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
   const handleMenuClose = () => {
     setMenuAnchorEl(null);
     setSelectedWorkbookUuid(null);
+  };
+
+  const handleUserMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setUserMenuAnchorEl(event.currentTarget);
+  };
+
+  const handleUserMenuClose = () => {
+    setUserMenuAnchorEl(null);
   };
 
   const elements = Object.keys(models).map((uuid) => (
@@ -145,17 +157,30 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
         )}
       </DrawerContent>
       <DrawerFooter>
-        <UserWrapper>
+        <UserWrapper
+          disableRipple
+          onClick={handleUserMenuOpen}
+          selected={Boolean(userMenuAnchorEl)}
+        >
           <StyledAvatar
             alt="Nikola Tesla"
             src="/path/to/avatar.jpg"
             sx={{ bgcolor: "#f2994a", width: 24, height: 24 }}
           />
           <Username>Nikola Tesla</Username>
-          <EllipsisButton size="small">
-            <EllipsisVertical />
-          </EllipsisButton>
         </UserWrapper>
+        <UserMenu
+          anchorEl={userMenuAnchorEl}
+          onClose={handleUserMenuClose}
+          onPreferences={() => {
+            console.log("Preferences clicked");
+            handleUserMenuClose();
+          }}
+          onLogout={() => {
+            console.log("Logout clicked");
+            handleUserMenuClose();
+          }}
+        />
       </DrawerFooter>
     </DrawerWrapper>
   );
@@ -290,7 +315,7 @@ const MenuItemText = styled("div")`
 const DrawerFooter = styled("div")`
   display: flex;
   align-items: center;
-  padding: 12px 8px 12px 16px;
+  padding: 12px;
   justify-content: space-between;
   max-height: 60px;
   height: 60px;
@@ -298,11 +323,16 @@ const DrawerFooter = styled("div")`
   box-sizing: border-box;
 `;
 
-const UserWrapper = styled("div")`
+const UserWrapper = styled(MenuItem)<{ selected: boolean }>`
   display: flex;
   align-items: center;
   gap: 8px;
   flex-grow: 1;
+  padding: 8px;
+  border-radius: 8px;
+  max-width: 100%;
+  background-color: ${({ selected }) =>
+    selected ? "#e0e0e0 !important" : "transparent"};
 `;
 
 const StyledAvatar = styled(Avatar)`
@@ -312,6 +342,9 @@ const StyledAvatar = styled(Avatar)`
 const Username = styled("div")`
   font-size: 12px;
   flex-grow: 1;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 export default LeftDrawer;

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { IronCalcLogo } from "@ironcalc/workbook";
 import { Avatar, Drawer, IconButton, MenuItem } from "@mui/material";
-import { EllipsisVertical, Plus } from "lucide-react";
+import { Check, EllipsisVertical, Plus } from "lucide-react";
 import type React from "react";
 
 interface LeftDrawerProps {
@@ -29,6 +29,9 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
       }}
       selected={uuid === selectedUuid}
     >
+      <CheckIndicator>
+        {uuid === selectedUuid ? <StyledCheck /> : ""}
+      </CheckIndicator>
       <MenuItemText
         style={{
           maxWidth: "240px",
@@ -38,14 +41,6 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
       >
         {models[uuid]}
       </MenuItemText>
-      <EllipsisButton
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
-        size="small"
-      >
-        <EllipsisVertical />
-      </EllipsisButton>
     </MenuItemWrapper>
   ));
 
@@ -71,11 +66,11 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
       <DrawerFooter>
         <UserWrapper>
           <StyledAvatar
-            alt="Tom Hemy"
+            alt="Nikola Tesla"
             src="/path/to/avatar.jpg"
             sx={{ bgcolor: "#f2994a", width: 24, height: 24 }}
           />
-          <Username>Tom Hemy</Username>
+          <Username>Nikola Tesla</Username>
           <EllipsisButton size="small">
             <EllipsisVertical />
           </EllipsisButton>
@@ -84,6 +79,18 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
     </DrawerWrapper>
   );
 };
+
+const StyledCheck = styled(Check)`
+  width: 16px;
+  height: 16px;
+  color: #333333;
+`;
+
+const CheckIndicator = styled("span")`
+  display: flex;
+  justify-content: center;
+  min-width: 26px;
+`;
 
 const DrawerWrapper = styled(Drawer)`
   width: 264px;
@@ -120,9 +127,9 @@ const AddButton = styled(IconButton)`
   align-items: center;
   justify-content: center;
   padding: 8px;
-  height: 36px;
-  width: 36px;
-  border-radius: 8px;
+  height: 32px;
+  width: 32px;
+  border-radius: 4px;
   margin-left: 10px;
   color: #333333;
   stroke-width: 2px;
@@ -155,12 +162,12 @@ const MenuItemWrapper = styled(MenuItem)<{ selected: boolean }>`
   border-radius: 8px;
   padding: 8px 4px 8px 8px;
   height: 32px;
-  transition: padding-left 0.5s;
+  transition: gap 0.5s;
   background-color: ${({ selected }) =>
     selected ? "#e0e0e0 !important" : "transparent"};
   &:hover {
-    padding-left: 12px;
-    transition: padding-left 0.1s;
+    gap: 4px;
+    transition: gap 0.1s;
   }
 `;
 

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { IronCalcLogo } from "@ironcalc/workbook";
-import { Drawer, IconButton, MenuItem } from "@mui/material";
+import { Avatar, Drawer, IconButton, MenuItem } from "@mui/material";
 import { EllipsisVertical, Plus } from "lucide-react";
 import type React from "react";
 
@@ -68,6 +68,19 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
         </AddButton>
       </DrawerHeader>
       <DrawerContent>{elements}</DrawerContent>
+      <DrawerFooter>
+        <UserWrapper>
+          <StyledAvatar
+            alt="Tom Hemy"
+            src="/path/to/avatar.jpg"
+            sx={{ bgcolor: "#f2994a", width: 24, height: 24 }}
+          />
+          <Username>Tom Hemy</Username>
+          <EllipsisButton size="small">
+            <EllipsisVertical />
+          </EllipsisButton>
+        </UserWrapper>
+      </DrawerFooter>
     </DrawerWrapper>
   );
 };
@@ -75,6 +88,7 @@ const LeftDrawer: React.FC<LeftDrawerProps> = ({
 const DrawerWrapper = styled(Drawer)`
   width: 264px;
   flex-shrink: 0;
+  font-family: "Inter", sans-serif;
 
   .MuiDrawer-paper {
     width: 264px;
@@ -174,6 +188,33 @@ const EllipsisButton = styled(IconButton)`
     background: none;
     opacity: 1;
   }
+`;
+
+const DrawerFooter = styled("div")`
+  display: flex;
+  align-items: center;
+  padding: 12px 8px 12px 16px;
+  justify-content: space-between;
+  max-height: 60px;
+  height: 60px;
+  border-top: 1px solid #e0e0e0;
+  box-sizing: border-box;
+`;
+
+const UserWrapper = styled("div")`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-grow: 1;
+`;
+
+const StyledAvatar = styled(Avatar)`
+  font-size: 14px;
+`;
+
+const Username = styled("div")`
+  font-size: 14px;
+  flex-grow: 1;
 `;
 
 export default LeftDrawer;

--- a/webapp/app.ironcalc.com/frontend/src/components/UserMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/UserMenu.tsx
@@ -1,0 +1,90 @@
+import styled from "@emotion/styled";
+import { Menu, MenuItem } from "@mui/material";
+import { LogOut, Settings } from "lucide-react";
+
+interface UserMenuProps {
+  anchorEl: null | HTMLElement;
+  onClose: () => void;
+  onPreferences: () => void;
+  onLogout: () => void;
+}
+
+const UserMenu: React.FC<UserMenuProps> = ({
+  anchorEl,
+  onClose,
+  onPreferences,
+  onLogout,
+}) => {
+  return (
+    <StyledMenu
+      anchorEl={anchorEl}
+      open={Boolean(anchorEl)}
+      onClose={onClose}
+      MenuListProps={{
+        dense: true,
+      }}
+      anchorOrigin={{
+        vertical: "top",
+        horizontal: "left",
+      }}
+      transformOrigin={{
+        vertical: "bottom",
+        horizontal: "left",
+      }}
+    >
+      <MenuItemWrapper onClick={onPreferences} sx={{ gap: 1, fontSize: 14 }}>
+        <Settings size={16} />
+        <MenuItemText>Preferences</MenuItemText>
+      </MenuItemWrapper>
+      <MenuDivider />
+      <MenuItemWrapper onClick={onLogout} sx={{ gap: 1, fontSize: 14 }}>
+        <LogOut size={16} />
+        <MenuItemText>Log out</MenuItemText>
+      </MenuItemWrapper>
+    </StyledMenu>
+  );
+};
+
+const StyledMenu = styled(Menu)`
+  & .MuiPaper-root {
+    border-radius: 8px;
+    padding: 4px 0px;
+    margin-top: -4px;
+    margin-left: 4px;
+  }
+  & .MuiList-root {
+    padding: 0;
+  }
+`;
+
+const MenuItemText = styled("div")`
+  color: #000;
+  font-size: 12px;
+  flex-grow: 1;
+`;
+
+const MenuItemWrapper = styled(MenuItem)`
+  display: flex;
+  justify-content: flex-start;
+  font-size: 14px;
+  width: calc(100% - 8px);
+  min-width: 172px;
+  margin: 0px 4px;
+  border-radius: 4px;
+  padding: 8px;
+  height: 32px;
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+const MenuDivider = styled("div")`
+  width: 100%;
+  margin: auto;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  border-top: 1px solid #eeeeee;
+`;
+
+export default UserMenu;

--- a/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
@@ -73,7 +73,7 @@ export function WorkbookTitle(properties: {
 
 const Container = styled("div")`
   text-align: left;
-  padding: 4px;
+  padding: 6px 4px;
   font-size: 12px;
   font-weight: 600;
   font-family: Inter;

--- a/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
@@ -74,7 +74,7 @@ export function WorkbookTitle(properties: {
 const Container = styled("div")`
   text-align: left;
   padding: 6px 4px;
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 600;
   font-family: Inter;
 `;

--- a/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
@@ -72,10 +72,10 @@ export function WorkbookTitle(properties: {
 }
 
 const Container = styled("div")`
-  text-align: center;
-  padding: 8px;
-  font-size: 14px;
-  font-weight: 700;
+  text-align: left;
+  padding: 4px;
+  font-size: 12px;
+  font-weight: 600;
   font-family: Inter;
 `;
 
@@ -108,7 +108,7 @@ const TitleInput = styled("input")`
     background-color: #f2f2f2;
   }
   &:focus {
-    border: 1px solid grey;
+    outline: 1px solid grey;
   }
   font-weight: inherit;
   font-family: inherit;


### PR DESCRIPTION
Hi there,

This PR aims to refresh the interface in the webapp by adding a collapsable drawer on the left side. Some reasons for this change:
- This will allow to list more workbooks
- Maybe will also allow search, and bulk actions (like multiple deletion)
- Declutter the current File Menu
- Use to list examples/templates (in the future)
- Use it to place sign in/sign out buttons (in the future)

There are still some missing things until this PR is ready to be merged:
- [ ] Ellipsis buttons should only be shown when hovering the list's items
- [ ] The 'Download workbook' button inside the ellipsis menu doesn't work for now
- [ ] Same for 'Delete workbook'

@nhatcher we can discuss this week.
