### PR TITLE
initial_draft_threaded_comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "bytemuck",
  "glam",
  "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -185,6 +186,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -575,6 +577,7 @@ dependencies = [
  "serde",
  "serde_json",
  "statrs",
+ "uuid",
 ]
 
 [[package]]
@@ -1267,9 +1270,9 @@ checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -13,13 +13,15 @@ readme = "README.md"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 ryu = "1.0"
-chrono = "0.4"
+chrono = { version="0.4", features=["serde"] }
 chrono-tz = "0.10"
 regex = { version = "1.0", optional = true}
 regex-lite = { version = "0.1.6", optional = true}
-bitcode = "0.6.8"
+bitcode = {version = "0.6.8", features = ["uuid"] }
 csv = "1.3.0"
 statrs = { version = "0.18.0", default-features = false, features = [] }
+uuid = { version = "1.2.2", features = ["serde", "v4"] }
+
 
 [features]
 default = ["use_regex_full"]

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version="0.4", features=["serde"] }
 chrono-tz = "0.10"
 regex = { version = "1.0", optional = true}
 regex-lite = { version = "0.1.6", optional = true}
-bitcode = {version = "0.6.8", features = ["uuid"] }
+bitcode = {version = "0.6.8", features = ["uuid", "serde"] }
 csv = "1.3.0"
 statrs = { version = "0.18.0", default-features = false, features = [] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -69,6 +69,7 @@ impl<'a> Model<'a> {
             frozen_rows: 0,
             show_grid_lines: true,
             views,
+            threaded_comments: vec![],
         }
     }
 

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -445,6 +445,7 @@ impl<'a> Model<'a> {
             },
             tables: HashMap::new(),
             views,
+            persons: vec![],
         };
         let parsed_formulas = Vec::new();
         let worksheets = &workbook.worksheets;

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -718,25 +718,6 @@ impl Provider {
     }
 }
 
