### PR TITLE
update: add a Help menu to App

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -3,6 +3,7 @@ import type { Model } from "@ironcalc/workbook";
 import { IronCalcIcon, IronCalcLogo } from "@ironcalc/workbook";
 import { useLayoutEffect, useRef, useState } from "react";
 import { FileMenu } from "./FileMenu";
+import { HelpMenu } from "./HelpMenu";
 import { ShareButton } from "./ShareButton";
 import ShareWorkbookDialog from "./ShareWorkbookDialog";
 import { WorkbookTitle } from "./WorkbookTitle";
@@ -61,11 +62,7 @@ export function FileBar(properties: {
         }}
         onDelete={properties.onDelete}
       />
-      <HelpButton
-        onClick={() => window.open("https://docs.ironcalc.com", "_blank")}
-      >
-        Help
-      </HelpButton>
+      <HelpMenu />
       <WorkbookTitleWrapper>
         <WorkbookTitle
           name={properties.model.getName()}

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -117,19 +117,6 @@ const StyledIronCalcIcon = styled(IronCalcIcon)`
   }
 `;
 
-const HelpButton = styled("div")`
-  display: flex;
-  align-items: center;
-  font-size: 12px;
-  font-family: Inter;
-  padding: 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  &:hover {
-    background-color: #f2f2f2;
-  }
-`;
-
 const Divider = styled("div")`
   margin: 0px 8px 0px 16px;
   height: 12px;

--- a/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
@@ -32,7 +32,13 @@ export function FileMenu(props: {
         }}
       >
         <CheckIndicator>
-          {uuid === selectedUuid ? <StyledCheck /> : ""}
+          {uuid === selectedUuid ? (
+            <StyledIcon>
+              <Check />
+            </StyledIcon>
+          ) : (
+            ""
+          )}
         </CheckIndicator>
         <MenuItemText
           style={{
@@ -43,15 +49,17 @@ export function FileMenu(props: {
         >
           {models[uuid]}
         </MenuItemText>
-      </MenuItemWrapper>,
+      </MenuItemWrapper>
     );
   }
 
   return (
     <>
       <FileMenuWrapper
+        id="file-menu-button"
         onClick={(): void => setMenuOpen(true)}
         ref={anchorElement}
+        $isActive={isMenuOpen}
       >
         File
       </FileMenuWrapper>
@@ -59,12 +67,19 @@ export function FileMenu(props: {
         open={isMenuOpen}
         onClose={(): void => setMenuOpen(false)}
         anchorEl={anchorElement.current}
+        autoFocus={false}
+        disableRestoreFocus={true}
         sx={{
           "& .MuiPaper-root": { borderRadius: "8px", padding: "4px 0px" },
           "& .MuiList-root": { padding: "0" },
+          transform: "translate(-4px, 4px)",
         }}
-
-        // anchorOrigin={properties.anchorOrigin}
+        slotProps={{
+          list: {
+            "aria-labelledby": "file-menu-button",
+            tabIndex: -1,
+          },
+        }}
       >
         <MenuItemWrapper
           onClick={() => {
@@ -72,7 +87,9 @@ export function FileMenu(props: {
             setMenuOpen(false);
           }}
         >
-          <StyledPlus />
+          <StyledIcon>
+            <Plus />
+          </StyledIcon>
           <MenuItemText>New</MenuItemText>
         </MenuItemWrapper>
         <MenuItemWrapper
@@ -81,11 +98,15 @@ export function FileMenu(props: {
             setMenuOpen(false);
           }}
         >
-          <StyledFileUp />
+          <StyledIcon>
+            <FileUp />
+          </StyledIcon>
           <MenuItemText>Import</MenuItemText>
         </MenuItemWrapper>
         <MenuItemWrapper>
-          <StyledFileDown />
+          <StyledIcon>
+            <FileDown />
+          </StyledIcon>
           <MenuItemText onClick={props.onDownload}>
             Download (.xlsx)
           </MenuItemText>
@@ -96,7 +117,9 @@ export function FileMenu(props: {
             setMenuOpen(false);
           }}
         >
-          <StyledTrash />
+          <StyledIcon>
+            <Trash2 />
+          </StyledIcon>
           <MenuItemText>Delete workbook</MenuItemText>
         </MenuItemWrapper>
         <MenuDivider />
@@ -133,42 +156,18 @@ export function FileMenu(props: {
   );
 }
 
-const StyledPlus = styled(Plus)`
-  width: 16px;
-  height: 16px;
-  color: #333333;
-  padding-right: 10px;
+const StyledIcon = styled.div`
+  display: flex;
+  align-items: center;
+  svg {
+    width: 16px;
+    height: 100%;
+    color: #757575;
+    padding-right: 10px;
+  }
 `;
 
