### PR TITLE
fix: corners in Type and Cell background color buttons

### DIFF
--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -278,6 +278,7 @@ function Toolbar(properties: ToolbarProperties) {
         onClick={() => setFontColorPickerOpen(true)}
       >
         <Type />
+        <ColorLine color={properties.fontColor} />
       </StyledButton>
       <StyledButton
         type="button"
@@ -289,6 +290,7 @@ function Toolbar(properties: ToolbarProperties) {
         onClick={() => setFillColorPickerOpen(true)}
       >
         <PaintBucket />
+        <ColorLine color={properties.fillColor} />
       </StyledButton>
       <StyledButton
         type="button"
@@ -500,57 +502,64 @@ const ToolbarContainer = styled("div")`
 `;
 
 type TypeButtonProperties = { $pressed: boolean; $underlinedColor?: string };
-export const StyledButton = styled("button")<TypeButtonProperties>(
-  ({ disabled, $pressed, $underlinedColor }) => {
-    const result = {
-      width: "24px",
-      minWidth: "24px",
-      height: "24px",
-      display: "inline-flex",
-      alignItems: "center",
-      justifyContent: "center",
-      fontSize: "12px",
-      border: `0px solid ${theme.palette.common.white}`,
-      borderRadius: "4px",
-      transition: "all 0.2s",
-      outline: `1px solid ${theme.palette.common.white}`,
-      cursor: "pointer",
-      backgroundColor: "white",
-      padding: "0px",
-      svg: {
-        width: "16px",
-        height: "16px",
-      },
-    };
-    if (disabled) {
-      return {
-        ...result,
-        color: theme.palette.grey["400"],
-        cursor: "default",
-      };
-    }
+export const StyledButton = styled("button", {
+  shouldForwardProp: (prop) =>
+    prop !== "$pressed" && prop !== "$underlinedColor",
+})<TypeButtonProperties>(({ disabled, $pressed }) => {
+  const result = {
+    width: "24px",
+    minWidth: "24px",
+    height: "24px",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: "12px",
+    border: `0px solid ${theme.palette.common.white}`,
+    borderRadius: "4px",
+    transition: "all 0.2s",
+    outline: `1px solid ${theme.palette.common.white}`,
+    cursor: "pointer",
+    backgroundColor: "white",
+    padding: "0px",
+    position: "relative" as const,
+    svg: {
+      width: "16px",
+      height: "16px",
+    },
+  };
+  if (disabled) {
     return {
       ...result,
-      borderTop: $underlinedColor
-        ? `3px solid ${theme.palette.common.white}`
-        : "none",
-      borderBottom: $underlinedColor ? `3px solid ${$underlinedColor}` : "none",
-      color: theme.palette.grey["900"],
-      backgroundColor: $pressed
-        ? theme.palette.grey["300"]
-        : theme.palette.common.white,
-      "&:hover": {
-        transition: "all 0.2s",
-        outline: `1px solid ${theme.palette.grey["200"]}`,
-        borderTopColor: theme.palette.common.white,
-      },
-      "&:active": {
-        backgroundColor: theme.palette.grey["300"],
-        outline: `1px solid ${theme.palette.grey["300"]}`,
-      },
+      color: theme.palette.grey["400"],
+      cursor: "default",
     };
-  },
-);
+  }
+  return {
+    ...result,
+    color: theme.palette.grey["900"],
+    backgroundColor: $pressed
+      ? theme.palette.grey["300"]
+      : theme.palette.common.white,
+    "&:hover": {
+      transition: "all 0.2s",
+      outline: `1px solid ${theme.palette.grey["200"]}`,
+    },
+    "&:active": {
+      backgroundColor: theme.palette.grey["300"],
+      outline: `1px solid ${theme.palette.grey["300"]}`,
+    },
+  };
+});
+
+const ColorLine = styled("div")<{ color: string }>(({ color }) => ({
+  height: "3px",
+  width: "16px",
+  position: "absolute",
+  bottom: "0px",
+  left: "50%",
+  transform: "translateX(-50%)",
+  backgroundColor: color,
+}));
 
 const Divider = styled("div")({
   width: "0px",

--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -274,7 +274,6 @@ function Toolbar(properties: ToolbarProperties) {
         disabled={!canEdit}
         title={t("toolbar.font_color")}
         ref={fontColorButton}
-        $underlinedColor={properties.fontColor}
         onClick={() => setFontColorPickerOpen(true)}
       >
         <Type />
@@ -286,7 +285,6 @@ function Toolbar(properties: ToolbarProperties) {
         disabled={!canEdit}
         title={t("toolbar.fill_color")}
         ref={fillColorButton}
-        $underlinedColor={properties.fillColor}
         onClick={() => setFillColorPickerOpen(true)}
       >
         <PaintBucket />
@@ -501,10 +499,9 @@ const ToolbarContainer = styled("div")`
   scrollbar-width: none;
 `;
 
-type TypeButtonProperties = { $pressed: boolean; $underlinedColor?: string };
+type TypeButtonProperties = { $pressed: boolean };
 export const StyledButton = styled("button", {
-  shouldForwardProp: (prop) =>
-    prop !== "$pressed" && prop !== "$underlinedColor",
+  shouldForwardProp: (prop) => prop !== "$pressed",
 })<TypeButtonProperties>(({ disabled, $pressed }) => {
   const result = {
     width: "24px",


### PR DESCRIPTION
This PR fixes a visual bug in the Type and Cell background color buttons, in the webapp's toolbar:

![IMG_9554](https://github.com/user-attachments/assets/9997985f-4649-4d2c-b30f-27f6ffa44e83)

This was specially visible in mobile devices.

After the fix, it should look like here below:

![IMG_9555](https://github.com/user-attachments/assets/eb7f77fe-06d4-408a-a766-93f5b8c3a635)
