### PR TITLE
update: show which format is active in FormatMenu

### DIFF
--- a/webapp/IronCalc/src/components/FormatMenu/FormatMenu.tsx
+++ b/webapp/IronCalc/src/components/FormatMenu/FormatMenu.tsx
@@ -1,15 +1,9 @@
 import { Menu, MenuItem, styled } from "@mui/material";
 import { Check } from "lucide-react";
-import {
-  type ComponentProps,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type ComponentProps, useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import FormatPicker from "./FormatPicker";
-import { NumberFormats } from "./formatUtil";
+import { KNOWN_FORMATS, NumberFormats } from "./formatUtil";
 
 type FormatMenuProps = {
   children: React.ReactNode;
@@ -33,11 +27,7 @@ const FormatMenu = (properties: FormatMenuProps) => {
     [properties.onChange],
   );
 
-  const isCustomFormat = useMemo(() => {
-    return !Object.values(NumberFormats).includes(
-      properties.numFmt as NumberFormats,
-    );
-  }, [properties.numFmt]);
+  const isCustomFormat = !KNOWN_FORMATS.has(properties.numFmt);
 
   return (
     <>
@@ -217,7 +207,7 @@ const MenuDivider = styled("div")`
 const CheckIcon = styled(Check)<{ $active: boolean }>`
   width: 16px;
   height: 16px;
-  color: ${(props) => (props.$active ? "" : "transparent")};
+  color: ${(props) => (props.$active ? "currentColor" : "transparent")};
   margin-right: 8px;
   flex-shrink: 0;
 `;

--- a/webapp/IronCalc/src/components/FormatMenu/formatUtil.ts
+++ b/webapp/IronCalc/src/components/FormatMenu/formatUtil.ts
@@ -42,3 +42,5 @@ export enum NumberFormats {
   PERCENTAGE = "0.00%",
   NUMBER = "#,##0.00",
 }
+
+export const KNOWN_FORMATS = new Set<string>(Object.values(NumberFormats));


### PR DESCRIPTION
This PR adds a **check icon** to the `FormatMenu`, allowing users to easily identify which format option is currently active for the selected cell(s).

Some screenshots of the menu after the update:

<img width="auto" height="333" alt="image" src="https://github.com/user-attachments/assets/a1af62cb-c4de-4d86-9cb9-66bd224b117b" />

<img width="auto" height="333" alt="image" src="https://github.com/user-attachments/assets/bd40209a-9331-4db0-9c42-ea454e484c5e" />

<img width="auto" height="333" alt="image" src="https://github.com/user-attachments/assets/c2f954ab-ca86-4f46-aef3-0ce5e62def57" />

---

### Changes
1. Added a check icon next to all format options in the menu.  
2. Updated menu rendering logic to show the icon only when the corresponding format is applied.  

### Testing
- Verify that the correct format option is marked with a check icon when a cell is selected.  
- Change the cell’s format (e.g., number → date → percentage) and confirm that the active icon updates accordingly.  