### PR TITLE
Fix running python tests on macos

### DIFF
--- a/bindings/python/run_examples.sh
+++ b/bindings/python/run_examples.sh
@@ -10,7 +10,13 @@ if [ ! -d "$EXAMPLES_DIR" ]; then
   exit 1
 fi
 
-python3 -m venv venv
+if command -v python3 &> /dev/null; then
+    PYTHON=python3
+else
+    PYTHON=python
+fi
+
+$PYTHON -m venv venv
 source venv/bin/activate
 pip install patchelf maturin pytest
 maturin develop

--- a/bindings/python/run_tests.sh
+++ b/bindings/python/run_tests.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-python3 -m venv venv
+if command -v python3 &> /dev/null; then
+    PYTHON=python3
+else
+    PYTHON=python
+fi
+
+$PYTHON -m venv venv
 source venv/bin/activate
 # Not sure why patchelf is needed
 pip install patchelf maturin pytest


### PR DESCRIPTION
Fixes running these python tests on macOS.

This all comes back to the invocation of `python`. My understanding is that explicitly invoking `python3` is the safest route here, calling `python` has somewhat undefined behavior depending on the OS (macOS doesn't include any `python` binaries, for example). For example, some versions of Ubuntu require installing the package `python-is-python3` to (as the name implies) call `python3` when `python` is invoked. See: https://askubuntu.com/questions/1296790/python-is-python3-package-in-ubuntu-20-04-what-is-it-and-what-does-it-actually

This failure was kind of being masked/hidden because these scripts didn't have `set -e`, so the initial `python` command would fail, then the script would continue running and do some odd stuff, eventually resulting in failure. So I added that flag along with a couple others I usually put in my bash scripts to do sane things.

Funnily enough, this does indicate that my stated opinion in this issue was wrong: https://github.com/ironcalc/IronCalc/issues/650#issue-3750456968
> My very finger-to-the-wind feeling is that "works on Linux" will probably imply "works on MacOS" much of the time anyway as long as the cargo build succeeds

So, does this indicate that we should run all the tests everywhere? 🤷 maybe