### PR TITLE
Fix example in README to reference Model correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ And then use this code in `main.rs`:
 
 ```rust
 use ironcalc::{
-    base::{expressions::utils::number_to_column, model::Model},
+    base::{expressions::utils::number_to_column, Model},
     export::save_to_xlsx,
 };
 


### PR DESCRIPTION
Since https://github.com/ironcalc/IronCalc/pull/27, using `base::model::Model` complains about `model` being a private module, and `base::Model` should be used instead.