-impl TryFrom<&str> for Provider {
-    type Error = String;
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        // Note that the provider_id is under specified. Both Active Directory and Office365 use "AD" but user_id for Office365
-        // "SHOULD be comprised of three individual values separated by a "::" character delimiter."
-        // In deanm0000's experience, the format for office365 is S::<email_address>::<lower case uuid> but the spec just says
-        // should be 3 individual values but doesn't say what each represent.
-        // Since that spec is vague, and since the user_id is going to be stored as a String anyway, I am not making a Struct
-        // for each provider to hold their format of user_id
-        match value {
-            "AD" => Ok(Provider::ActiveDirectory),
-            "Windows Live" => Ok(Provider::WindowsLiveID),
-            "PeoplePicker" => Ok(Provider::PeoplePicker),
-            "None" => Ok(Provider::NoProvider),
-            _ => Err("unknown provider".to_string()),
-        }
-    }
-}
-
 impl From<Provider> for &str {
     fn from(value: Provider) -> Self {
         match value {

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -1,6 +1,5 @@
 use crate::expressions::token::Error;
 use bitcode::{Decode, Encode};
-use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
 use uuid::Uuid;
@@ -118,6 +117,7 @@ pub struct Worksheet {
     pub views: HashMap<u32, WorksheetView>,
     /// Whether or not to show the grid lines in the worksheet
     pub show_grid_lines: bool,
+    pub threaded_comments: Vec<ThreadedComment>,
 }
 
 /// Internal representation of Excel's sheet_data
@@ -750,13 +750,13 @@ impl From<Provider> for &str {
 }
 
 // https://learn.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/42f9b03d-9662-4204-9783-dbeb324a691c
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Encode, Decode, Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ThreadedComment {
     pub text: String, // Technically occurs between 0 and 1 time so maybe should use Option or Vec but in practice it's always there, if not use empty string.
     pub mentions: Vec<Mention>,
     pub ext_lst: Vec<String>,
     pub rref: Option<String>, // really named ref
-    pub dt: Option<NaiveDateTime>,
+    pub dt: Option<String>,
     pub person_id: Uuid, // this joins with the person_id in Person
     pub id: Uuid,
     pub parent_id: Option<Uuid>,
@@ -768,7 +768,7 @@ impl ThreadedComment {
         mentions: Vec<Mention>,
         ext_lst: Vec<String>,
         rref: Option<&str>,
-        dt: Option<NaiveDateTime>,
+        dt: Option<String>,
         person_id: Uuid,
         id: Uuid,
         parent_id: Option<Uuid>,
@@ -790,7 +790,7 @@ impl ThreadedComment {
 }
 
 // https://learn.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/b03ed619-e307-4d3e-9c67-b68612274128
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Encode, Decode, Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Mention {
     pub mention_person_id: Uuid,
     pub mention_id: Uuid,

--- a/xlsx/Cargo.toml
+++ b/xlsx/Cargo.toml
@@ -24,9 +24,9 @@ ironcalc_base = { path = "../base", version = "0.7" }
 itertools = "0.12"
 chrono = "0.4"
 bitcode = "0.6.8"
-
-[dev-dependencies]
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
+[dev-dependencies]
+
 
 [lib]
 name = "ironcalc"

--- a/xlsx/src/import/mod.rs
+++ b/xlsx/src/import/mod.rs
@@ -3,15 +3,16 @@ mod metadata;
 mod shared_strings;
 mod styles;
 mod tables;
+mod threaded_comments;
 mod util;
 mod workbook;
 mod worksheets;
-
 use std::{
     collections::HashMap,
     fs,
     io::{BufReader, Cursor, Read},
 };
+use threaded_comments::read_persons_from_archive;
 
 use roxmltree::Node;
 
@@ -66,6 +67,7 @@ fn load_xlsx_from_reader<R: Read + std::io::Seek>(
     let workbook = load_workbook(&mut archive)?;
     let rels = load_relationships(&mut archive)?;
     let mut tables = HashMap::new();
+    let persons = read_persons_from_archive(&mut archive)?;
     let (worksheets, selected_sheet) = load_sheets(
         &mut archive,
         &rels,
@@ -110,6 +112,7 @@ fn load_xlsx_from_reader<R: Read + std::io::Seek>(
         metadata,
         tables,
         views,
+        persons,
     })
 }
 

--- a/xlsx/src/import/threaded_comments.rs
+++ b/xlsx/src/import/threaded_comments.rs
@@ -1,0 +1,215 @@
+use std::io::Read;
+
+use chrono::NaiveDateTime;
+use ironcalc_base::types::{Mention, Person, Provider, ThreadedComment};
+use roxmltree::Node;
+use uuid::Uuid;
+
+use crate::error::XlsxError;
+
+// pub(crate) fn read_threaded_comments_and_people<R: Read + std::io::Seek>(
+//     archive: &mut zip::read::ZipArchive<R>,
+// ) -> Result<(Vec<Person>, Vec<ThreadedComment>), XlsxError> {
+//     let person_xml = "xl/persons/person.xml";
+//     let people = match archive.by_name(person_xml) {
+//         Ok(mut file) => {
+//             let mut text = String::new();
+//             file.read_to_string(&mut text)?;
+//             read_people_from_string(&text)?
+//         }
+//         Err(_e) => Vec::new(),
+//     };
+
+//     let threaded_prefix = "xl/threadedComments";
+
+//     let mut comments: Vec<ThreadedComment> = Vec::new();
+//     let mut references:
+//     for i in 0..archive.len() {
+//         let mut file = archive.by_index(i)?;
+//         if !file.name().starts_with(threaded_prefix) {
+//             continue;
+//         }
+//         let mut text = String::new();
+//         file.read_to_string(&mut text)?;
+//         let sheet_comments = read_comments_from_string(&text)?;
+//         comments.extend(sheet_comments);
+//     }
+//     Ok((people, comments))
+// }
+
+pub fn read_persons_from_archive<R: Read + std::io::Seek>(
+    archive: &mut zip::read::ZipArchive<R>,
+) -> Result<Vec<Person>, XlsxError> {
+    let person_xml = "xl/persons/person.xml";
+    match archive.by_name(person_xml) {
+        Ok(mut file) => {
+            let mut text = String::new();
+            file.read_to_string(&mut text)?;
+            read_people_from_string(&text)
+        }
+        Err(_e) => Ok(vec![]),
+    }
+}
+fn read_people_from_string(text: &str) -> Result<Vec<Person>, XlsxError> {
+    let doc = roxmltree::Document::parse(text)?;
+    let person_list_node = doc.descendants().find(|n| n.has_tag_name("personList"));
+    match person_list_node {
+        Some(person_list_node) => parse_people_from_person_list_node(person_list_node),
+        None => Ok(Vec::new()),
+    }
+}
+fn str_to_uuid(raw_str: &str) -> Result<Uuid, XlsxError> {
+    Uuid::parse_str(raw_str.trim_matches(|c| c == '{' || c == '}'))
+        .map_err(|_| XlsxError::Xml("Can't get person UUID".to_string()))
+}
+fn parse_people_from_person_list_node(person_list_node: Node) -> Result<Vec<Person>, XlsxError> {
+    let mut persons: Vec<Person> = Vec::new();
+    for person_node in person_list_node
+        .children()
+        .filter(|n| n.has_tag_name("person"))
+    {
+        let display_name = person_node.attribute("displayName").unwrap_or_default();
+        let raw_id = person_node.attribute("id").unwrap_or_default();
+        let person_id = str_to_uuid(raw_id)?;
+
+        let user_id = person_node.attribute("userId");
+
+        let provider_str = person_node.attribute("provider").unwrap_or("Other");
+        let provider = Provider::from_str_and_user_id(provider_str, user_id)
+            .map_err(|e| XlsxError::Xml(e.to_string()))?;
+        let mut ext_lst = Vec::new();
+        if let Some(ext_lst_node) = person_node.children().find(|n| n.has_tag_name("extLst")) {
+            for ext in ext_lst_node.children().filter(|n| n.is_element()) {
+                if let Some(text) = ext.text() {
+                    ext_lst.push(text.to_string());
+                }
+            }
+        }
+        persons.push(Person::new(
+            ext_lst,
+            display_name,
+            person_id,
+            user_id,
+            provider,
+        ))
+    }
+    Ok(persons)
+}
+
+pub fn read_threaded_from_archive<R: Read + std::io::Seek>(
+    archive: &mut zip::read::ZipArchive<R>,
+    path: &str,
+) -> Result<Vec<ThreadedComment>, XlsxError> {
+    match archive.by_name(path) {
+        Ok(mut file) => {
+            let mut text = String::new();
+            file.read_to_string(&mut text)?;
+            read_comments_from_string(&text)
+        }
+        Err(_e) => Ok(vec![]),
+    }
+}
+fn read_comments_from_string(text: &str) -> Result<Vec<ThreadedComment>, XlsxError> {
+    let doc = roxmltree::Document::parse(text)?;
+    let comment_list_node = doc
+        .descendants()
+        .find(|n| n.has_tag_name("ThreadedComments"));
+    match comment_list_node {
+        Some(comment_list_node) => parse_comments_from_comment_list_node(comment_list_node),
+        None => Ok(vec![]),
+    }
+}
+
+fn parse_comments_from_comment_list_node(
+    comment_list_node: Node,
+) -> Result<Vec<ThreadedComment>, XlsxError> {
+    let mut threaded: Vec<ThreadedComment> = Vec::new();
+    for comment_node in comment_list_node
+        .children()
+        .filter(|n| n.has_tag_name("threadedComment"))
+    {
+        let rref = comment_node.attribute("ref");
+        let dt = comment_node
+            .attribute("dT")
+            .and_then(|dt| NaiveDateTime::parse_from_str(dt, "%Y-%m-%dT%H:%M:%S%.f").ok());
+        let person_id = comment_node
+            .attribute("personId")
+            .ok_or_else(|| XlsxError::Xml("Missing personId attribute".to_string()))
+            .and_then(|p| str_to_uuid(p))?;
+        let id = comment_node
+            .attribute("id")
+            .ok_or_else(|| XlsxError::Xml("Missing personId attribute".to_string()))
+            .and_then(|p| str_to_uuid(p))?;
+        let done = comment_node
+            .attribute("id")
+            .map(|p| p.to_lowercase() == "true");
+        let parent_id = comment_node
+            .attribute("parentId")
+            .and_then(|p| str_to_uuid(p).ok());
+        let mut ext_lst = vec![];
+        if let Some(ext_lst_node) = comment_node.children().find(|n| n.has_tag_name("extLst")) {
+            for ext in ext_lst_node.children().filter(|n| n.is_element()) {
+                if let Some(text) = ext.text() {
+                    ext_lst.push(text.to_string());
+                }
+            }
+        }
+
+        let text = {
+            if let Some(text_node) = comment_node.children().find(|n| n.has_tag_name("text")) {
+                if let Some(txt) = text_node.text() {
+                    txt.to_string()
+                } else {
+                    "".to_string()
+                }
+            } else {
+                "".to_string()
+            }
+        };
+        let mentions = parse_mentions_from_comment_node(comment_node)?;
+        threaded.push(ThreadedComment::new(
+            text, mentions, ext_lst, rref, dt, person_id, id, parent_id, done,
+        ))
+    }
+    Ok(vec![])
+}
+
+fn parse_mentions_from_comment_node(comment_node: Node) -> Result<Vec<Mention>, XlsxError> {
+    match comment_node.children().find(|n| n.has_tag_name("mentions")) {
+        Some(mentions_node) => {
+            let mut mentions: Vec<Mention> = vec![];
+            for mention_node in mentions_node.children() {
+                let mention_person_id = mention_node
+                    .attribute("mentionpersonId")
+                    .ok_or_else(|| XlsxError::Xml("Missing mentionpersonId attribute".to_string()))
+                    .and_then(|p| str_to_uuid(p))?;
+                let mention_id = mention_node
+                    .attribute("mentionId")
+                    .ok_or_else(|| XlsxError::Xml("Missing mentionId attribute".to_string()))
+                    .and_then(|p| str_to_uuid(p))?;
+                let start_index = mention_node
+                    .attribute("startIndex")
+                    .ok_or_else(|| XlsxError::Xml("Missing startIndex attribute".to_string()))
+                    .and_then(|p| {
+                        p.parse::<u32>()
+                            .map_err(|_| XlsxError::Xml("Can't make u32".to_string()))
+                    })?;
+                let length = mention_node
+                    .attribute("length")
+                    .ok_or_else(|| XlsxError::Xml("Missing length attribute".to_string()))
+                    .and_then(|p| {
+                        p.parse::<u32>()
+                            .map_err(|_| XlsxError::Xml("Can't make u32".to_string()))
+                    })?;
+                mentions.push(Mention::new(
+                    mention_person_id,
+                    mention_id,
+                    start_index,
+                    length,
+                ))
+            }
+            Ok(mentions)
+        }
+        None => Ok(vec![]),
+    }
+}

--- a/xlsx/src/import/threaded_comments.rs
+++ b/xlsx/src/import/threaded_comments.rs
@@ -1,41 +1,9 @@
-use std::io::Read;
-
-use chrono::NaiveDateTime;
 use ironcalc_base::types::{Mention, Person, Provider, ThreadedComment};
 use roxmltree::Node;
+use std::io::Read;
 use uuid::Uuid;
 
 use crate::error::XlsxError;
-
-// pub(crate) fn read_threaded_comments_and_people<R: Read + std::io::Seek>(
-//     archive: &mut zip::read::ZipArchive<R>,
-// ) -> Result<(Vec<Person>, Vec<ThreadedComment>), XlsxError> {
-//     let person_xml = "xl/persons/person.xml";
-//     let people = match archive.by_name(person_xml) {
-//         Ok(mut file) => {
-//             let mut text = String::new();
-//             file.read_to_string(&mut text)?;
-//             read_people_from_string(&text)?
-//         }
-//         Err(_e) => Vec::new(),
-//     };
-
-//     let threaded_prefix = "xl/threadedComments";
-
-//     let mut comments: Vec<ThreadedComment> = Vec::new();
-//     let mut references:
-//     for i in 0..archive.len() {
-//         let mut file = archive.by_index(i)?;
-//         if !file.name().starts_with(threaded_prefix) {
-//             continue;
-//         }
-//         let mut text = String::new();
-//         file.read_to_string(&mut text)?;
-//         let sheet_comments = read_comments_from_string(&text)?;
-//         comments.extend(sheet_comments);
-//     }
-//     Ok((people, comments))
-// }
 
 pub fn read_persons_from_archive<R: Read + std::io::Seek>(
     archive: &mut zip::read::ZipArchive<R>,
@@ -129,9 +97,7 @@ fn parse_comments_from_comment_list_node(
         .filter(|n| n.has_tag_name("threadedComment"))
     {
         let rref = comment_node.attribute("ref");
-        let dt = comment_node
-            .attribute("dT")
-            .and_then(|dt| NaiveDateTime::parse_from_str(dt, "%Y-%m-%dT%H:%M:%S%.f").ok());
+        let dt = comment_node.attribute("dT").map(|dt| dt.to_string());
         let person_id = comment_node
             .attribute("personId")
             .ok_or_else(|| XlsxError::Xml("Missing personId attribute".to_string()))

--- a/xlsx/src/import/worksheets.rs
+++ b/xlsx/src/import/worksheets.rs
@@ -714,6 +714,7 @@ pub(super) fn load_sheet<R: Read + std::io::Seek>(
     tables: &HashMap<String, Table>,
     shared_strings: &mut Vec<String>,
     defined_names: Vec<DefinedNameS>,
+    threaded_comments: Vec<ThreadedComment>,
 ) -> Result<(Worksheet, bool), XlsxError> {
     let sheet_name = &settings.name;
     let sheet_id = settings.id;
@@ -1058,6 +1059,7 @@ pub(super) fn load_sheet<R: Read + std::io::Seek>(
             frozen_columns: sheet_view.frozen_columns,
             show_grid_lines: sheet_view.show_grid_lines,
             views,
+            threaded_comments,
         },
         sheet_view.is_selected,
     ))
@@ -1100,6 +1102,7 @@ pub(super) fn load_sheets<R: Read + std::io::Seek>(
         let rel_id = &sheet.id;
         let state = &sheet.state;
         let rel = &rels[rel_id];
+        let sheet_threaded = threaded.remove(&sheet.id).unwrap_or_default();
         if rel.rel_type.ends_with("worksheet") {
             let path = &rel.target;
             let path = if let Some(p) = path.strip_prefix('/') {
@@ -1124,6 +1127,7 @@ pub(super) fn load_sheets<R: Read + std::io::Seek>(
                 tables,
                 shared_strings,
                 defined_names.clone(),
+                sheet_threaded,
             )?;
             if is_selected {
                 selected_sheet = sheet_index;


### PR DESCRIPTION
working on https://github.com/ironcalc/IronCalc/issues/295

I did a drive-by refactor on the `load_sheet_rels` function. It was both returning a value and mutating an input. To keep from iterating on the same rel files twice, I needed to add my bit to it which meant another thing it'd be mutating along the way. Rather than having it mutate two variables while returning values for the third, I just made it mutate 3 variables and have no value returned.

Progress:
Made structs/enums for threaded comments and its related fields.
Added those structs to Workbook and Worksheet
Parses the xml of xlsx file to create them

To Do:
add methods for users to read, edit, add threaded comments
save threaded comments back to a file

Stumbling blocks:
I couldn't figure out how to do Encode, Decode on NaiveDateTime so that's just stored as a String. To get Encode, Decode to work on uuid I had to add features to 