### PR TITLE
fix: abort copy styles action when pressing esc

### DIFF
--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -322,6 +322,11 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
     },
     onEscape: (): void => {
       workbookState.clearCutRange();
+      workbookState.setCopyStyles(null);
+      const el = rootRef.current?.getElementsByClassName("sheet-container")[0];
+      if (el) {
+        (el as HTMLElement).style.cursor = "auto";
+      }
       setRedrawId((id) => id + 1);
     },
     onSelectColumn: (): void => {


### PR DESCRIPTION
This PR improves the usability of the **Copy Styles** feature by allowing users to cancel the action using the **Escape (Esc)** key.  Previously, once the “copy styles” mode was activated, there was no quick way to abort it without completing the action. 

---

## Changes

1. Added support for **Esc key** to abort the copy-styles mode.  

---

## Testing

- [ ] Activate the Copy Styles action.  
- [ ] Press **Esc** and confirm the mode exits immediately.  
- [ ] Ensure no styles are applied when aborting.  
- [ ] Verify that the cursor and UI return to their normal state.  