-const StyledFileDown = styled(FileDown)`
-  width: 16px;
-  height: 16px;
-  color: #333333;
-  padding-right: 10px;
-`;
-
-const StyledFileUp = styled(FileUp)`
-  width: 16px;
-  height: 16px;
-  color: #333333;
-  padding-right: 10px;
-`;
-
-const StyledTrash = styled(Trash2)`
-  width: 16px;
-  height: 16px;
-  color: #333333;
-  padding-right: 10px;
-`;
-
-const StyledCheck = styled(Check)`
-  width: 16px;
-  height: 16px;
-  color: #333333;
-  padding-right: 10px;
-`;
-
-const MenuDivider = styled("div")`
+const MenuDivider = styled.div`
   width: 100%;
   margin: auto;
   margin-top: 4px;
@@ -176,7 +175,7 @@ const MenuDivider = styled("div")`
   border-top: 1px solid #eeeeee;
 `;
 
-const MenuItemText = styled("div")`
+const MenuItemText = styled.div`
   color: #000;
   font-size: 12px;
 `;
@@ -193,7 +192,7 @@ const MenuItemWrapper = styled(MenuItem)`
   height: 32px;
 `;
 
-const FileMenuWrapper = styled("div")`
+const FileMenuWrapper = styled.div<{ $isActive?: boolean }>`
   display: flex;
   align-items: center;
   font-size: 12px;
@@ -201,12 +200,13 @@ const FileMenuWrapper = styled("div")`
   padding: 8px;
   border-radius: 4px;
   cursor: pointer;
+  background-color: ${(props) => (props.$isActive ? "#e6e6e6" : "transparent")};
   &:hover {
     background-color: #f2f2f2;
   }
 `;
 
-const CheckIndicator = styled("span")`
+const CheckIndicator = styled.span`
   display: flex;
   justify-content: center;
   min-width: 26px;

--- a/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
@@ -15,7 +15,7 @@ export function FileMenu(props: {
 }) {
   const [isMenuOpen, setMenuOpen] = useState(false);
   const [isImportMenuOpen, setImportMenuOpen] = useState(false);
-  const anchorElement = useRef<HTMLDivElement>(null);
+  const anchorElement = useRef<HTMLButtonElement>(null);
   const models = getModelsMetadata();
   const uuids = Object.keys(models);
   const selectedUuid = getSelectedUuid();
@@ -56,10 +56,12 @@ export function FileMenu(props: {
   return (
     <>
       <FileMenuWrapper
+        type="button"
         id="file-menu-button"
         onClick={(): void => setMenuOpen(true)}
         ref={anchorElement}
         $isActive={isMenuOpen}
+        aria-haspopup="true"
       >
         File
       </FileMenuWrapper>
@@ -103,13 +105,11 @@ export function FileMenu(props: {
           </StyledIcon>
           <MenuItemText>Import</MenuItemText>
         </MenuItemWrapper>
-        <MenuItemWrapper>
+        <MenuItemWrapper onClick={props.onDownload}>
           <StyledIcon>
             <FileDown />
           </StyledIcon>
-          <MenuItemText onClick={props.onDownload}>
-            Download (.xlsx)
-          </MenuItemText>
+          <MenuItemText>Download (.xlsx)</MenuItemText>
         </MenuItemWrapper>
         <MenuItemWrapper
           onClick={() => {
@@ -192,7 +192,7 @@ const MenuItemWrapper = styled(MenuItem)`
   height: 32px;
 `;
 
-const FileMenuWrapper = styled.div<{ $isActive?: boolean }>`
+const FileMenuWrapper = styled.button<{ $isActive?: boolean }>`
   display: flex;
   align-items: center;
   font-size: 12px;
@@ -201,6 +201,8 @@ const FileMenuWrapper = styled.div<{ $isActive?: boolean }>`
   border-radius: 4px;
   cursor: pointer;
   background-color: ${(props) => (props.$isActive ? "#e6e6e6" : "transparent")};
