### PR TITLE
update: adjust row height on font size change

### DIFF
--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -154,34 +154,43 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
       row: number;
       oldFontSize: number;
       oldRowHeight: number;
+      maxLineCount: number;
     }> = [];
 
     for (let row = actualRowStart; row <= actualRowEnd; row++) {
       let maxFontSize = 0;
+      let maxLineCount = 1;
       for (let col = actualColumnStart; col <= actualColumnEnd; col++) {
         const style = model.getCellStyle(sheet, row, col);
         maxFontSize = Math.max(maxFontSize, style.font.sz);
+
+        // Count lines in cell content (we add new lines with Alt+Enter / Option+Enter)
+        const cellContent = model.getCellContent(sheet, row, col);
+        const lineCount = cellContent.split("\n").length;
+        maxLineCount = Math.max(maxLineCount, lineCount);
       }
       const oldRowHeight = model.getRowHeight(sheet, row);
       rowData.push({
         row,
         oldFontSize: maxFontSize,
         oldRowHeight,
+        maxLineCount,
       });
     }
 
     /** Update the font size in the model */
     updateRangeStyle("font.size_delta", `${delta}`);
 
-    /** Adjust row heights based on the new font sizes */
-    for (const { row, oldFontSize, oldRowHeight } of rowData) {
+    /** Adjust row heights based on the new font sizes and line counts */
+    for (const { row, oldFontSize, oldRowHeight, maxLineCount } of rowData) {
       const newFontSize = oldFontSize + delta;
 
       if (oldRowHeight < DEFAULT_ROW_HEIGHT) {
         continue;
       }
 
-      const requiredHeight = 8 + newFontSize;
+      const lineHeight = newFontSize * 1.5;
+      const requiredHeight = (maxLineCount - 1) * lineHeight + 8 + newFontSize;
 
       let newRowHeight: number;
       if (requiredHeight > DEFAULT_ROW_HEIGHT) {


### PR DESCRIPTION
This PR ensures that row heights automatically adapt when the font size changes.  
Previously, increasing the font size could cause text to overflow or become clipped, requiring manual row resizing.  
The update introduces a smarter height adjustment mechanism and fixes issues with multi-line cell content.

---

## Changes

1. Added a function to **automatically adjust row height** when font size increases.  
2. Added support for **multi-line cells** as well.

https://github.com/user-attachments/assets/76901e64-a178-4207-be13-8bee81b55ed0

---

## Testing

- [ ] Increase font size in a single cell and verify the row height adjusts automatically.  
- [ ] Test multi-line cells (Shift/Option+Enter) to ensure the entire content remains visible.  
- [ ] Apply font size changes to multiple selected rows and confirm consistent behavior.  
- [ ] Resize rows manually and check that automatic resizing still behaves correctly afterward.  
- [ ] Validate no regressions in row resizing across different browsers and screen sizes.