### PR TITLE
update: add testing for CHISQ functions

### DIFF
--- a/base/src/test/statistical/test_fn_chisq.rs
+++ b/base/src/test/statistical/test_fn_chisq.rs
@@ -171,3 +171,52 @@ fn test_booleans() {
     assert_eq!(model._get_text("A3"), "0.008150972");
     assert_eq!(model._get_text("A4"), "7");
 }
+
+#[test]
+fn test_arguments() {
+    let mut model = new_empty_model();
+
+    model._set("A1", "=CHISQ.DIST()");
+    model._set("A2", "=CHISQ.DIST(8)");
+    model._set("A3", "=CHISQ.DIST(8, 3)");
+    model._set("A4", "=CHISQ.DIST(8, 3, TRUE)");
+    model._set("A5", "=CHISQ.DIST(8, 3, TRUE, 2)");
+
+    model._set("B1", "=CHISQ.INV()");
+    model._set("B2", "=CHISQ.INV(0)");
+    model._set("B3", "=CHISQ.INV(A4, 3)");
+    model._set("B4", "=CHISQ.INV(0, 1, 2)");
+
+    model._set("C1", "=CHISQ.DIST.RT()");
+    model._set("C2", "=CHISQ.DIST.RT(8)");
+    model._set("C3", "=CHISQ.DIST.RT(8, 3)");
+    model._set("C4", "=CHISQ.DIST.RT(8, 3, 2)");
+
+    model._set("D1", "=CHISQ.INV.RT()");
+    model._set("D2", "=CHISQ.INV.RT(0)");
+    model._set("D3", "=CHISQ.INV.RT(C3, 3)");
+    model._set("D4", "=CHISQ.INV.RT(0, 1, 2)");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), "#ERROR!");
+    assert_eq!(model._get_text("A2"), "#ERROR!");
+    assert_eq!(model._get_text("A3"), "#ERROR!");
+    assert_eq!(model._get_text("A4"), "0.953988294");
+    assert_eq!(model._get_text("A5"), "#ERROR!");
+
+    assert_eq!(model._get_text("B1"), "#ERROR!");
+    assert_eq!(model._get_text("B2"), "#ERROR!");
+    assert_eq!(model._get_text("B3"), "8");
+    assert_eq!(model._get_text("B4"), "#ERROR!");
+
+    assert_eq!(model._get_text("C1"), "#ERROR!");
+    assert_eq!(model._get_text("C2"), "#ERROR!");
+    assert_eq!(model._get_text("C3"), "0.046011706");
+    assert_eq!(model._get_text("C4"), "#ERROR!");
+
+    assert_eq!(model._get_text("D1"), "#ERROR!");
+    assert_eq!(model._get_text("D2"), "#ERROR!");
+    assert_eq!(model._get_text("D3"), "8");
+    assert_eq!(model._get_text("D4"), "#ERROR!");
+}

--- a/base/src/test/statistical/test_fn_chisq_test.rs
+++ b/base/src/test/statistical/test_fn_chisq_test.rs
@@ -125,3 +125,24 @@ fn ranges_1d() {
     assert_eq!(model._get_text("G1"), *"0.062349477");
     assert_eq!(model._get_text("G2"), *"0.000261259");
 }
+
+#[test]
+fn arguments() {
+    let mut model = new_empty_model();
+
+    model._set("A1", "1");
+    model._set("A2", "2");
+    model._set("A3", "3");
+    model._set("B1", "4");
+    model._set("B2", "5");
+    model._set("B3", "6");
+
+    model._set("C1", "=CHISQ.TEST()");
+    model._set("C2", "=CHISQ.TEST(A1:B3)");
+    model._set("C3", "=CHISQ.TEST(A1:A3, B1:B3)");
+
+    model.evaluate();
+    assert_eq!(model._get_text("C1"), *"#ERROR!");
+    assert_eq!(model._get_text("C2"), *"#ERROR!");
+    assert_eq!(model._get_text("C3"), *"0.006234947");
+}

--- a/base/src/test/statistical/test_fn_chisq_test.rs
+++ b/base/src/test/statistical/test_fn_chisq_test.rs
@@ -144,5 +144,5 @@ fn arguments() {
     model.evaluate();
     assert_eq!(model._get_text("C1"), *"#ERROR!");
     assert_eq!(model._get_text("C2"), *"#ERROR!");
-    assert_eq!(model._get_text("C3"), *"0.006234947");
+    assert_eq!(model._get_text("C3"), *"0.062349477");
 }


### PR DESCRIPTION
This PR adds testing for the CHISQ set of functions: CHISQ.DIST, CHISQ.INV, CHISQ.DIST.RT, CHISQ.INV,RT and CHISQ.TEST. More specifically, an argument test was added to make sure the correct number of arguments is passed to the function. 

While testing, some issues with the CHISQ.TEST function were found and described in #763 
Issues with the other CHISQ functions can be found in #733 

This PR closes #588