### PR TITLE
fix: remove unintended vertical scroll in workbook

### DIFF
--- a/webapp/IronCalc/src/components/FormulaBar/FormulaBar.tsx
+++ b/webapp/IronCalc/src/components/FormulaBar/FormulaBar.tsx
@@ -143,6 +143,7 @@ const Container = styled("div")`
   background: ${(properties): string =>
     properties.theme.palette.background.default};
   height: ${FORMULA_BAR_HEIGHT}px;
+  border-top: 1px solid ${theme.palette.grey["300"]};
 `;
 
 const AddressContainer = styled("div")<{ $active?: boolean }>`

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -763,7 +763,7 @@ type WorksheetAreaLeftProps = { $drawerWidth: number };
 const WorksheetAreaLeft = styled("div")<WorksheetAreaLeftProps>(
   ({ $drawerWidth }) => ({
     position: "absolute",
-    top: `${TOOLBAR_HEIGHT + 1}px`,
+    top: `${TOOLBAR_HEIGHT}px`,
     width: `calc(100% - ${$drawerWidth}px)`,
     height: `calc(100% - ${TOOLBAR_HEIGHT}px)`,
   }),


### PR DESCRIPTION
This PR fixes a small bug introduced probably by a recent change. This has added an annoying **vertical scrollbar** in the workbook, even when no scrolling was necessary. See the video for more details.

https://github.com/user-attachments/assets/6b04ae4d-9ecc-4b01-a4da-14bd6141b8c2


---

## Changes

1. Adjusted layout/overflow rules to eliminate the unwanted vertical scroll.  



---

## Testing

- [ ] Open a workbook and confirm that **no vertical scrollbar** appears when the content fits the screen.  