### PR TITLE
fix: mobile issues in app

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/App.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/App.tsx
@@ -227,7 +227,7 @@ const Wrapper = styled("div")`
 `;
 
 const DRAWER_WIDTH = 264;
-const MIN_MAIN_CONTENT_WIDTH_FOR_MOBILE = 768;
+export const MIN_MAIN_CONTENT_WIDTH_FOR_MOBILE = 768;
 
 const MainContent = styled("div")<{ isDrawerOpen: boolean }>`
   margin-left: ${({ isDrawerOpen }) =>

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -3,6 +3,7 @@ import type { Model } from "@ironcalc/workbook";
 import { IconButton, Tooltip } from "@mui/material";
 import { CloudOff, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
+import { MIN_MAIN_CONTENT_WIDTH_FOR_MOBILE } from "../App";
 import { FileMenu } from "./FileMenu";
 import { HelpMenu } from "./HelpMenu";
 import { downloadModel } from "./rpc";
@@ -77,7 +78,7 @@ export function FileBar(properties: {
           {properties.isDrawerOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
         </DrawerButton>
       </Tooltip>
-      {width > 768 && (
+      {width > MIN_MAIN_CONTENT_WIDTH_FOR_MOBILE && (
         <FileMenu
           newModel={properties.newModel}
           newModelFromTemplate={properties.newModelFromTemplate}
@@ -92,7 +93,7 @@ export function FileBar(properties: {
           onDelete={properties.onDelete}
         />
       )}
-      {width > 768 && <HelpMenu />}
+      {width > MIN_MAIN_CONTENT_WIDTH_FOR_MOBILE && <HelpMenu />}
       <WorkbookTitleWrapper>
         <WorkbookTitle
           name={properties.model.getName()}


### PR DESCRIPTION
This PR fixes a couple of annoying behaviours that were affecting the mobile view of the app.

---

## Changes

1. Allow triggering the title tooltip on tap, not only on hover.

<img width="299" height="136" alt="image" src="https://github.com/user-attachments/assets/e8b6fe7e-71b7-49b5-bee1-6515524a2294" />

2. Increase breakpoint to trigger the mobile view on wider screens: should make easier using the app in wider mobile displays and tablets.

<img width="auto" height="460" alt="image" src="https://github.com/user-attachments/assets/3dd01211-3c96-4bd8-9ee5-8ea8bd07c827" />

---

## Testing

- [ ] Make sure the fixes work both on desktop and mobile