### PR TITLE
fix: treat leading comma as text

### DIFF
--- a/base/src/formatter/format.rs
+++ b/base/src/formatter/format.rs
@@ -928,6 +928,11 @@ fn parse_number(
     } else {
         1.0
     };
+
+    if bytes[position] == group_separator {
+        return Err("Cannot parse number".to_string());
+    }
+
     // numbers before the decimal point
     while position < len {
         let x = bytes[position];

--- a/base/src/test/test_number_format.rs
+++ b/base/src/test/test_number_format.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::unwrap_used)]
 
 use crate::number_format::format_number;
+use crate::test::util::new_empty_model;
+use crate::UserModel;
 
 #[test]
 fn test_simple_format() {
@@ -15,6 +17,28 @@ fn test_maximum_zeros() {
 
     let formatted = format_number(1234.0 + 1.0 / 3.0, "#,##0.0000000000000000000", "en");
     assert_eq!(formatted.text, "1,234.3333333333300000000".to_string());
+}
+
+#[test]
+fn test_leading_comma_text() {
+    let model = new_empty_model();
+    let mut model = UserModel::from_model(model);
+    model.set_user_input(0, 1, 1, ",10").unwrap(); // A1
+    model.set_user_input(0, 2, 1, ",100").unwrap(); // A2
+    model.set_user_input(0, 3, 1, ",1000").unwrap(); // A3
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 1),
+        Ok(",10".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok(",100".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 3, 1),
+        Ok(",1000".to_string())
+    );
 }
 
 #[test]


### PR DESCRIPTION
Prevent numbers starting with a group separator (e.g. ,100, where the digit count after the comma is a multiple of three) from being parsed as numeric.

Note that the current `parse_number` implementation does not depend on localization rules (e.g. Indian grouping like 1,00,000.00).

close #690
