### PR TITLE
update: replace custom made icons with lucide's

### DIFF
--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -14,6 +14,8 @@ import {
   ArrowUpToLine,
   Bold,
   ChevronDown,
+  DecimalsArrowLeft,
+  DecimalsArrowRight,
   Euro,
   Grid2X2,
   Grid2x2Check,
@@ -36,11 +38,7 @@ import {
 } from "lucide-react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  ArrowMiddleFromLine,
-  DecimalPlacesDecreaseIcon,
-  DecimalPlacesIncreaseIcon,
-} from "../../icons";
+import { ArrowMiddleFromLine } from "../../icons";
 import { theme } from "../../theme";
 import BorderPicker from "../BorderPicker/BorderPicker";
 import ColorPicker from "../ColorPicker/ColorPicker";
@@ -168,7 +166,7 @@ function Toolbar(properties: ToolbarProperties) {
         disabled={!canEdit}
         title={t("toolbar.decimal_places_decrease")}
       >
-        <DecimalPlacesDecreaseIcon />
+        <DecimalsArrowLeft />
       </StyledButton>
       <StyledButton
         type="button"
@@ -181,7 +179,7 @@ function Toolbar(properties: ToolbarProperties) {
         disabled={!canEdit}
         title={t("toolbar.decimal_places_increase")}
       >
-        <DecimalPlacesIncreaseIcon />
+        <DecimalsArrowRight />
       </StyledButton>
       <FormatMenu
         numFmt={properties.numFmt}

--- a/webapp/IronCalc/src/icons/decrease-decimal.svg
+++ b/webapp/IronCalc/src/icons/decrease-decimal.svg
@@ -1,6 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12.5 11.3333H5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7 9.33333L5 11.3333L7 13.3333" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.66667 4.33333C7.66667 3.59695 7.06971 3 6.33333 3C5.59695 3 5 3.59695 5 4.33333V5.66667C5 6.40305 5.59695 7 6.33333 7C7.06971 7 7.66667 6.40305 7.66667 5.66667V4.33333Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M3 7H3.00667" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/webapp/IronCalc/src/icons/increase-decimal.svg
+++ b/webapp/IronCalc/src/icons/increase-decimal.svg
@@ -1,7 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12.5 11.3333H5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M10.5 9.33333L12.5 11.3333L10.5 13.3333" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7.66667 4.33333C7.66667 3.59695 7.06971 3 6.33333 3C5.59695 3 5 3.59695 5 4.33333V5.66667C5 6.40305 5.59695 7 6.33333 7C7.06971 7 7.66667 6.40305 7.66667 5.66667V4.33333Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.3333 4.33333C12.3333 3.59695 11.7364 3 11 3C10.2636 3 9.66667 3.59695 9.66667 4.33333V5.66667C9.66667 6.40305 10.2636 7 11 7C11.7364 7 12.3333 6.40305 12.3333 5.66667V4.33333Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M3 7H3.00667" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>


### PR DESCRIPTION
This PR replaces the current `remove decimal` and `increase decimal` icons in the widget. Until now we were using custom-made icons but since Lucide has added [similar ones](https://lucide.dev/icons/?search=decimal) to their library, it's better to use these.

`before`
<img width="191" height="49" alt="image" src="https://github.com/user-attachments/assets/730b7a3e-f20e-4223-b80e-f0dd906984ab" />

`after`
<img width="194" height="50" alt="image" src="https://github.com/user-attachments/assets/fd0845a9-6a12-43a4-93e3-57a69b080d6f" />