### PR TITLE
update: adds unit test for NETWORKDAYS, NETWORKDAYS.INTL

### DIFF
--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -41,6 +41,7 @@ mod test_model_cell_clear_all;
 mod test_model_is_empty_cell;
 mod test_move_formula;
 mod test_mround_trunc_int;
+mod test_networkdays_networkdaysintl;
 mod test_quote_prefix;
 mod test_row_column_styles;
 mod test_set_user_input;

--- a/base/src/test/test_networkdays_networkdaysintl.rs
+++ b/base/src/test/test_networkdays_networkdaysintl.rs
@@ -1,0 +1,36 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+#[test]
+fn arguments() {
+    let mut model = new_empty_model();
+    // 01/01/2025 = serial number 45658
+    // 01/01/2026 = serial number 46023
+    model._set("A1", "=NETWORKDAYS()");
+    model._set("A2", "=NETWORKDAYS(45658)");
+    model._set("A3", "=NETWORKDAYS(45658, 46023)");
+    model._set("A4", "=NETWORKDAYS(45658, 46023, 46000)");
+    model._set("A5", "=NETWORKDAYS(45658, 46023, 5, 6)");
+
+    model._set("B1", "=NETWORKDAYS.INTL()");
+    model._set("B2", "=NETWORKDAYS.INTL(45658)");
+    model._set("B3", "=NETWORKDAYS.INTL(45658, 46023)");
+    model._set("B4", "=NETWORKDAYS.INTL(45658, 46023, 5)");
+    model._set("B5", "=NETWORKDAYS.INTL(45658, 46023, 5, 46000)");
+    model._set("B6", "=NETWORKDAYS.INTL(45658, 46023, 5, 46000, 5)");
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"#ERROR!");
+    assert_eq!(model._get_text("A2"), *"#ERROR!");
+    assert_eq!(model._get_text("A3"), *"262");
+    assert_eq!(model._get_text("A4"), *"261");
+    assert_eq!(model._get_text("A5"), *"#ERROR!");
+
+    assert_eq!(model._get_text("B1"), *"#ERROR!");
+    assert_eq!(model._get_text("B2"), *"#ERROR!");
+    assert_eq!(model._get_text("B3"), *"262");
+    assert_eq!(model._get_text("B4"), *"260");
+    assert_eq!(model._get_text("B5"), *"259");
+    assert_eq!(model._get_text("B6"), *"#ERROR!");
+}


### PR DESCRIPTION
This PR adds testing for WORKDAY and WORKDAY.INTL functions. These include unit tests to check the number of arguments taken by the function.

The xlsx tests have issues that need to be fixed, as described in #624, #625 and #629

This PR closes part of #601 