+  border: none;
+  background: none;
   &:hover {
     background-color: #f2f2f2;
   }

--- a/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
@@ -192,7 +192,7 @@ const MenuItemWrapper = styled(MenuItem)`
   height: 32px;
 `;
 
-const FileMenuWrapper = styled.button<{ $isActive?: boolean }>`
+const FileMenuWrapper = styled.button<{ $isActive: boolean }>`
   display: flex;
   align-items: center;
   font-size: 12px;

--- a/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
@@ -49,7 +49,7 @@ export function FileMenu(props: {
         >
           {models[uuid]}
         </MenuItemText>
-      </MenuItemWrapper>
+      </MenuItemWrapper>,
     );
   }
 

--- a/webapp/app.ironcalc.com/frontend/src/components/HelpMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/HelpMenu.tsx
@@ -55,7 +55,7 @@ export function HelpMenu() {
           onClick={() => {
             handleClose();
             window.open(
-              "https://docs.ironcalc.com",
+              "https://docs.ironcalc.com/web-application/about.html",
               "_blank",
               "noopener,noreferrer",
             );

--- a/webapp/app.ironcalc.com/frontend/src/components/HelpMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/HelpMenu.tsx
@@ -1,0 +1,123 @@
+import styled from "@emotion/styled";
+import { Menu, MenuItem } from "@mui/material";
+import { BookOpen, Keyboard } from "lucide-react";
+import { useRef, useState } from "react";
+
+export function HelpMenu() {
+  const [isMenuOpen, setMenuOpen] = useState(false);
+  const anchorElement = useRef<HTMLDivElement>(null);
+
+  const handleClick = () => {
+    setMenuOpen(true);
+  };
+
+  const handleClose = () => {
+    setMenuOpen(false);
+  };
+
+  return (
+    <div>
+      <HelpButton
+        ref={anchorElement}
+        id="help-button"
+        aria-controls={isMenuOpen ? "help-menu" : undefined}
+        onClick={handleClick}
+        $isActive={isMenuOpen}
+      >
+        Help
+      </HelpButton>
+      <Menu
+        id="help-menu"
+        anchorEl={anchorElement.current}
+        open={isMenuOpen}
+        onClose={handleClose}
+        autoFocus={false}
+        disableRestoreFocus={true}
+        sx={{
+          "& .MuiPaper-root": {
+            borderRadius: "8px",
+            padding: "4px 0px",
+            transform: "translate(-4px, 4px)",
+          },
+          "& .MuiList-root": { padding: "0" },
+          transform: "translate(-4px, 4px)",
+        }}
+        slotProps={{
+          list: {
+            "aria-labelledby": "help-button",
+            tabIndex: -1,
+          },
+        }}
+      >
+        <MenuItemWrapper
+          onClick={() => {
+            handleClose();
+            window.open("https://docs.ironcalc.com", "_blank");
+          }}
+        >
+          <StyledIcon>
+            <BookOpen />
+          </StyledIcon>
+          <MenuItemText>Documentation</MenuItemText>
+        </MenuItemWrapper>
+        <MenuItemWrapper
+          onClick={() => {
+            handleClose();
+            window.open(
+              "https://docs.ironcalc.com/features/keyboard-shortcuts.html",
+              "_blank",
+            );
+          }}
+        >
+          <StyledIcon>
+            <Keyboard />
+          </StyledIcon>
+          <MenuItemText>Keyboard Shortcuts</MenuItemText>
+        </MenuItemWrapper>
+      </Menu>
+    </div>
+  );
+}
+
+const HelpButton = styled.div<{ $isActive?: boolean }>`
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  font-family: Inter;
+  padding: 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  background-color: ${(props) => (props.$isActive ? "#e6e6e6" : "transparent")};
+  &:hover {
+    background-color: #f2f2f2;
+  }
+`;
+
+const MenuItemWrapper = styled(MenuItem)`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  font-size: 14px;
+  width: calc(100% - 8px);
+  min-width: 172px;
+  margin: 0px 4px;
+  border-radius: 4px;
+  padding: 8px;
+  height: 32px;
+`;
+
+const StyledIcon = styled.div`
+  display: flex;
+  align-items: center;
+  svg {
+    width: 16px;
+    height: 100%;
+    color: #757575;
+    padding-right: 10px;
+  }
+`;
+
+const MenuItemText = styled.div`
+  color: #000;
+  font-size: 12px;
+`;

--- a/webapp/app.ironcalc.com/frontend/src/components/HelpMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/HelpMenu.tsx
@@ -5,7 +5,7 @@ import { useRef, useState } from "react";
 
 export function HelpMenu() {
   const [isMenuOpen, setMenuOpen] = useState(false);
-  const anchorElement = useRef<HTMLDivElement>(null);
+  const anchorElement = useRef<HTMLButtonElement>(null);
 
   const handleClick = () => {
     setMenuOpen(true);
@@ -18,9 +18,11 @@ export function HelpMenu() {
   return (
     <div>
       <HelpButton
+        type="button"
         ref={anchorElement}
         id="help-button"
         aria-controls={isMenuOpen ? "help-menu" : undefined}
+        aria-haspopup="true"
         onClick={handleClick}
         $isActive={isMenuOpen}
       >
@@ -52,7 +54,11 @@ export function HelpMenu() {
         <MenuItemWrapper
           onClick={() => {
             handleClose();
-            window.open("https://docs.ironcalc.com", "_blank");
+            window.open(
+              "https://docs.ironcalc.com",
+              "_blank",
+              "noopener,noreferrer",
+            );
           }}
         >
           <StyledIcon>
@@ -66,6 +72,7 @@ export function HelpMenu() {
             window.open(
               "https://docs.ironcalc.com/features/keyboard-shortcuts.html",
               "_blank",
+              "noopener,noreferrer",
             );
           }}
         >
@@ -79,7 +86,7 @@ export function HelpMenu() {
   );
 }
 
-const HelpButton = styled.div<{ $isActive?: boolean }>`
+const HelpButton = styled.button<{ $isActive?: boolean }>`
   display: flex;
   align-items: center;
   font-size: 12px;
@@ -88,6 +95,8 @@ const HelpButton = styled.div<{ $isActive?: boolean }>`
   border-radius: 4px;
   cursor: pointer;
   background-color: ${(props) => (props.$isActive ? "#e6e6e6" : "transparent")};
+  border: none;
+  background: none;
   &:hover {
     background-color: #f2f2f2;
   }


### PR DESCRIPTION
This PR introduces a small change in the file bar of the app by adding a new menu for the Help button, which until now it was just opening the documentation.

The update avoids confusion caused by accidental clicking (as it was just opening a new tab which was very sudden). In the future we should add other items to this menu and maybe place the shortcuts in its own dialog, instead of just relying in the Docs.

<img width="295" height="158" alt="image" src="https://github.com/user-attachments/assets/55113ba0-c14d-41a7-9a26-7d1fbb30ab93" />


