### PR TITLE
FIX: There are two fills in every new Excel model

### DIFF
--- a/base/src/test/test_styles.rs
+++ b/base/src/test/test_styles.rs
@@ -62,3 +62,17 @@ fn test_create_named_style() {
     let style = model.get_style_for_cell(0, 1, 1).unwrap();
     assert!(style.font.b);
 }
+
+#[test]
+fn empty_models_have_two_fills() {
+    let model = new_empty_model();
+    assert_eq!(model.workbook.styles.fills.len(), 2);
+    assert_eq!(
+        model.workbook.styles.fills[0].pattern_type,
+        "none".to_string()
+    );
+    assert_eq!(
+        model.workbook.styles.fills[1].pattern_type,
+        "gray125".to_string()
+    );
+}

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -303,7 +303,14 @@ impl Default for Styles {
         Styles {
             num_fmts: vec![],
             fonts: vec![Default::default()],
-            fills: vec![Default::default()],
+            fills: vec![
+                Default::default(),
+                Fill {
+                    pattern_type: "gray125".to_string(),
+                    fg_color: None,
+                    bg_color: None,
+                },
+            ],
             borders: vec![Default::default()],
             cell_style_xfs: vec![Default::default()],
             cell_xfs: vec![Default::default()],


### PR DESCRIPTION
Excel expects two default fills. If a different fill is present Excel removes it and substitutes it with the defaults.

This resulted in models having the default fill for the first style.

Thanks @scandel!