### PR TITLE
update: adds testing for WORKDAY, WORKDAY.INTL

### DIFF
--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -51,6 +51,7 @@ mod test_true_false;
 mod test_weekday_return_types;
 mod test_weeknum_return_types;
 mod test_workbook;
+mod test_workday_workdayintl;
 mod test_worksheet;
 mod test_yearfrac_basis;
 pub(crate) mod util;

--- a/base/src/test/test_workday_workdayintl.rs
+++ b/base/src/test/test_workday_workdayintl.rs
@@ -1,0 +1,35 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+#[test]
+fn arguments() {
+    // Day 9 Dec 2025 = serial number 46000, Tuesday, week 50
+    let mut model = new_empty_model();
+    model._set("A1", "=WORKDAY()");
+    model._set("A2", "=WORKDAY(46000)");
+    model._set("A3", "=WORKDAY(46000, 5)");
+    model._set("A4", "=WORKDAY(46000, 5, 46001)");
+    model._set("A5", "=WORKDAY(46000, 5, 46001, 2)");
+
+    model._set("B1", "=WORKDAY.INTL()");
+    model._set("B2", "=WORKDAY.INTL(46000)");
+    model._set("B3", "=WORKDAY.INTL(46000, 5)");
+    model._set("B4", "=WORKDAY.INTL(46000, 5, 11)");
+    model._set("B5", "=WORKDAY.INTL(46000, 5, 11, 46001)");
+    model._set("B6", "=WORKDAY.INTL(46000, 5, 11, 46001, 2)");
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"#ERROR!");
+    assert_eq!(model._get_text("A2"), *"#ERROR!");
+    assert_eq!(model._get_text("A3"), *"46007");
+    assert_eq!(model._get_text("A4"), *"46008");
+    assert_eq!(model._get_text("A5"), *"#ERROR!");
+
+    assert_eq!(model._get_text("B1"), *"#ERROR!");
+    assert_eq!(model._get_text("B2"), *"#ERROR!");
+    assert_eq!(model._get_text("B3"), *"46007");
+    assert_eq!(model._get_text("B4"), *"46006");
+    assert_eq!(model._get_text("B5"), *"46007");
+    assert_eq!(model._get_text("B6"), *"#ERROR!");
+}


### PR DESCRIPTION
This PR adds testing for WORKDAY and WORKDAY.INTL functions. This includes unit tests to check the number of arguments taken by the function.

This PR closes #602 

(See failing edge cases in #621 )