### PR TITLE
update: fixes to Date and Time main page

### DIFF
--- a/docs/src/functions/date-and-time.md
+++ b/docs/src/functions/date-and-time.md
@@ -6,29 +6,28 @@ lang: en-US
 
 # Date and Time functions
 
-At the moment IronCalc only supports a few function in this section.  
-You can track the progress in this [GitHub issue](https://github.com/ironcalc/IronCalc/issues/48).
+All Date and Time functions are already supported in IronCalc.
 
 | Function         | Status                                         | Documentation |
 | ---------------- | ---------------------------------------------- | ------------- |
 | DATE             | <Badge type="tip" text="Available" />          | –             |
-| DATEDIF          | <Badge type="tip" text="Available" />          | [DATEDIF](date_and_time/datedif) |
-| DATEVALUE        | <Badge type="tip" text="Available" />          | [DATEVALUE](date_and_time/datevalue) |
+| DATEDIF          | <Badge type="tip" text="Available" />          | –             |
+| DATEVALUE        | <Badge type="tip" text="Available" />          | –             |
 | DAY              | <Badge type="tip" text="Available" />          | [DAY](date_and_time/day) |
 | DAYS             | <Badge type="tip" text="Available" />          | –             |
 | DAYS360          | <Badge type="tip" text="Available" />          | –             |
 | EDATE            | <Badge type="tip" text="Available" />          | –             |
 | EOMONTH          | <Badge type="tip" text="Available" />          | –             |
-| HOUR             | <Badge type="tip" text="Available" />          | [HOUR](date_and_time/hour) |
+| HOUR             | <Badge type="tip" text="Available" />          | –             |
 | ISOWEEKNUM       | <Badge type="tip" text="Available" />          | –             |
-| MINUTE           | <Badge type="tip" text="Available" />          | [MINUTE](date_and_time/minute) |
+| MINUTE           | <Badge type="tip" text="Available" />          | –             |
 | MONTH            | <Badge type="tip" text="Available" />          | [MONTH](date_and_time/month) |
 | NETWORKDAYS      | <Badge type="tip" text="Available" />          | [NETWORKDAYS](date_and_time/networkdays) |
 | NETWORKDAYS.INTL | <Badge type="tip" text="Available" />          | [NETWORKDAYS.INTL](date_and_time/networkdays.intl) |
 | NOW              | <Badge type="tip" text="Available" />          | –             |
-| SECOND           | <Badge type="tip" text="Available" />          | [SECOND](date_and_time/second) |
-| TIME             | <Badge type="tip" text="Available" />          | [TIME](date_and_time/time) |
-| TIMEVALUE        | <Badge type="tip" text="Available" />          | [TIMEVALUE](date_and_time/timevalue) |
+| SECOND           | <Badge type="tip" text="Available" />          | –             |
+| TIME             | <Badge type="tip" text="Available" />          | –             |
+| TIMEVALUE        | <Badge type="tip" text="Available" />          | –             |
 | TODAY            | <Badge type="tip" text="Available" />          | –             |
 | WEEKDAY          | <Badge type="tip" text="Available" />          | –             |
 | WEEKNUM          | <Badge type="tip" text="Available" />          | –             |


### PR DESCRIPTION
This PR fixes inaccuracies in the Date and Time main page. Some functions were incorrectly listed as already having dedicated documentation pages when they didn't. 

Changes
- Removed links for functions that don't have their own documentation page yet
- Updated the section description to "all functions in this section are already supported"