### PR TITLE
FIX: Remove wrong content-type is sharing workbooks

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbookDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbookDialog.tsx
@@ -17,8 +17,7 @@ function ShareWorkbookDialog(properties: {
     const generateUrl = async () => {
       if (properties.model) {
         const bytes = properties.model.toBytes();
-        const fileName = properties.model.getName();
-        const hash = await shareModel(bytes, fileName);
+        const hash = await shareModel(bytes);
         setUrl(`${location.origin}/?model=${hash}`);
       }
     };

--- a/webapp/app.ironcalc.com/frontend/src/components/rpc.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/rpc.ts
@@ -81,15 +81,11 @@ export async function downloadModel(bytes: Uint8Array, fileName: string) {
   a.remove();
 }
 
-export async function shareModel(
-  bytes: Uint8Array,
-  fileName: string,
-): Promise<string> {
+export async function shareModel(bytes: Uint8Array): Promise<string> {
   const response = await fetch("/api/share", {
     method: "POST",
     headers: {
       "Content-Type": "application/octet-stream",
-      "Content-Disposition": `attachment; filename="${fileName}"`,
     },
     body: bytes,
   });


### PR DESCRIPTION
This failed to share workbooks with emojis, for instance.

Thanks @dg-ac !