### PR TITLE
Fix/issue 761 locale date edit

### DIFF
--- a/base/src/constants.rs
+++ b/base/src/constants.rs
@@ -26,3 +26,13 @@ pub(crate) const MINIMUM_DATE_SERIAL_NUMBER: i32 = 1;
 // Excel can handle dates until the year 9999-12-31
 // 2958465 is the number of days from 1900-01-01 to 9999-12-31
 pub(crate) const MAXIMUM_DATE_SERIAL_NUMBER: i32 = 2_958_465;
+
+// https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/0e59abdb-7f4e-48fc-9b89-67832fa11789
+/// Locale short date numFmtId: 14
+pub(crate) const SHORT_DATE_ID: i32 = 14;
+/// Locale short date+time numFmt id: 22
+pub(crate) const SHORT_DATETIME_ID: i32 = 22;
+
+/// ECMA-376 §18.8.30: custom numFmtIds must be ≥ 164.
+/// IDs 0–163 are reserved for built-in formats; assigning lower IDs corrupts XLSX readers.
+pub(crate) const ECMA_CUSTOM_FMT_MIN_ID: i32 = 164;

--- a/base/src/expressions/lexer/mod.rs
+++ b/base/src/expressions/lexer/mod.rs
@@ -387,9 +387,7 @@ impl<'a> Lexer<'a> {
                                         ));
                                     }
                                     return TokenType::Ident(name);
-                                } else if !name.is_ascii() {
-                                    // Non-ASCII identifier (e.g. =ä, =ы): pass through as Ident so the
-                                    // evaluator produces #NAME? instead of #ERROR! — matching Excel.
+                                } else if !utils::non_latin(&name) {
                                     // Same handling added for R1C1 below
                                     return TokenType::Ident(name);
                                 } else {
@@ -406,7 +404,9 @@ impl<'a> Lexer<'a> {
                                     Ok(ParsedRange { left, right }) => {
                                         if pos > self.position {
                                             self.position = pos;
-                                            if utils::is_valid_identifier(&name) | !name.is_ascii() {
+                                            if utils::is_valid_identifier(&name)
+                                                || utils::non_latin(&name)
+                                            {
                                                 return TokenType::Ident(name);
                                             } else {
                                                 self.position = self.len;
@@ -449,7 +449,9 @@ impl<'a> Lexer<'a> {
                                         }
                                         self.position = pos;
 
-                                        if utils::is_valid_identifier(&name) | !name.is_ascii(){
+                                        if utils::is_valid_identifier(&name)
+                                            || utils::non_latin(&name)
+                                        {
                                             return TokenType::Ident(name);
                                         } else {
                                             return TokenType::Illegal(self.set_error(

--- a/base/src/expressions/lexer/mod.rs
+++ b/base/src/expressions/lexer/mod.rs
@@ -387,6 +387,11 @@ impl<'a> Lexer<'a> {
                                         ));
                                     }
                                     return TokenType::Ident(name);
+                                } else if name.chars().any(|c| !c.is_ascii()) {
+                                    // Non-ASCII identifier (e.g. =ä, =ы): pass through as Ident so the
+                                    // evaluator produces #NAME? instead of #ERROR! — matching Excel.
+                                    // Same handling added for R1C1 below
+                                    return TokenType::Ident(name);
                                 } else {
                                     return TokenType::Illegal(
                                         self.set_error("Invalid identifier (A1)", self.position),
@@ -402,6 +407,8 @@ impl<'a> Lexer<'a> {
                                         if pos > self.position {
                                             self.position = pos;
                                             if utils::is_valid_identifier(&name) {
+                                                return TokenType::Ident(name);
+                                            } else if name.chars().any(|c| !c.is_ascii()) {
                                                 return TokenType::Ident(name);
                                             } else {
                                                 self.position = self.len;
@@ -445,6 +452,8 @@ impl<'a> Lexer<'a> {
                                         self.position = pos;
 
                                         if utils::is_valid_identifier(&name) {
+                                            return TokenType::Ident(name);
+                                        } else if name.chars().any(|c| !c.is_ascii()) {
                                             return TokenType::Ident(name);
                                         } else {
                                             return TokenType::Illegal(self.set_error(

--- a/base/src/expressions/lexer/mod.rs
+++ b/base/src/expressions/lexer/mod.rs
@@ -387,7 +387,7 @@ impl<'a> Lexer<'a> {
                                         ));
                                     }
                                     return TokenType::Ident(name);
-                                } else if name.chars().any(|c| !c.is_ascii()) {
+                                } else if !name.is_ascii() {
                                     // Non-ASCII identifier (e.g. =ä, =ы): pass through as Ident so the
                                     // evaluator produces #NAME? instead of #ERROR! — matching Excel.
                                     // Same handling added for R1C1 below
@@ -406,9 +406,7 @@ impl<'a> Lexer<'a> {
                                     Ok(ParsedRange { left, right }) => {
                                         if pos > self.position {
                                             self.position = pos;
-                                            if utils::is_valid_identifier(&name) {
-                                                return TokenType::Ident(name);
-                                            } else if name.chars().any(|c| !c.is_ascii()) {
+                                            if utils::is_valid_identifier(&name) | !name.is_ascii() {
                                                 return TokenType::Ident(name);
                                             } else {
                                                 self.position = self.len;
@@ -451,9 +449,7 @@ impl<'a> Lexer<'a> {
                                         }
                                         self.position = pos;
 
-                                        if utils::is_valid_identifier(&name) {
-                                            return TokenType::Ident(name);
-                                        } else if name.chars().any(|c| !c.is_ascii()) {
+                                        if utils::is_valid_identifier(&name) | !name.is_ascii(){
                                             return TokenType::Ident(name);
                                         } else {
                                             return TokenType::Illegal(self.set_error(

--- a/base/src/expressions/lexer/mod.rs
+++ b/base/src/expressions/lexer/mod.rs
@@ -387,7 +387,7 @@ impl<'a> Lexer<'a> {
                                         ));
                                     }
                                     return TokenType::Ident(name);
-                                } else if !utils::non_latin(&name) {
+                                } else if !name.is_ascii() {
                                     // Same handling added for R1C1 below
                                     return TokenType::Ident(name);
                                 } else {
@@ -404,9 +404,7 @@ impl<'a> Lexer<'a> {
                                     Ok(ParsedRange { left, right }) => {
                                         if pos > self.position {
                                             self.position = pos;
-                                            if utils::is_valid_identifier(&name)
-                                                || utils::non_latin(&name)
-                                            {
+                                            if utils::is_valid_non_latin(&name) {
                                                 return TokenType::Ident(name);
                                             } else {
                                                 self.position = self.len;
@@ -449,9 +447,7 @@ impl<'a> Lexer<'a> {
                                         }
                                         self.position = pos;
 
-                                        if utils::is_valid_identifier(&name)
-                                            || utils::non_latin(&name)
-                                        {
+                                        if utils::is_valid_non_latin(&name) {
                                             return TokenType::Ident(name);
                                         } else {
                                             return TokenType::Illegal(self.set_error(

--- a/base/src/expressions/utils/mod.rs
+++ b/base/src/expressions/utils/mod.rs
@@ -253,8 +253,8 @@ pub fn is_valid_identifier(name: &str) -> bool {
 // Non-ASCII identifier (e.g. =ä, =ы): pass through as Ident so the
 // evaluator produces #NAME? instead of #ERROR! — matching Excel.
 /// Returns `true` for non-Latin characters (e.g., =ä or =ы)
-pub fn non_latin(name: &str) -> bool {
-    name.is_ascii()
+pub fn is_valid_non_latin(name: &str) -> bool {
+    !name.is_ascii() || is_valid_identifier(name)
 }
 
 fn name_needs_quoting(name: &str) -> bool {

--- a/base/src/expressions/utils/mod.rs
+++ b/base/src/expressions/utils/mod.rs
@@ -250,6 +250,13 @@ pub fn is_valid_identifier(name: &str) -> bool {
     true
 }
 
+// Non-ASCII identifier (e.g. =ä, =ы): pass through as Ident so the
+// evaluator produces #NAME? instead of #ERROR! — matching Excel.
+/// Returns `true` for non-Latin characters (e.g., =ä or =ы)
+pub fn non_latin(name: &str) -> bool {
+    name.is_ascii()
+}
+
 fn name_needs_quoting(name: &str) -> bool {
     let chars = name.chars();
     // it contains any of these characters: ()'$,;-+{} or space

--- a/base/src/formatter/format.rs
+++ b/base/src/formatter/format.rs
@@ -788,8 +788,7 @@ fn parse_date(value: &str, locale: &Locale) -> Result<(i32, Option<String>), Str
             (parts[2], parts[1], parts[0])
         } else {
             //  localized date dd-mm-yyyy or mm-dd-yyyy
-            // TODO: A bit hacky, but works for now
-            if locale.dates.date_formats.short.starts_with('d') {
+            if locale.day_first() {
                 (parts[0], parts[1], parts[2])
             } else {
                 (parts[1], parts[0], parts[2])

--- a/base/src/formatter/format.rs
+++ b/base/src/formatter/format.rs
@@ -831,7 +831,7 @@ fn parse_date(value: &str, locale: &Locale) -> Result<(i32, Option<String>), Str
 ///
 /// Examples:
 /// - `"$ 123,345.678"` → `(123345.678, Some(Literal("$#,##0.00")))`
-/// - `"30.34%"`        → `(0.3034,     Some(Literal("0.00%")))`
+/// - `"30.34%"`        → `(0.3034,     Some(Literal(#,##0.00%")))`
 /// - `"11/1/2026"` (en)→ `(serial,     Some(LocaleDate))`
 /// - `"2026-11-01"`    → `(serial,     Some(Literal("yyyy-mm-dd")))`
 pub(crate) fn parse_formatted_number(

--- a/base/src/formatter/format.rs
+++ b/base/src/formatter/format.rs
@@ -1,6 +1,9 @@
 use chrono::Datelike;
 
-use crate::{locale::Locale, number_format::to_precision};
+use crate::{
+    locale::Locale,
+    number_format::{to_precision, DefaultFmts},
+};
 
 use super::{
     dates::{date_to_serial_number, from_excel_date},
@@ -812,13 +815,13 @@ fn parse_date(value: &str, locale: &Locale) -> Result<(i32, Option<String>), Str
 }
 
 /// Parses a formatted number; returns the value and [`NumFmtSpec`] to apply, or `Err`.
+/// TODO: Add DefaultFmts
 pub(crate) fn parse_formatted_number(
     original: &str,
     currencies: &[&str],
     locale: &Locale,
 ) -> Result<(f64, Option<NumFmtSpec>), String> {
     let value = original.trim();
-    let scientific_format = "0.00E+00";
 
     let (decimal_separator, group_separator) = if locale.numbers.symbols.decimal == "," {
         (b',', b'.')
@@ -832,7 +835,7 @@ pub(crate) fn parse_formatted_number(
         if options.is_scientific {
             return Ok((
                 f / 100.0,
-                Some(NumFmtSpec::Literal(scientific_format.to_string())),
+                Some(NumFmtSpec::Literal(DefaultFmts::scientific_format())),
             ));
         }
         // We ignore the separator
@@ -840,11 +843,14 @@ pub(crate) fn parse_formatted_number(
             // Percentage format with decimals
             return Ok((
                 f / 100.0,
-                Some(NumFmtSpec::Literal("#,##0.00%".to_string())),
+                Some(NumFmtSpec::Literal(DefaultFmts::percent_dec())),
             ));
         }
         // Percentage format standard
-        return Ok((f / 100.0, Some(NumFmtSpec::Literal("#,##0%".to_string()))));
+        return Ok((
+            f / 100.0,
+            Some(NumFmtSpec::Literal(DefaultFmts::percent_int())),
+        ));
     }
 
     // check if it is a currency in currencies
@@ -852,31 +858,64 @@ pub(crate) fn parse_formatted_number(
         if let Some(p) = value.strip_prefix(&format!("-{currency}")) {
             let (f, options) = parse_number(p.trim(), decimal_separator, group_separator)?;
             if options.is_scientific {
-                return Ok((f, Some(NumFmtSpec::Literal(scientific_format.to_string()))));
+                return Ok((
+                    f,
+                    Some(NumFmtSpec::Literal(DefaultFmts::scientific_format())),
+                ));
             }
             if options.decimal_digits > 0 {
-                return Ok((-f, Some(NumFmtSpec::Literal(format!("{currency}#,##0.00")))));
+                return Ok((
+                    -f,
+                    Some(NumFmtSpec::Literal(format!(
+                        "{currency}{}",
+                        DefaultFmts::comma_dec()
+                    ))),
+                ));
             }
-            return Ok((-f, Some(NumFmtSpec::Literal(format!("{currency}#,##0")))));
+            return Ok((
+                -f,
+                Some(NumFmtSpec::Literal(format!(
+                    "{currency}{}",
+                    DefaultFmts::comma_int()
+                ))),
+            ));
         } else if let Some(p) = value.strip_prefix(currency) {
             let (f, options) = parse_number(p.trim(), decimal_separator, group_separator)?;
             if options.is_scientific {
-                return Ok((f, Some(NumFmtSpec::Literal(scientific_format.to_string()))));
+                return Ok((
+                    f,
+                    Some(NumFmtSpec::Literal(DefaultFmts::scientific_format())),
+                ));
             }
             if options.decimal_digits > 0 {
-                return Ok((f, Some(NumFmtSpec::Literal(format!("{currency}#,##0.00")))));
+                return Ok((
+                    f,
+                    Some(NumFmtSpec::Literal(format!(
+                        "{currency}{}",
+                        DefaultFmts::comma_dec()
+                    ))),
+                ));
             }
-            return Ok((f, Some(NumFmtSpec::Literal(format!("{currency}#,##0")))));
+            return Ok((
+                f,
+                Some(NumFmtSpec::Literal(format!(
+                    "{currency}{}",
+                    DefaultFmts::comma_int()
+                ))),
+            ));
         } else if let Some(p) = value.strip_suffix(currency) {
             let (f, options) = parse_number(p.trim(), decimal_separator, group_separator)?;
             if options.is_scientific {
-                return Ok((f, Some(NumFmtSpec::Literal(scientific_format.to_string()))));
+                return Ok((
+                    f,
+                    Some(NumFmtSpec::Literal(DefaultFmts::scientific_format())),
+                ));
             }
             if options.decimal_digits > 0 {
-                let currency_format = format!("#,##0.00{currency}");
+                let currency_format = format!("{}{currency}", DefaultFmts::comma_dec());
                 return Ok((f, Some(NumFmtSpec::Literal(currency_format))));
             }
-            let currency_format = format!("#,##0{currency}");
+            let currency_format = format!("{}{currency}", DefaultFmts::comma_int());
             return Ok((f, Some(NumFmtSpec::Literal(currency_format))));
         }
     }
@@ -893,15 +932,18 @@ pub(crate) fn parse_formatted_number(
     // Lastly we check if it is a number
     let (f, options) = parse_number(value, decimal_separator, group_separator)?;
     if options.is_scientific {
-        return Ok((f, Some(NumFmtSpec::Literal(scientific_format.to_string()))));
+        return Ok((
+            f,
+            Some(NumFmtSpec::Literal(DefaultFmts::scientific_format())),
+        ));
     }
     if options.has_commas {
         if options.decimal_digits > 0 {
             // group separator and two decimal points
-            return Ok((f, Some(NumFmtSpec::Literal("#,##0.00".to_string()))));
+            return Ok((f, Some(NumFmtSpec::Literal(DefaultFmts::comma_dec()))));
         }
         // Group separator and no decimal points
-        return Ok((f, Some(NumFmtSpec::Literal("#,##0".to_string()))));
+        return Ok((f, Some(NumFmtSpec::Literal(DefaultFmts::comma_int()))));
     }
     Ok((f, None))
 }

--- a/base/src/formatter/format.rs
+++ b/base/src/formatter/format.rs
@@ -3,6 +3,7 @@ use chrono::Datelike;
 use crate::{
     locale::Locale,
     number_format::{to_precision, DefaultFmts},
+    types::NumFmtSpec,
 };
 
 use super::{
@@ -747,16 +748,7 @@ fn parse_year(year_str: &str) -> Result<(i32, String), String> {
 //
 // NOTE 1: The separator has to be the same
 // NOTE 2: In some engines "2/3" is implemented ad "2/March of the present year"
-// NOTE 3: I did not implement the "short date"
-/// Number format to apply when storing a parsed cell value.
-/// No `LocaleDateTime` variant: numFmtId 22 is set only by formula evaluation, not user input.
-#[derive(Debug, PartialEq)]
-pub(crate) enum NumFmtSpec {
-    /// Locale short date (numFmtId 14).
-    LocaleDate,
-    /// A literal format string (ISO dates, currency, percent, …).
-    Literal(String),
-}
+// [x] NOTE 3: I did not implement the "short date"
 
 fn parse_date(value: &str, locale: &Locale) -> Result<(i32, Option<String>), String> {
     let separator = if value.contains('/') {
@@ -815,7 +807,6 @@ fn parse_date(value: &str, locale: &Locale) -> Result<(i32, Option<String>), Str
 }
 
 /// Parses a formatted number; returns the value and [`NumFmtSpec`] to apply, or `Err`.
-/// TODO: Add DefaultFmts
 pub(crate) fn parse_formatted_number(
     original: &str,
     currencies: &[&str],

--- a/base/src/formatter/format.rs
+++ b/base/src/formatter/format.rs
@@ -745,29 +745,16 @@ fn parse_year(year_str: &str) -> Result<(i32, String), String> {
 // NOTE 1: The separator has to be the same
 // NOTE 2: In some engines "2/3" is implemented ad "2/March of the present year"
 // NOTE 3: I did not implement the "short date"
-/// Describes the number format that should be applied to a parsed value.
-///
-/// `LocaleDate` means "store as `LOCALE_SHORT_DATE_FMT_ID` (14)": the cell
-/// renders with the *current locale's* short date format rather than any
-/// literal format string.  All other formats are stored as literal strings.
-///
-/// Note: there is intentionally no `LocaleDateTime` variant here.  numFmtId 22
-/// (locale short date+time) is only ever assigned by formula evaluation (NOW,
-/// EDATE, WORKDAY, …) via `Units::LocaleDateTime` → `get_style_with_num_fmt_id`.
-/// User input never produces a bare date+time token that would resolve to ID 22,
-/// so the parse path only needs `LocaleDate`.
+/// Number format to apply when storing a parsed cell value.
+/// No `LocaleDateTime` variant: numFmtId 22 is set only by formula evaluation, not user input.
 #[derive(Debug, PartialEq)]
 pub(crate) enum NumFmtSpec {
-    /// Simple locale date — store as numFmtId 14 (`LOCALE_SHORT_DATE_FMT_ID`).
+    /// Locale short date (numFmtId 14).
     LocaleDate,
-    /// A specific literal format string (ISO dates, currency, percent, …).
+    /// A literal format string (ISO dates, currency, percent, …).
     Literal(String),
 }
 
-/// Returns the serial number for a date string together with the format hint.
-///
-/// - ISO dates (`yyyy-…`) → `Some(literal_format)` — locale-independent.
-/// - All other recognised dates → `None` — caller stores as `LOCALE_SHORT_DATE_FMT_ID`.
 fn parse_date(value: &str, locale: &Locale) -> Result<(i32, Option<String>), String> {
     let separator = if value.contains('/') {
         '/'
@@ -811,7 +798,7 @@ fn parse_date(value: &str, locale: &Locale) -> Result<(i32, Option<String>), Str
         Err(_) => return Err("Not a valid date".to_string()),
     };
     if is_iso_date {
-        // ISO dates are locale-independent — preserve the exact format string.
+        // ISO date — locale-independent; preserve the literal format string.
         Ok((
             serial_number,
             Some(format!(
@@ -819,26 +806,12 @@ fn parse_date(value: &str, locale: &Locale) -> Result<(i32, Option<String>), Str
             )),
         ))
     } else {
-        // Simple locale date: signal to the caller to store as LOCALE_SHORT_DATE_FMT_ID.
-        // The day_first / day_format values were used only for serial-number parsing;
-        // the display format is entirely locale-derived at render time.
+        // Simple locale date: caller stores as numFmtId 14.
         Ok((serial_number, None))
     }
 }
 
-/// Parses a formatted number, returning the numeric value together with a
-/// [`NumFmtSpec`] that describes how the value should be stored.
-///
-/// - `None`  → plain number, leave the cell's existing format unchanged.
-/// - `Some(NumFmtSpec::LocaleDate)`  → simple date; store as numFmtId 14.
-/// - `Some(NumFmtSpec::Literal(s))` → explicit format string (ISO dates,
-///   currency, percentage, …).
-///
-/// Examples:
-/// - `"$ 123,345.678"` → `(123345.678, Some(Literal("$#,##0.00")))`
-/// - `"30.34%"`        → `(0.3034,     Some(Literal(#,##0.00%")))`
-/// - `"11/1/2026"` (en)→ `(serial,     Some(LocaleDate))`
-/// - `"2026-11-01"`    → `(serial,     Some(Literal("yyyy-mm-dd")))`
+/// Parses a formatted number; returns the value and [`NumFmtSpec`] to apply, or `Err`.
 pub(crate) fn parse_formatted_number(
     original: &str,
     currencies: &[&str],
@@ -911,9 +884,7 @@ pub(crate) fn parse_formatted_number(
     // check if it is a date. NOTE: we don't trim the original here
     if let Ok((serial_number, fmt_opt)) = parse_date(original, locale) {
         let spec = match fmt_opt {
-            // ISO date — preserve the literal format string (e.g. "yyyy-mm-dd").
             Some(fmt) => NumFmtSpec::Literal(fmt),
-            // Simple locale date — caller stores as LOCALE_SHORT_DATE_FMT_ID (14).
             None => NumFmtSpec::LocaleDate,
         };
         return Ok((serial_number as f64, Some(spec)));

--- a/base/src/formatter/format.rs
+++ b/base/src/formatter/format.rs
@@ -750,6 +750,12 @@ fn parse_year(year_str: &str) -> Result<(i32, String), String> {
 /// `LocaleDate` means "store as `LOCALE_SHORT_DATE_FMT_ID` (14)": the cell
 /// renders with the *current locale's* short date format rather than any
 /// literal format string.  All other formats are stored as literal strings.
+///
+/// Note: there is intentionally no `LocaleDateTime` variant here.  numFmtId 22
+/// (locale short date+time) is only ever assigned by formula evaluation (NOW,
+/// EDATE, WORKDAY, …) via `Units::LocaleDateTime` → `get_style_with_num_fmt_id`.
+/// User input never produces a bare date+time token that would resolve to ID 22,
+/// so the parse path only needs `LocaleDate`.
 #[derive(Debug, PartialEq)]
 pub(crate) enum NumFmtSpec {
     /// Simple locale date — store as numFmtId 14 (`LOCALE_SHORT_DATE_FMT_ID`).

--- a/base/src/formatter/format.rs
+++ b/base/src/formatter/format.rs
@@ -745,7 +745,24 @@ fn parse_year(year_str: &str) -> Result<(i32, String), String> {
 // NOTE 1: The separator has to be the same
 // NOTE 2: In some engines "2/3" is implemented ad "2/March of the present year"
 // NOTE 3: I did not implement the "short date"
-fn parse_date(value: &str, locale: &Locale) -> Result<(i32, String), String> {
+/// Describes the number format that should be applied to a parsed value.
+///
+/// `LocaleDate` means "store as `LOCALE_SHORT_DATE_FMT_ID` (14)": the cell
+/// renders with the *current locale's* short date format rather than any
+/// literal format string.  All other formats are stored as literal strings.
+#[derive(Debug, PartialEq)]
+pub(crate) enum NumFmtSpec {
+    /// Simple locale date — store as numFmtId 14 (`LOCALE_SHORT_DATE_FMT_ID`).
+    LocaleDate,
+    /// A specific literal format string (ISO dates, currency, percent, …).
+    Literal(String),
+}
+
+/// Returns the serial number for a date string together with the format hint.
+///
+/// - ISO dates (`yyyy-…`) → `Some(literal_format)` — locale-independent.
+/// - All other recognised dates → `None` — caller stores as `LOCALE_SHORT_DATE_FMT_ID`.
+fn parse_date(value: &str, locale: &Locale) -> Result<(i32, Option<String>), String> {
     let separator = if value.contains('/') {
         '/'
     } else if value.contains('-') {
@@ -758,7 +775,6 @@ fn parse_date(value: &str, locale: &Locale) -> Result<(i32, String), String> {
 
     let parts: Vec<&str> = value.split(separator).collect();
     let mut is_iso_date = false;
-    let mut day_first = true;
     let (day_str, month_str, year_str) = if parts.len() == 3 {
         if parts[0].len() == 4 {
             // ISO date  yyyy-mm-dd
@@ -776,7 +792,6 @@ fn parse_date(value: &str, locale: &Locale) -> Result<(i32, String), String> {
             if locale.dates.date_formats.short.starts_with('d') {
                 (parts[0], parts[1], parts[2])
             } else {
-                day_first = false;
                 (parts[1], parts[0], parts[2])
             }
         }
@@ -785,39 +800,45 @@ fn parse_date(value: &str, locale: &Locale) -> Result<(i32, String), String> {
     };
     let (day, day_format) = parse_day(day_str)?;
     let (month, month_format) = parse_month(month_str, locale)?;
-    let (year, year_format) = parse_year(year_str)?;
+    let (year, _year_format) = parse_year(year_str)?;
     let serial_number = match date_to_serial_number(day, month, year) {
         Ok(n) => n,
         Err(_) => return Err("Not a valid date".to_string()),
     };
     if is_iso_date {
+        // ISO dates are locale-independent — preserve the exact format string.
         Ok((
             serial_number,
-            format!("yyyy{separator}{month_format}{separator}{day_format}"),
-        ))
-    } else if !day_first {
-        Ok((
-            serial_number,
-            format!("{month_format}{separator}{day_format}{separator}{year_format}"),
+            Some(format!(
+                "yyyy{separator}{month_format}{separator}{day_format}"
+            )),
         ))
     } else {
-        Ok((
-            serial_number,
-            format!("{day_format}{separator}{month_format}{separator}{year_format}"),
-        ))
+        // Simple locale date: signal to the caller to store as LOCALE_SHORT_DATE_FMT_ID.
+        // The day_first / day_format values were used only for serial-number parsing;
+        // the display format is entirely locale-derived at render time.
+        Ok((serial_number, None))
     }
 }
 
-/// Parses a formatted number, returning the numeric value together with the format
-/// Uses heuristics to guess the format string
-/// "$ 123,345.678" => (123345.678, "$#,##0.00")
-/// "30.34%" => (0.3034, "0.00%")
-/// 100€ => (100, "100€")
+/// Parses a formatted number, returning the numeric value together with a
+/// [`NumFmtSpec`] that describes how the value should be stored.
+///
+/// - `None`  → plain number, leave the cell's existing format unchanged.
+/// - `Some(NumFmtSpec::LocaleDate)`  → simple date; store as numFmtId 14.
+/// - `Some(NumFmtSpec::Literal(s))` → explicit format string (ISO dates,
+///   currency, percentage, …).
+///
+/// Examples:
+/// - `"$ 123,345.678"` → `(123345.678, Some(Literal("$#,##0.00")))`
+/// - `"30.34%"`        → `(0.3034,     Some(Literal("0.00%")))`
+/// - `"11/1/2026"` (en)→ `(serial,     Some(LocaleDate))`
+/// - `"2026-11-01"`    → `(serial,     Some(Literal("yyyy-mm-dd")))`
 pub(crate) fn parse_formatted_number(
     original: &str,
     currencies: &[&str],
     locale: &Locale,
-) -> Result<(f64, Option<String>), String> {
+) -> Result<(f64, Option<NumFmtSpec>), String> {
     let value = original.trim();
     let scientific_format = "0.00E+00";
 
@@ -831,15 +852,21 @@ pub(crate) fn parse_formatted_number(
     if let Some(p) = value.strip_suffix('%') {
         let (f, options) = parse_number(p.trim(), decimal_separator, group_separator)?;
         if options.is_scientific {
-            return Ok((f / 100.0, Some(scientific_format.to_string())));
+            return Ok((
+                f / 100.0,
+                Some(NumFmtSpec::Literal(scientific_format.to_string())),
+            ));
         }
         // We ignore the separator
         if options.decimal_digits > 0 {
             // Percentage format with decimals
-            return Ok((f / 100.0, Some("#,##0.00%".to_string())));
+            return Ok((
+                f / 100.0,
+                Some(NumFmtSpec::Literal("#,##0.00%".to_string())),
+            ));
         }
         // Percentage format standard
-        return Ok((f / 100.0, Some("#,##0%".to_string())));
+        return Ok((f / 100.0, Some(NumFmtSpec::Literal("#,##0%".to_string()))));
     }
 
     // check if it is a currency in currencies
@@ -847,52 +874,58 @@ pub(crate) fn parse_formatted_number(
         if let Some(p) = value.strip_prefix(&format!("-{currency}")) {
             let (f, options) = parse_number(p.trim(), decimal_separator, group_separator)?;
             if options.is_scientific {
-                return Ok((f, Some(scientific_format.to_string())));
+                return Ok((f, Some(NumFmtSpec::Literal(scientific_format.to_string()))));
             }
             if options.decimal_digits > 0 {
-                return Ok((-f, Some(format!("{currency}#,##0.00"))));
+                return Ok((-f, Some(NumFmtSpec::Literal(format!("{currency}#,##0.00")))));
             }
-            return Ok((-f, Some(format!("{currency}#,##0"))));
+            return Ok((-f, Some(NumFmtSpec::Literal(format!("{currency}#,##0")))));
         } else if let Some(p) = value.strip_prefix(currency) {
             let (f, options) = parse_number(p.trim(), decimal_separator, group_separator)?;
             if options.is_scientific {
-                return Ok((f, Some(scientific_format.to_string())));
+                return Ok((f, Some(NumFmtSpec::Literal(scientific_format.to_string()))));
             }
             if options.decimal_digits > 0 {
-                return Ok((f, Some(format!("{currency}#,##0.00"))));
+                return Ok((f, Some(NumFmtSpec::Literal(format!("{currency}#,##0.00")))));
             }
-            return Ok((f, Some(format!("{currency}#,##0"))));
+            return Ok((f, Some(NumFmtSpec::Literal(format!("{currency}#,##0")))));
         } else if let Some(p) = value.strip_suffix(currency) {
             let (f, options) = parse_number(p.trim(), decimal_separator, group_separator)?;
             if options.is_scientific {
-                return Ok((f, Some(scientific_format.to_string())));
+                return Ok((f, Some(NumFmtSpec::Literal(scientific_format.to_string()))));
             }
             if options.decimal_digits > 0 {
-                let currency_format = &format!("#,##0.00{currency}");
-                return Ok((f, Some(currency_format.to_string())));
+                let currency_format = format!("#,##0.00{currency}");
+                return Ok((f, Some(NumFmtSpec::Literal(currency_format))));
             }
-            let currency_format = &format!("#,##0{currency}");
-            return Ok((f, Some(currency_format.to_string())));
+            let currency_format = format!("#,##0{currency}");
+            return Ok((f, Some(NumFmtSpec::Literal(currency_format))));
         }
     }
 
     // check if it is a date. NOTE: we don't trim the original here
-    if let Ok((serial_number, format)) = parse_date(original, locale) {
-        return Ok((serial_number as f64, Some(format)));
+    if let Ok((serial_number, fmt_opt)) = parse_date(original, locale) {
+        let spec = match fmt_opt {
+            // ISO date — preserve the literal format string (e.g. "yyyy-mm-dd").
+            Some(fmt) => NumFmtSpec::Literal(fmt),
+            // Simple locale date — caller stores as LOCALE_SHORT_DATE_FMT_ID (14).
+            None => NumFmtSpec::LocaleDate,
+        };
+        return Ok((serial_number as f64, Some(spec)));
     }
 
     // Lastly we check if it is a number
     let (f, options) = parse_number(value, decimal_separator, group_separator)?;
     if options.is_scientific {
-        return Ok((f, Some(scientific_format.to_string())));
+        return Ok((f, Some(NumFmtSpec::Literal(scientific_format.to_string()))));
     }
     if options.has_commas {
         if options.decimal_digits > 0 {
             // group separator and two decimal points
-            return Ok((f, Some("#,##0.00".to_string())));
+            return Ok((f, Some(NumFmtSpec::Literal("#,##0.00".to_string()))));
         }
         // Group separator and no decimal points
-        return Ok((f, Some("#,##0".to_string())));
+        return Ok((f, Some(NumFmtSpec::Literal("#,##0".to_string()))));
     }
     Ok((f, None))
 }

--- a/base/src/formatter/test/test_parse_formatted_number.rs
+++ b/base/src/formatter/test/test_parse_formatted_number.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
 use crate::{
-    formatter::format::{parse_formatted_number, NumFmtSpec},
-    locale::get_default_locale,
+    formatter::format::parse_formatted_number, locale::get_default_locale, types::NumFmtSpec,
 };
 
 const PARSE_ERROR_MSG: &str = "Could not parse number";

--- a/base/src/formatter/test/test_parse_formatted_number.rs
+++ b/base/src/formatter/test/test_parse_formatted_number.rs
@@ -62,7 +62,7 @@ fn percentage() {
     // whole numbers
     assert_eq!(
         parse("400%", &["$"]),
-        Ok((4.0, Some(NumFmtSpec::Literal("#,##0%".to_string()))))
+        Ok((4.0, Some(NumFmtSpec::Literal("0%".to_string()))))
     );
     // decimal numbers
     assert_eq!(

--- a/base/src/formatter/test/test_parse_formatted_number.rs
+++ b/base/src/formatter/test/test_parse_formatted_number.rs
@@ -1,10 +1,13 @@
 #![allow(clippy::unwrap_used)]
 
-use crate::{formatter::format::parse_formatted_number, locale::get_default_locale};
+use crate::{
+    formatter::format::{parse_formatted_number, NumFmtSpec},
+    locale::get_default_locale,
+};
 
 const PARSE_ERROR_MSG: &str = "Could not parse number";
 
-fn parse(input: &str, currencies: &[&str]) -> Result<(f64, Option<String>), String> {
+fn parse(input: &str, currencies: &[&str]) -> Result<(f64, Option<NumFmtSpec>), String> {
     let locale = get_default_locale();
     parse_formatted_number(input, currencies, locale)
 }
@@ -20,23 +23,26 @@ fn numbers() {
     // scientific notation
     assert_eq!(
         parse("23e-12", &["$"]),
-        Ok((2.3e-11, Some("0.00E+00".to_string())))
+        Ok((2.3e-11, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
     assert_eq!(
         parse("2.123456789e-11", &["$"]),
-        Ok((2.123456789e-11, Some("0.00E+00".to_string())))
+        Ok((
+            2.123456789e-11,
+            Some(NumFmtSpec::Literal("0.00E+00".to_string()))
+        ))
     );
     assert_eq!(
         parse("4.5E-9", &["$"]),
-        Ok((4.5e-9, Some("0.00E+00".to_string())))
+        Ok((4.5e-9, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
     assert_eq!(
         parse("23e+2", &["$"]),
-        Ok((2300.0, Some("0.00E+00".to_string())))
+        Ok((2300.0, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
     assert_eq!(
         parse("4.5E9", &["$"]),
-        Ok((4.5e9, Some("0.00E+00".to_string())))
+        Ok((4.5e9, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
 
     // negative numbers
@@ -44,7 +50,7 @@ fn numbers() {
     assert_eq!(parse("-4.456", &["$"]), Ok((-4.456, None)));
     assert_eq!(
         parse("-23e-12", &["$"]),
-        Ok((-2.3e-11, Some("0.00E+00".to_string())))
+        Ok((-2.3e-11, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
 
     // trims space
@@ -54,20 +60,26 @@ fn numbers() {
 #[test]
 fn percentage() {
     // whole numbers
-    assert_eq!(parse("400%", &["$"]), Ok((4.0, Some("#,##0%".to_string()))));
+    assert_eq!(
+        parse("400%", &["$"]),
+        Ok((4.0, Some(NumFmtSpec::Literal("#,##0%".to_string()))))
+    );
     // decimal numbers
     assert_eq!(
         parse("4.456$", &["$"]),
-        Ok((4.456, Some("#,##0.00$".to_string())))
+        Ok((4.456, Some(NumFmtSpec::Literal("#,##0.00$".to_string()))))
     );
     // Percentage in scientific notation will not be formatted as percentage
     assert_eq!(
         parse("23e-12%", &["$"]),
-        Ok((23e-12 / 100.0, Some("0.00E+00".to_string())))
+        Ok((
+            23e-12 / 100.0,
+            Some(NumFmtSpec::Literal("0.00E+00".to_string()))
+        ))
     );
     assert_eq!(
         parse("2.3E4%", &["$"]),
-        Ok((230.0, Some("0.00E+00".to_string())))
+        Ok((230.0, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
 }
 
@@ -76,47 +88,47 @@ fn currency() {
     // whole numbers
     assert_eq!(
         parse("400$", &["$"]),
-        Ok((400.0, Some("#,##0$".to_string())))
+        Ok((400.0, Some(NumFmtSpec::Literal("#,##0$".to_string()))))
     );
     // decimal numbers
     assert_eq!(
         parse("4.456$", &["$"]),
-        Ok((4.456, Some("#,##0.00$".to_string())))
+        Ok((4.456, Some(NumFmtSpec::Literal("#,##0.00$".to_string()))))
     );
     // Currencies in scientific notation will not be formatted as currencies
     assert_eq!(
         parse("23e-12$", &["$"]),
-        Ok((2.3e-11, Some("0.00E+00".to_string())))
+        Ok((2.3e-11, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
     assert_eq!(
         parse("2.3e-12$", &["$"]),
-        Ok((2.3e-12, Some("0.00E+00".to_string())))
+        Ok((2.3e-12, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
     assert_eq!(
         parse("€23e-12", &["€"]),
-        Ok((2.3e-11, Some("0.00E+00".to_string())))
+        Ok((2.3e-11, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
 
     // switch side of currencies
     assert_eq!(
         parse("$400", &["$"]),
-        Ok((400.0, Some("$#,##0".to_string())))
+        Ok((400.0, Some(NumFmtSpec::Literal("$#,##0".to_string()))))
     );
     assert_eq!(
         parse("$4.456", &["$"]),
-        Ok((4.456, Some("$#,##0.00".to_string())))
+        Ok((4.456, Some(NumFmtSpec::Literal("$#,##0.00".to_string()))))
     );
     assert_eq!(
         parse("$23e-12", &["$"]),
-        Ok((2.3e-11, Some("0.00E+00".to_string())))
+        Ok((2.3e-11, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
     assert_eq!(
         parse("$2.3e-12", &["$"]),
-        Ok((2.3e-12, Some("0.00E+00".to_string())))
+        Ok((2.3e-12, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
     assert_eq!(
         parse("23e-12€", &["€"]),
-        Ok((2.3e-11, Some("0.00E+00".to_string())))
+        Ok((2.3e-11, Some(NumFmtSpec::Literal("0.00E+00".to_string()))))
     );
 }
 
@@ -124,15 +136,15 @@ fn currency() {
 fn negative_currencies() {
     assert_eq!(
         parse("-400$", &["$"]),
-        Ok((-400.0, Some("#,##0$".to_string())))
+        Ok((-400.0, Some(NumFmtSpec::Literal("#,##0$".to_string()))))
     );
     assert_eq!(
         parse("-$400", &["$"]),
-        Ok((-400.0, Some("$#,##0".to_string())))
+        Ok((-400.0, Some(NumFmtSpec::Literal("$#,##0".to_string()))))
     );
     assert_eq!(
         parse("$-400", &["$"]),
-        Ok((-400.0, Some("$#,##0".to_string())))
+        Ok((-400.0, Some(NumFmtSpec::Literal("$#,##0".to_string()))))
     );
 }
 
@@ -154,55 +166,58 @@ fn errors_wrong_currency() {
 }
 
 #[test]
-fn long_dates_en_us() {
+fn locale_dates_en_us() {
+    // All non-ISO dates return LocaleDate — the serial number is what matters,
+    // the display format is derived from the locale at render time.
     assert_eq!(
         parse("03/02/2024", &["$"]),
-        Ok((45353.0, Some("mm/dd/yyyy".to_string())))
+        Ok((45353.0, Some(NumFmtSpec::LocaleDate)))
     );
     assert_eq!(
         parse("3/02/2024", &["$"]),
-        Ok((45353.0, Some("m/dd/yyyy".to_string())))
+        Ok((45353.0, Some(NumFmtSpec::LocaleDate)))
     );
     assert_eq!(
         parse("Mar/02/2024", &["$"]),
-        Ok((45353.0, Some("mmm/dd/yyyy".to_string())))
+        Ok((45353.0, Some(NumFmtSpec::LocaleDate)))
     );
     assert_eq!(
         parse("March/02/2024", &["$"]),
-        Ok((45353.0, Some("mmmm/dd/yyyy".to_string())))
+        Ok((45353.0, Some(NumFmtSpec::LocaleDate)))
     );
     assert_eq!(
         parse("3/2/24", &["$"]),
-        Ok((45353.0, Some("m/d/yy".to_string())))
+        Ok((45353.0, Some(NumFmtSpec::LocaleDate)))
     );
 
     assert_eq!(
         parse("02-10-1975", &["$"]),
-        Ok((27435.0, Some("mm-dd-yyyy".to_string())))
+        Ok((27435.0, Some(NumFmtSpec::LocaleDate)))
     );
     assert_eq!(
         parse("2-10-1975", &["$"]),
-        Ok((27435.0, Some("m-dd-yyyy".to_string())))
+        Ok((27435.0, Some(NumFmtSpec::LocaleDate)))
     );
     assert_eq!(
         parse("Feb-10-1975", &["$"]),
-        Ok((27435.0, Some("mmm-dd-yyyy".to_string())))
+        Ok((27435.0, Some(NumFmtSpec::LocaleDate)))
     );
     assert_eq!(
         parse("February-10-1975", &["$"]),
-        Ok((27435.0, Some("mmmm-dd-yyyy".to_string())))
+        Ok((27435.0, Some(NumFmtSpec::LocaleDate)))
     );
     assert_eq!(
         parse("2-10-75", &["$"]),
-        Ok((27435.0, Some("m-dd-yy".to_string())))
+        Ok((27435.0, Some(NumFmtSpec::LocaleDate)))
     );
 }
 
 #[test]
 fn iso_dates() {
+    // ISO dates retain their literal format string — they are locale-independent.
     assert_eq!(
         parse("2024/03/02", &["$"]),
-        Ok((45353.0, Some("yyyy/mm/dd".to_string())))
+        Ok((45353.0, Some(NumFmtSpec::Literal("yyyy/mm/dd".to_string()))))
     );
     assert_eq!(
         parse("2024/March/02", &["$"]),
@@ -211,9 +226,9 @@ fn iso_dates() {
 }
 
 #[test]
-fn long_dates_with_dots() {
+fn locale_dates_with_dots() {
     assert_eq!(
         parse("03.02.2024", &["$"]),
-        Ok((45353.0, Some("mm.dd.yyyy".to_string())))
+        Ok((45353.0, Some(NumFmtSpec::LocaleDate)))
     );
 }

--- a/base/src/functions/date_and_time.rs
+++ b/base/src/functions/date_and_time.rs
@@ -404,7 +404,7 @@ fn parse_year_simple(year_str: &str) -> Result<i32, String> {
     }
 }
 
-fn parse_datevalue_text(value: &str) -> Result<i32, String> {
+fn parse_datevalue_text(value: &str, day_first: bool) -> Result<i32, String> {
     // Trim whitespace and discard any time component (e.g., "2024-02-29 06:00" -> "2024-02-29")
     let mut date_str = value.trim();
     if let Some(idx) = date_str.find('T') {
@@ -459,7 +459,14 @@ fn parse_datevalue_text(value: &str) -> Result<i32, String> {
         match (v1 > 12, v2 > 12) {
             (true, false) => (part2, part1), // first cannot be month
             (false, true) => (part1, part2), // second cannot be month
-            _ => (part1, part2),             // ambiguous -> assume MM/DD
+            // Ambiguous: use locale order (DD/MM for day-first locales, MM/DD otherwise).
+            _ => {
+                if day_first {
+                    (part2, part1)
+                } else {
+                    (part1, part2)
+                }
+            }
         }
     };
 
@@ -487,14 +494,17 @@ impl<'a> Model<'a> {
         let result = self.evaluate_node_in_context(node, cell);
         match result {
             CalcResult::Number(f) => Ok(f.floor() as i64),
-            CalcResult::String(s) => match parse_datevalue_text(&s) {
-                Ok(n) => Ok(n as i64),
-                Err(_) => Err(CalcResult::Error {
-                    error: Error::VALUE,
-                    origin: cell,
-                    message: "Invalid date".to_string(),
-                }),
-            },
+            CalcResult::String(s) => {
+                let day_first = self.locale.day_first();
+                match parse_datevalue_text(&s, day_first) {
+                    Ok(n) => Ok(n as i64),
+                    Err(_) => Err(CalcResult::Error {
+                        error: Error::VALUE,
+                        origin: cell,
+                        message: "Invalid date".to_string(),
+                    }),
+                }
+            }
             CalcResult::Boolean(b) => {
                 if b {
                     Ok(1)
@@ -1101,14 +1111,17 @@ impl<'a> Model<'a> {
             return CalcResult::new_args_number_error(cell);
         }
         match self.evaluate_node_in_context(&args[0], cell) {
-            CalcResult::String(s) => match parse_datevalue_text(&s) {
-                Ok(n) => CalcResult::Number(n as f64),
-                Err(_) => CalcResult::Error {
-                    error: Error::VALUE,
-                    origin: cell,
-                    message: "Invalid date".to_string(),
-                },
-            },
+            CalcResult::String(s) => {
+                let day_first = self.locale.day_first();
+                match parse_datevalue_text(&s, day_first) {
+                    Ok(n) => CalcResult::Number(n as f64),
+                    Err(_) => CalcResult::Error {
+                        error: Error::VALUE,
+                        origin: cell,
+                        message: "Invalid date".to_string(),
+                    },
+                }
+            }
             CalcResult::Number(f) => CalcResult::Number(f.floor()),
             CalcResult::Boolean(b) => {
                 if b {

--- a/base/src/locale/mod.rs
+++ b/base/src/locale/mod.rs
@@ -86,6 +86,7 @@ pub struct TimeFormats {
 impl Locale {
     /// True if the locale's short date pattern starts with day (e.g. en-GB `"dd/MM/yyyy"`).
     pub fn day_first(&self) -> bool {
+        // TODO: A bit hacky, but works for now
         self.dates.date_formats.short.starts_with('d')
     }
 }

--- a/base/src/locale/mod.rs
+++ b/base/src/locale/mod.rs
@@ -83,6 +83,18 @@ pub struct TimeFormats {
     pub short: String,
 }
 
+impl Locale {
+    /// Returns `true` if this locale places the day before the month in its
+    /// short date pattern (e.g. `"dd/MM/yyyy"` for en-GB) and `false` for
+    /// month-first locales (e.g. `"M/d/yy"` for en-US).
+    ///
+    /// Used for disambiguation when parsing numeric date strings like
+    /// `"01/02/2025"` where both components are ≤ 12.
+    pub fn day_first(&self) -> bool {
+        self.dates.date_formats.short.starts_with('d')
+    }
+}
+
 pub fn get_default_locale() -> &'static Locale {
     #[allow(clippy::unwrap_used)]
     get_locale("en").unwrap()

--- a/base/src/locale/mod.rs
+++ b/base/src/locale/mod.rs
@@ -84,12 +84,7 @@ pub struct TimeFormats {
 }
 
 impl Locale {
-    /// Returns `true` if this locale places the day before the month in its
-    /// short date pattern (e.g. `"dd/MM/yyyy"` for en-GB) and `false` for
-    /// month-first locales (e.g. `"M/d/yy"` for en-US).
-    ///
-    /// Used for disambiguation when parsing numeric date strings like
-    /// `"01/02/2025"` where both components are ≤ 12.
+    /// True if the locale's short date pattern starts with day (e.g. en-GB `"dd/MM/yyyy"`).
     pub fn day_first(&self) -> bool {
         self.dates.date_formats.short.starts_with('d')
     }

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1877,7 +1877,7 @@ impl<'a> Model<'a> {
                 ))
             }
             None => {
-                let style_index = cell.get_style();
+                let style_index = self.get_cell_style_index(sheet, row, column)?;
                 let num_fmt_id = self.workbook.styles.get_num_fmt_id(style_index)?;
                 let style = self.workbook.styles.get_style(style_index)?;
                 if style.quote_prefix {

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -26,6 +26,7 @@ use crate::{
     implicit_intersection::implicit_intersection,
     language::{get_default_language, get_language, Language},
     locale::{get_locale, Locale},
+    number_format::DefaultFmts,
     types::*,
     units::Units,
     utils as common,
@@ -1566,13 +1567,13 @@ impl<'a> Model<'a> {
                 let parsed_formula = &self.parsed_formulas[sheet as usize][formula_index as usize];
                 if let Some(units) = self.compute_node_units(parsed_formula, &cell) {
                     let new_style_index = match units {
-                        Units::LocaleDate => self
-                            .workbook
-                            .styles
-                            .get_style_with_num_fmt_id(new_style_index, NumFmt::SHORT_DATE_ID)?,
+                        Units::LocaleDate => self.workbook.styles.get_style_with_num_fmt_id(
+                            new_style_index,
+                            DefaultFmts::SHORT_DATE_ID,
+                        )?,
                         Units::LocaleDateTime => self.workbook.styles.get_style_with_num_fmt_id(
                             new_style_index,
-                            NumFmt::SHORT_DATETIME_ID,
+                            DefaultFmts::SHORT_DATETIME_ID,
                         )?,
                         Units::Number { num_fmt, .. }
                         | Units::Currency { num_fmt, .. }
@@ -1608,7 +1609,7 @@ impl<'a> Model<'a> {
                         };
                         let existing_style = self.workbook.styles.get_style(new_style_index)?;
                         let existing_id = existing_style.num_fmt.num_fmt_id;
-                        let existing_is_date = NumFmt::is_locale_date_id(existing_id)
+                        let existing_is_date = DefaultFmts::is_locale_date(existing_id)
                             || is_likely_date_number_format(&existing_style.num_fmt.format_code);
                         let should_apply_format = !(existing_is_date && new_is_date);
                         if should_apply_format {
@@ -1616,7 +1617,7 @@ impl<'a> Model<'a> {
                                 NumFmtSpec::LocaleDate => {
                                     self.workbook.styles.get_style_with_num_fmt_id(
                                         new_style_index,
-                                        NumFmt::SHORT_DATE_ID,
+                                        DefaultFmts::SHORT_DATE_ID,
                                     )?
                                 }
                                 NumFmtSpec::Literal(s) => self
@@ -1854,8 +1855,8 @@ impl<'a> Model<'a> {
                 let num_fmt_id = self.workbook.styles.get_num_fmt_id(style_index)?;
                 // Locale IDs 14/22 derive the pattern from the active locale; others use stored string.
                 let format = match num_fmt_id {
-                    NumFmt::SHORT_DATE_ID => self.locale.dates.date_formats.short.clone(),
-                    NumFmt::SHORT_DATETIME_ID => locale_short_datetime_fmt(self.locale),
+                    DefaultFmts::SHORT_DATE_ID => self.locale.dates.date_formats.short.clone(),
+                    DefaultFmts::SHORT_DATETIME_ID => locale_short_datetime_fmt(self.locale),
                     _ => {
                         self.workbook
                             .styles
@@ -1928,10 +1929,10 @@ impl<'a> Model<'a> {
                 } else {
                     // Locale IDs 14/22 derive the pattern from the active locale; others use stored string.
                     let date_fmt = match num_fmt_id {
-                        NumFmt::SHORT_DATE_ID => {
+                        DefaultFmts::SHORT_DATE_ID => {
                             Some(self.locale.dates.date_formats.short.clone())
                         }
-                        NumFmt::SHORT_DATETIME_ID => {
+                        DefaultFmts::SHORT_DATETIME_ID => {
                             Some(locale_short_datetime_fmt(self.locale))
                         }
                         _ if is_likely_date_number_format(&style.num_fmt.format_code) => {

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -92,7 +92,7 @@ fn locale_short_datetime_fmt(locale: &Locale) -> String {
         .short
         .replace("{0}", time_short.trim())
         .replace("{1}", date_short);
-    // Normalize narrow no-break space (U+202F) used by some CLDR locales.
+    // Normalise narrow no-break space (U+202F) in the assembled template.
     fmt.replace('\u{202f}', " ")
 }
 

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -19,13 +19,14 @@ use crate::{
         utils::{self, is_valid_column_number, is_valid_identifier, is_valid_row},
     },
     formatter::{
-        format::{format_number, parse_formatted_number},
+        format::{format_number, parse_formatted_number, NumFmtSpec},
         lexer::is_likely_date_number_format,
     },
     functions::util::compare_values,
     implicit_intersection::implicit_intersection,
     language::{get_default_language, get_language, Language},
     locale::{get_locale, Locale},
+    number_format::{is_locale_short_date_id, LOCALE_SHORT_DATE_FMT_ID},
     types::*,
     utils as common,
 };
@@ -1564,17 +1565,33 @@ impl<'a> Model<'a> {
                 if let Ok((v, number_format)) =
                     parse_formatted_number(&value, &currencies, self.locale)
                 {
-                    if let Some(num_fmt) = number_format {
-                        // Should not apply the format in the following cases:
-                        // - we assign a date to already date-formatted cell
+                    if let Some(num_fmt_spec) = number_format {
+                        // Don't overwrite an existing date format when a date is
+                        // re-entered into a cell already formatted as a date — the
+                        // user may have set a more specific format manually.
+                        let new_is_date = match &num_fmt_spec {
+                            NumFmtSpec::LocaleDate => true,
+                            NumFmtSpec::Literal(s) => is_likely_date_number_format(s),
+                        };
                         let should_apply_format = !(is_likely_date_number_format(
                             &self.workbook.styles.get_style(new_style_index)?.num_fmt,
-                        ) && is_likely_date_number_format(&num_fmt));
+                        ) && new_is_date);
                         if should_apply_format {
-                            new_style_index = self
-                                .workbook
-                                .styles
-                                .get_style_with_format(new_style_index, &num_fmt)?;
+                            new_style_index = match num_fmt_spec {
+                                // Locale date: store as numFmtId 14, render
+                                // functions can detect it via is_locale_short_date_id.
+                                NumFmtSpec::LocaleDate => {
+                                    self.workbook.styles.get_style_with_num_fmt_id(
+                                        new_style_index,
+                                        LOCALE_SHORT_DATE_FMT_ID,
+                                    )?
+                                }
+                                // Explicit format string (ISO dates, currency, …).
+                                NumFmtSpec::Literal(s) => self
+                                    .workbook
+                                    .styles
+                                    .get_style_with_format(new_style_index, &s)?,
+                            };
                         }
                     }
                     let worksheet = self.workbook.worksheet_mut(sheet)?;
@@ -1801,7 +1818,16 @@ impl<'a> Model<'a> {
     ) -> Result<String, String> {
         match self.workbook.worksheet(sheet_index)?.cell(row, column) {
             Some(cell) => {
-                let format = self.get_style_for_cell(sheet_index, row, column)?.num_fmt;
+                let style_index = self.get_cell_style_index(sheet_index, row, column)?;
+                let num_fmt_id = self.workbook.styles.get_num_fmt_id(style_index)?;
+                // For locale-derived date formats (numFmtId 14) use the
+                // locale's own short-date pattern so the display updates
+                // automatically when the user switches locales.
+                let format = if is_locale_short_date_id(num_fmt_id) {
+                    self.locale.dates.date_formats.short.clone()
+                } else {
+                    self.workbook.styles.get_style(style_index)?.num_fmt
+                };
                 let formatted_value =
                     cell.formatted_value(&self.workbook.shared_strings, self.language, |value| {
                         format_number(value, &format, self.locale).text
@@ -1852,6 +1878,7 @@ impl<'a> Model<'a> {
             }
             None => {
                 let style_index = cell.get_style();
+                let num_fmt_id = self.workbook.styles.get_num_fmt_id(style_index)?;
                 let style = self.workbook.styles.get_style(style_index)?;
                 if style.quote_prefix {
                     Ok(format!(
@@ -1863,11 +1890,21 @@ impl<'a> Model<'a> {
                         )
                     ))
                 } else {
-                    // If it is a date formatted cell we try to format it as date, if it fails we return the raw value
-                    if is_likely_date_number_format(&style.num_fmt) {
+                    // If it is a date formatted cell we try to format it as date,
+                    // if it fails we return the raw value.
+                    // For locale-derived dates (numFmtId 14) use the locale's own
+                    // short-date pattern so the edit bar stays in sync with locale.
+                    let is_locale_date = is_locale_short_date_id(num_fmt_id);
+                    let is_date = is_locale_date || is_likely_date_number_format(&style.num_fmt);
+                    if is_date {
                         let value = cell.value(&self.workbook.shared_strings, self.language);
                         if let CellValue::Number(n) = value {
-                            let formatted = format_number(n, &style.num_fmt, self.locale);
+                            let fmt_str = if is_locale_date {
+                                &self.locale.dates.date_formats.short
+                            } else {
+                                &style.num_fmt
+                            };
+                            let formatted = format_number(n, fmt_str, self.locale);
                             if formatted.error.is_none() {
                                 return Ok(formatted.text);
                             }

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -75,10 +75,16 @@ fn locale_short_datetime_fmt(locale: &Locale) -> String {
     // Normalise narrow no-break space (U+202F) used by many CLDR locales
     // (e.g. "h:mm\u{202f}a"), then map the trailing CLDR meridiem token to
     // the IronCalc DSL token "AM/PM".
-    // TODO: CLDR also allows leading-'a' placement (e.g. "ah:mm" in some
-    // locales) and no-space trailing (e.g. "h:mma").  A proper tokenised
-    // replacement would cover all cases; the simple string replace below
-    // suffices for the locales currently supported by IronCalc.
+    //
+    // KNOWN LIMITATION: this replace covers only the common Western pattern
+    // "h:mm a" (trailing space + 'a').  CLDR also defines:
+    //   • Leading 'a': "ah:mm" (Chinese, Japanese) — left as-is, 'a' renders raw
+    //   • No-space trailing: "h:mma" — left as-is, 'a' renders raw
+    //
+    // Fix: replace the two `.replace()` calls with a proper CLDR token scanner
+    // that strips 'a'/'a*'/'aaa*' tokens regardless of position and injects
+    // "AM/PM" at the correct place.  Until then, only locales whose
+    // `time_formats.short` matches the "…space-a" pattern work correctly.
     let time_short = locale
         .dates
         .time_formats

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -19,7 +19,7 @@ use crate::{
         utils::{self, is_valid_column_number, is_valid_identifier, is_valid_row},
     },
     formatter::{
-        format::{format_number, parse_formatted_number, NumFmtSpec},
+        format::{format_number, parse_formatted_number},
         lexer::is_likely_date_number_format,
     },
     functions::util::compare_values,

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -64,40 +64,22 @@ pub fn get_milliseconds_since_epoch() -> i64 {
     Date::now() as i64
 }
 
-/// Build the locale's short date+time format string at render time.
-///
-/// Mirrors the logic that was previously baked into `units_fn_date_times` at
-/// formula-entry time.  Called whenever a cell carries numFmtId 22 so that
-/// locale switches update the display without requiring a re-edit.
 fn locale_short_datetime_fmt(locale: &Locale) -> String {
     let date_short = &locale.dates.date_formats.short;
-    // Normalise narrow no-break space (U+202F) used by many CLDR locales
-    // (e.g. "h:mm\u{202f}a"), then map the trailing CLDR meridiem token to
-    // the IronCalc DSL token "AM/PM".
-    //
-    // KNOWN LIMITATION: this replace covers only the common Western pattern
-    // "h:mm a" (trailing space + 'a').  CLDR also defines:
-    //   • Leading 'a': "ah:mm" (Chinese, Japanese) — left as-is, 'a' renders raw
-    //   • No-space trailing: "h:mma" — left as-is, 'a' renders raw
-    //
-    // Fix: replace the two `.replace()` calls with a proper CLDR token scanner
-    // that strips 'a'/'a*'/'aaa*' tokens regardless of position and injects
-    // "AM/PM" at the correct place.  Until then, only locales whose
-    // `time_formats.short` matches the "…space-a" pattern work correctly.
+    // Normalise CLDR narrow no-break space (U+202F) and meridiem token 'a' → "AM/PM".
+    // TODO: only "…space-a" CLDR pattern handled; leading/no-space 'a' renders raw.
     let time_short = locale
         .dates
         .time_formats
         .short
         .replace('\u{202f}', " ")
         .replace(" a", " AM/PM");
-    // Template is typically "{1}, {0}" — date first, then time.
     let fmt = locale
         .dates
         .date_time_formats
         .short
         .replace("{0}", time_short.trim())
         .replace("{1}", date_short);
-    // Normalise narrow no-break space (U+202F) in the assembled template.
     fmt.replace('\u{202f}', " ")
 }
 
@@ -1583,10 +1565,6 @@ impl<'a> Model<'a> {
                 let cell = CellReferenceIndex { sheet, row, column };
                 let parsed_formula = &self.parsed_formulas[sheet as usize][formula_index as usize];
                 if let Some(units) = self.compute_node_units(parsed_formula, &cell) {
-                    // Date-returning functions (DATE, TODAY, …) get numFmtId 14 so
-                    // that get_formatted_cell_value derives the display pattern from
-                    // the active locale at render time.  All other units (currency,
-                    // percentage, plain number) keep their literal format string.
                     let new_style_index = match units {
                         Units::LocaleDate => self
                             .workbook
@@ -1623,17 +1601,11 @@ impl<'a> Model<'a> {
                     parse_formatted_number(&value, &currencies, self.locale)
                 {
                     if let Some(num_fmt_spec) = number_format {
-                        // Don't overwrite an existing date format when a date is
-                        // re-entered into a cell already formatted as a date — the
-                        // user may have set a more specific format manually.
+                        // Don't overwrite a user-set date format when a date is re-entered.
                         let new_is_date = match &num_fmt_spec {
                             NumFmtSpec::LocaleDate => true,
                             NumFmtSpec::Literal(s) => is_likely_date_number_format(s),
                         };
-                        // Prefer checking the numFmtId directly for locale-date
-                        // cells (ID 14/22): get_style() resolves those IDs to an
-                        // en-US literal like "mm-dd-yy", so the string heuristic
-                        // works only by coincidence.  The ID check is exact.
                         let existing_style = self.workbook.styles.get_style(new_style_index)?;
                         let existing_id = existing_style.num_fmt.num_fmt_id;
                         let existing_is_date = NumFmt::is_locale_date_id(existing_id)
@@ -1641,14 +1613,12 @@ impl<'a> Model<'a> {
                         let should_apply_format = !(existing_is_date && new_is_date);
                         if should_apply_format {
                             new_style_index = match num_fmt_spec {
-                                // Locale date: store as numFmtId 14, render
                                 NumFmtSpec::LocaleDate => {
                                     self.workbook.styles.get_style_with_num_fmt_id(
                                         new_style_index,
                                         NumFmt::SHORT_DATE_ID,
                                     )?
                                 }
-                                // Explicit format string (ISO dates, currency, …).
                                 NumFmtSpec::Literal(s) => self
                                     .workbook
                                     .styles
@@ -1882,9 +1852,7 @@ impl<'a> Model<'a> {
             Some(cell) => {
                 let style_index = self.get_cell_style_index(sheet_index, row, column)?;
                 let num_fmt_id = self.workbook.styles.get_num_fmt_id(style_index)?;
-                // For locale-derived formats derive the pattern from the active
-                // locale at render time so locale switches take effect without
-                // requiring a re-edit.
+                // Locale IDs 14/22 derive the pattern from the active locale; others use stored string.
                 let format = match num_fmt_id {
                     NumFmt::SHORT_DATE_ID => self.locale.dates.date_formats.short.clone(),
                     NumFmt::SHORT_DATETIME_ID => locale_short_datetime_fmt(self.locale),
@@ -1958,10 +1926,7 @@ impl<'a> Model<'a> {
                         )
                     ))
                 } else {
-                    // Resolve the date format string, or None if the cell is not
-                    // date-formatted.  Locale-derived IDs (14, 22) build their
-                    // pattern from the active locale so the edit bar stays in sync
-                    // after a locale switch; literal formats use the stored string.
+                    // Locale IDs 14/22 derive the pattern from the active locale; others use stored string.
                     let date_fmt = match num_fmt_id {
                         NumFmt::SHORT_DATE_ID => {
                             Some(self.locale.dates.date_formats.short.clone())

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -72,8 +72,19 @@ pub fn get_milliseconds_since_epoch() -> i64 {
 /// locale switches update the display without requiring a re-edit.
 fn locale_short_datetime_fmt(locale: &Locale) -> String {
     let date_short = &locale.dates.date_formats.short;
-    // Replace the CLDR meridiem indicator 'a' with the Excel "AM/PM" token.
-    let time_short = locale.dates.time_formats.short.replace('a', "AM/PM");
+    // Normalise narrow no-break space (U+202F) used by many CLDR locales
+    // (e.g. "h:mm\u{202f}a"), then map the trailing CLDR meridiem token to
+    // the IronCalc DSL token "AM/PM".
+    // TODO: CLDR also allows leading-'a' placement (e.g. "ah:mm" in some
+    // locales) and no-space trailing (e.g. "h:mma").  A proper tokenised
+    // replacement would cover all cases; the simple string replace below
+    // suffices for the locales currently supported by IronCalc.
+    let time_short = locale
+        .dates
+        .time_formats
+        .short
+        .replace('\u{202f}', " ")
+        .replace(" a", " AM/PM");
     // Template is typically "{1}, {0}" — date first, then time.
     let fmt = locale
         .dates
@@ -1580,10 +1591,16 @@ impl<'a> Model<'a> {
                             new_style_index,
                             LOCALE_SHORT_DATE_TIME_FMT_ID,
                         )?,
-                        _ => self
+                        Units::Number { num_fmt, .. }
+                        | Units::Currency { num_fmt, .. }
+                        | Units::Percentage { num_fmt, .. } => self
                             .workbook
                             .styles
-                            .get_style_with_format(new_style_index, &units.get_num_fmt())?,
+                            .get_style_with_format(new_style_index, &num_fmt)?,
+                        Units::Date(fmt) => self
+                            .workbook
+                            .styles
+                            .get_style_with_format(new_style_index, &fmt)?,
                     };
                     let style = self.workbook.styles.get_style(new_style_index)?;
                     self.set_cell_style(sheet, row, column, &style)?
@@ -1608,9 +1625,16 @@ impl<'a> Model<'a> {
                             NumFmtSpec::LocaleDate => true,
                             NumFmtSpec::Literal(s) => is_likely_date_number_format(s),
                         };
-                        let should_apply_format = !(is_likely_date_number_format(
-                            &self.workbook.styles.get_style(new_style_index)?.num_fmt,
-                        ) && new_is_date);
+                        // Prefer checking the numFmtId directly for locale-date
+                        // cells (ID 14/22): get_style() resolves those IDs to an
+                        // en-US literal like "mm-dd-yy", so the string heuristic
+                        // works only by coincidence.  The ID check is exact.
+                        let existing_style = self.workbook.styles.get_style(new_style_index)?;
+                        let existing_id = existing_style.num_fmt.num_fmt_id;
+                        let existing_is_date = existing_id == LOCALE_SHORT_DATE_FMT_ID
+                            || existing_id == LOCALE_SHORT_DATE_TIME_FMT_ID
+                            || is_likely_date_number_format(&existing_style.num_fmt.format_code);
+                        let should_apply_format = !(existing_is_date && new_is_date);
                         if should_apply_format {
                             new_style_index = match num_fmt_spec {
                                 // Locale date: store as numFmtId 14, render
@@ -1860,7 +1884,13 @@ impl<'a> Model<'a> {
                 let format = match num_fmt_id {
                     LOCALE_SHORT_DATE_FMT_ID => self.locale.dates.date_formats.short.clone(),
                     LOCALE_SHORT_DATE_TIME_FMT_ID => locale_short_datetime_fmt(self.locale),
-                    _ => self.workbook.styles.get_style(style_index)?.num_fmt,
+                    _ => {
+                        self.workbook
+                            .styles
+                            .get_style(style_index)?
+                            .num_fmt
+                            .format_code
+                    }
                 };
                 let formatted_value =
                     cell.formatted_value(&self.workbook.shared_strings, self.language, |value| {
@@ -1912,8 +1942,8 @@ impl<'a> Model<'a> {
             }
             None => {
                 let style_index = self.get_cell_style_index(sheet, row, column)?;
-                let num_fmt_id = self.workbook.styles.get_num_fmt_id(style_index)?;
                 let style = self.workbook.styles.get_style(style_index)?;
+                let num_fmt_id = style.num_fmt.num_fmt_id;
                 if style.quote_prefix {
                     Ok(format!(
                         "'{}",
@@ -1935,8 +1965,8 @@ impl<'a> Model<'a> {
                         LOCALE_SHORT_DATE_TIME_FMT_ID => {
                             Some(locale_short_datetime_fmt(self.locale))
                         }
-                        _ if is_likely_date_number_format(&style.num_fmt) => {
-                            Some(style.num_fmt.clone())
+                        _ if is_likely_date_number_format(&style.num_fmt.format_code) => {
+                            Some(style.num_fmt.format_code.clone())
                         }
                         _ => None,
                     };

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -6,7 +6,7 @@ use std::vec::Vec;
 use crate::{
     calc_result::{CalcResult, Range},
     cell::CellValue,
-    constants::{self, LAST_COLUMN, LAST_ROW},
+    constants::{self, LAST_COLUMN, LAST_ROW, SHORT_DATETIME_ID, SHORT_DATE_ID},
     expressions::{
         lexer::LexerMode,
         parser::{
@@ -1567,14 +1567,14 @@ impl<'a> Model<'a> {
                 let parsed_formula = &self.parsed_formulas[sheet as usize][formula_index as usize];
                 if let Some(units) = self.compute_node_units(parsed_formula, &cell) {
                     let new_style_index = match units {
-                        Units::LocaleDate => self.workbook.styles.get_style_with_num_fmt_id(
-                            new_style_index,
-                            DefaultFmts::SHORT_DATE_ID,
-                        )?,
-                        Units::LocaleDateTime => self.workbook.styles.get_style_with_num_fmt_id(
-                            new_style_index,
-                            DefaultFmts::SHORT_DATETIME_ID,
-                        )?,
+                        Units::LocaleDate => self
+                            .workbook
+                            .styles
+                            .get_style_with_num_fmt_id(new_style_index, SHORT_DATE_ID)?,
+                        Units::LocaleDateTime => self
+                            .workbook
+                            .styles
+                            .get_style_with_num_fmt_id(new_style_index, SHORT_DATETIME_ID)?,
                         Units::Number { num_fmt, .. }
                         | Units::Currency { num_fmt, .. }
                         | Units::Percentage { num_fmt, .. } => self
@@ -1614,12 +1614,10 @@ impl<'a> Model<'a> {
                         let should_apply_format = !(existing_is_date && new_is_date);
                         if should_apply_format {
                             new_style_index = match num_fmt_spec {
-                                NumFmtSpec::LocaleDate => {
-                                    self.workbook.styles.get_style_with_num_fmt_id(
-                                        new_style_index,
-                                        DefaultFmts::SHORT_DATE_ID,
-                                    )?
-                                }
+                                NumFmtSpec::LocaleDate => self
+                                    .workbook
+                                    .styles
+                                    .get_style_with_num_fmt_id(new_style_index, SHORT_DATE_ID)?,
                                 NumFmtSpec::Literal(s) => self
                                     .workbook
                                     .styles
@@ -1855,8 +1853,8 @@ impl<'a> Model<'a> {
                 let num_fmt_id = self.workbook.styles.get_num_fmt_id(style_index)?;
                 // Locale IDs 14/22 derive the pattern from the active locale; others use stored string.
                 let format = match num_fmt_id {
-                    DefaultFmts::SHORT_DATE_ID => self.locale.dates.date_formats.short.clone(),
-                    DefaultFmts::SHORT_DATETIME_ID => locale_short_datetime_fmt(self.locale),
+                    SHORT_DATE_ID => self.locale.dates.date_formats.short.clone(),
+                    SHORT_DATETIME_ID => locale_short_datetime_fmt(self.locale),
                     _ => {
                         self.workbook
                             .styles
@@ -1929,12 +1927,8 @@ impl<'a> Model<'a> {
                 } else {
                     // Locale IDs 14/22 derive the pattern from the active locale; others use stored string.
                     let date_fmt = match num_fmt_id {
-                        DefaultFmts::SHORT_DATE_ID => {
-                            Some(self.locale.dates.date_formats.short.clone())
-                        }
-                        DefaultFmts::SHORT_DATETIME_ID => {
-                            Some(locale_short_datetime_fmt(self.locale))
-                        }
+                        SHORT_DATE_ID => Some(self.locale.dates.date_formats.short.clone()),
+                        SHORT_DATETIME_ID => Some(locale_short_datetime_fmt(self.locale)),
                         _ if is_likely_date_number_format(&style.num_fmt.format_code) => {
                             Some(style.num_fmt.format_code.clone())
                         }

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1591,10 +1591,10 @@ impl<'a> Model<'a> {
                         Units::LocaleDate => self
                             .workbook
                             .styles
-                            .get_style_with_num_fmt_id(new_style_index, NumFmt::LOCALE_DATE_ID)?,
+                            .get_style_with_num_fmt_id(new_style_index, NumFmt::SHORT_DATE_ID)?,
                         Units::LocaleDateTime => self.workbook.styles.get_style_with_num_fmt_id(
                             new_style_index,
-                            NumFmt::LOCALE_DATETIME_ID,
+                            NumFmt::SHORT_DATETIME_ID,
                         )?,
                         Units::Number { num_fmt, .. }
                         | Units::Currency { num_fmt, .. }
@@ -1645,7 +1645,7 @@ impl<'a> Model<'a> {
                                 NumFmtSpec::LocaleDate => {
                                     self.workbook.styles.get_style_with_num_fmt_id(
                                         new_style_index,
-                                        NumFmt::LOCALE_DATE_ID,
+                                        NumFmt::SHORT_DATE_ID,
                                     )?
                                 }
                                 // Explicit format string (ISO dates, currency, …).
@@ -1886,8 +1886,8 @@ impl<'a> Model<'a> {
                 // locale at render time so locale switches take effect without
                 // requiring a re-edit.
                 let format = match num_fmt_id {
-                    NumFmt::LOCALE_DATE_ID => self.locale.dates.date_formats.short.clone(),
-                    NumFmt::LOCALE_DATETIME_ID => locale_short_datetime_fmt(self.locale),
+                    NumFmt::SHORT_DATE_ID => self.locale.dates.date_formats.short.clone(),
+                    NumFmt::SHORT_DATETIME_ID => locale_short_datetime_fmt(self.locale),
                     _ => {
                         self.workbook
                             .styles
@@ -1963,10 +1963,10 @@ impl<'a> Model<'a> {
                     // pattern from the active locale so the edit bar stays in sync
                     // after a locale switch; literal formats use the stored string.
                     let date_fmt = match num_fmt_id {
-                        NumFmt::LOCALE_DATE_ID => {
+                        NumFmt::SHORT_DATE_ID => {
                             Some(self.locale.dates.date_formats.short.clone())
                         }
-                        NumFmt::LOCALE_DATETIME_ID => {
+                        NumFmt::SHORT_DATETIME_ID => {
                             Some(locale_short_datetime_fmt(self.locale))
                         }
                         _ if is_likely_date_number_format(&style.num_fmt.format_code) => {

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -26,7 +26,7 @@ use crate::{
     implicit_intersection::implicit_intersection,
     language::{get_default_language, get_language, Language},
     locale::{get_locale, Locale},
-    number_format::{is_locale_short_date_id, LOCALE_SHORT_DATE_FMT_ID},
+    number_format::{LOCALE_SHORT_DATE_FMT_ID, LOCALE_SHORT_DATE_TIME_FMT_ID},
     types::*,
     units::Units,
     utils as common,
@@ -63,6 +63,26 @@ pub fn get_milliseconds_since_epoch() -> i64 {
 pub fn get_milliseconds_since_epoch() -> i64 {
     use js_sys::Date;
     Date::now() as i64
+}
+
+/// Build the locale's short date+time format string at render time.
+///
+/// Mirrors the logic that was previously baked into `units_fn_date_times` at
+/// formula-entry time.  Called whenever a cell carries numFmtId 22 so that
+/// locale switches update the display without requiring a re-edit.
+fn locale_short_datetime_fmt(locale: &Locale) -> String {
+    let date_short = &locale.dates.date_formats.short;
+    // Replace the CLDR meridiem indicator 'a' with the Excel "AM/PM" token.
+    let time_short = locale.dates.time_formats.short.replace('a', "AM/PM");
+    // Template is typically "{1}, {0}" — date first, then time.
+    let fmt = locale
+        .dates
+        .date_time_formats
+        .short
+        .replace("{0}", time_short.trim())
+        .replace("{1}", date_short);
+    // Normalize narrow no-break space (U+202F) used by some CLDR locales.
+    fmt.replace('\u{202f}', " ")
 }
 
 /// A cell might be evaluated or being evaluated
@@ -1556,6 +1576,10 @@ impl<'a> Model<'a> {
                             .workbook
                             .styles
                             .get_style_with_num_fmt_id(new_style_index, LOCALE_SHORT_DATE_FMT_ID)?,
+                        Units::LocaleDateTime => self.workbook.styles.get_style_with_num_fmt_id(
+                            new_style_index,
+                            LOCALE_SHORT_DATE_TIME_FMT_ID,
+                        )?,
                         _ => self
                             .workbook
                             .styles
@@ -1590,7 +1614,6 @@ impl<'a> Model<'a> {
                         if should_apply_format {
                             new_style_index = match num_fmt_spec {
                                 // Locale date: store as numFmtId 14, render
-                                // functions can detect it via is_locale_short_date_id.
                                 NumFmtSpec::LocaleDate => {
                                     self.workbook.styles.get_style_with_num_fmt_id(
                                         new_style_index,
@@ -1831,13 +1854,13 @@ impl<'a> Model<'a> {
             Some(cell) => {
                 let style_index = self.get_cell_style_index(sheet_index, row, column)?;
                 let num_fmt_id = self.workbook.styles.get_num_fmt_id(style_index)?;
-                // For locale-derived date formats (numFmtId 14) use the
-                // locale's own short-date pattern so the display updates
-                // automatically when the user switches locales.
-                let format = if is_locale_short_date_id(num_fmt_id) {
-                    self.locale.dates.date_formats.short.clone()
-                } else {
-                    self.workbook.styles.get_style(style_index)?.num_fmt
+                // For locale-derived formats derive the pattern from the active
+                // locale at render time so locale switches take effect without
+                // requiring a re-edit.
+                let format = match num_fmt_id {
+                    LOCALE_SHORT_DATE_FMT_ID => self.locale.dates.date_formats.short.clone(),
+                    LOCALE_SHORT_DATE_TIME_FMT_ID => locale_short_datetime_fmt(self.locale),
+                    _ => self.workbook.styles.get_style(style_index)?.num_fmt,
                 };
                 let formatted_value =
                     cell.formatted_value(&self.workbook.shared_strings, self.language, |value| {
@@ -1901,21 +1924,26 @@ impl<'a> Model<'a> {
                         )
                     ))
                 } else {
-                    // If it is a date formatted cell we try to format it as date,
-                    // if it fails we return the raw value.
-                    // For locale-derived dates (numFmtId 14) use the locale's own
-                    // short-date pattern so the edit bar stays in sync with locale.
-                    let is_locale_date = is_locale_short_date_id(num_fmt_id);
-                    let is_date = is_locale_date || is_likely_date_number_format(&style.num_fmt);
-                    if is_date {
+                    // Resolve the date format string, or None if the cell is not
+                    // date-formatted.  Locale-derived IDs (14, 22) build their
+                    // pattern from the active locale so the edit bar stays in sync
+                    // after a locale switch; literal formats use the stored string.
+                    let date_fmt = match num_fmt_id {
+                        LOCALE_SHORT_DATE_FMT_ID => {
+                            Some(self.locale.dates.date_formats.short.clone())
+                        }
+                        LOCALE_SHORT_DATE_TIME_FMT_ID => {
+                            Some(locale_short_datetime_fmt(self.locale))
+                        }
+                        _ if is_likely_date_number_format(&style.num_fmt) => {
+                            Some(style.num_fmt.clone())
+                        }
+                        _ => None,
+                    };
+                    if let Some(fmt_str) = date_fmt {
                         let value = cell.value(&self.workbook.shared_strings, self.language);
                         if let CellValue::Number(n) = value {
-                            let fmt_str = if is_locale_date {
-                                &self.locale.dates.date_formats.short
-                            } else {
-                                &style.num_fmt
-                            };
-                            let formatted = format_number(n, fmt_str, self.locale);
+                            let formatted = format_number(n, &fmt_str, self.locale);
                             if formatted.error.is_none() {
                                 return Ok(formatted.text);
                             }

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -2575,7 +2575,7 @@ impl<'a> Model<'a> {
             .replace("¤", &format!("\"{}\"", currency_symbol))
             .replace(" ", " ");
 
-        let number_fmt = "#,##0.00".to_string();
+        let number_fmt = DefaultFmts::comma_dec(); //"#,##0.00"
         let number_example = format_number(1234.567, &number_fmt, self.locale).text;
         FmtSettings {
             currency,

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -28,6 +28,7 @@ use crate::{
     locale::{get_locale, Locale},
     number_format::{is_locale_short_date_id, LOCALE_SHORT_DATE_FMT_ID},
     types::*,
+    units::Units,
     utils as common,
 };
 
@@ -1546,10 +1547,20 @@ impl<'a> Model<'a> {
                 let cell = CellReferenceIndex { sheet, row, column };
                 let parsed_formula = &self.parsed_formulas[sheet as usize][formula_index as usize];
                 if let Some(units) = self.compute_node_units(parsed_formula, &cell) {
-                    let new_style_index = self
-                        .workbook
-                        .styles
-                        .get_style_with_format(new_style_index, &units.get_num_fmt())?;
+                    // Date-returning functions (DATE, TODAY, …) get numFmtId 14 so
+                    // that get_formatted_cell_value derives the display pattern from
+                    // the active locale at render time.  All other units (currency,
+                    // percentage, plain number) keep their literal format string.
+                    let new_style_index = match units {
+                        Units::LocaleDate => self
+                            .workbook
+                            .styles
+                            .get_style_with_num_fmt_id(new_style_index, LOCALE_SHORT_DATE_FMT_ID)?,
+                        _ => self
+                            .workbook
+                            .styles
+                            .get_style_with_format(new_style_index, &units.get_num_fmt())?,
+                    };
                     let style = self.workbook.styles.get_style(new_style_index)?;
                     self.set_cell_style(sheet, row, column, &style)?
                 }

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -26,7 +26,6 @@ use crate::{
     implicit_intersection::implicit_intersection,
     language::{get_default_language, get_language, Language},
     locale::{get_locale, Locale},
-    number_format::{LOCALE_SHORT_DATE_FMT_ID, LOCALE_SHORT_DATE_TIME_FMT_ID},
     types::*,
     units::Units,
     utils as common,
@@ -1592,10 +1591,10 @@ impl<'a> Model<'a> {
                         Units::LocaleDate => self
                             .workbook
                             .styles
-                            .get_style_with_num_fmt_id(new_style_index, LOCALE_SHORT_DATE_FMT_ID)?,
+                            .get_style_with_num_fmt_id(new_style_index, NumFmt::LOCALE_DATE_ID)?,
                         Units::LocaleDateTime => self.workbook.styles.get_style_with_num_fmt_id(
                             new_style_index,
-                            LOCALE_SHORT_DATE_TIME_FMT_ID,
+                            NumFmt::LOCALE_DATETIME_ID,
                         )?,
                         Units::Number { num_fmt, .. }
                         | Units::Currency { num_fmt, .. }
@@ -1637,8 +1636,7 @@ impl<'a> Model<'a> {
                         // works only by coincidence.  The ID check is exact.
                         let existing_style = self.workbook.styles.get_style(new_style_index)?;
                         let existing_id = existing_style.num_fmt.num_fmt_id;
-                        let existing_is_date = existing_id == LOCALE_SHORT_DATE_FMT_ID
-                            || existing_id == LOCALE_SHORT_DATE_TIME_FMT_ID
+                        let existing_is_date = NumFmt::is_locale_date_id(existing_id)
                             || is_likely_date_number_format(&existing_style.num_fmt.format_code);
                         let should_apply_format = !(existing_is_date && new_is_date);
                         if should_apply_format {
@@ -1647,7 +1645,7 @@ impl<'a> Model<'a> {
                                 NumFmtSpec::LocaleDate => {
                                     self.workbook.styles.get_style_with_num_fmt_id(
                                         new_style_index,
-                                        LOCALE_SHORT_DATE_FMT_ID,
+                                        NumFmt::LOCALE_DATE_ID,
                                     )?
                                 }
                                 // Explicit format string (ISO dates, currency, …).
@@ -1888,8 +1886,8 @@ impl<'a> Model<'a> {
                 // locale at render time so locale switches take effect without
                 // requiring a re-edit.
                 let format = match num_fmt_id {
-                    LOCALE_SHORT_DATE_FMT_ID => self.locale.dates.date_formats.short.clone(),
-                    LOCALE_SHORT_DATE_TIME_FMT_ID => locale_short_datetime_fmt(self.locale),
+                    NumFmt::LOCALE_DATE_ID => self.locale.dates.date_formats.short.clone(),
+                    NumFmt::LOCALE_DATETIME_ID => locale_short_datetime_fmt(self.locale),
                     _ => {
                         self.workbook
                             .styles
@@ -1965,10 +1963,10 @@ impl<'a> Model<'a> {
                     // pattern from the active locale so the edit bar stays in sync
                     // after a locale switch; literal formats use the stored string.
                     let date_fmt = match num_fmt_id {
-                        LOCALE_SHORT_DATE_FMT_ID => {
+                        NumFmt::LOCALE_DATE_ID => {
                             Some(self.locale.dates.date_formats.short.clone())
                         }
-                        LOCALE_SHORT_DATE_TIME_FMT_ID => {
+                        NumFmt::LOCALE_DATETIME_ID => {
                             Some(locale_short_datetime_fmt(self.locale))
                         }
                         _ if is_likely_date_number_format(&style.num_fmt.format_code) => {

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -208,7 +208,7 @@ mod tests {
     /// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.numberingformat?view=openxml-3.0.1
 
     #[test]
-    fn test_supported_num_fmt() {
+    fn test_full_numbering_format_class() {
         let plain = "
         0
 

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -93,7 +93,7 @@ impl DefaultFmts {
     // Formatter helper, otherwise we would need to do for each
     // function above to satisfy clippy.
     // DefaultFmts::by_id().unwrap_or("#,##0.00").to_string()
-    fn id_fmt_or_general(id: i32) -> String {
+    pub fn id_fmt_or_general(id: i32) -> String {
         DEFAULT_NUM_FMTS
             .iter()
             .find(|&&(fid, _)| fid == id)
@@ -362,7 +362,6 @@ mod tests {
             .collect();
 
         for id in gaps {
-            dbg!(&id);
             let fmt = NumFmt::from_id(id, &[]);
             assert_eq!(
                 fmt.num_fmt_id, 0,

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -1,4 +1,5 @@
 use crate::{
+    constants::{SHORT_DATETIME_ID, SHORT_DATE_ID},
     formatter::{self, format::Formatted},
     locale::get_locale,
 };
@@ -65,38 +66,44 @@ impl DefaultFmts {
         Self::by_id(id).is_some()
     }
 
-    ///
     /// 3: `#,##0`
     pub(crate) fn comma_int() -> String {
-        DefaultFmts::by_id(3).unwrap().to_string()
+        DefaultFmts::id_fmt_or_general(3) //.unwrap_or("#,##0").to_string()
     }
 
     ///  4: `#,##0.00`
     pub(crate) fn comma_dec() -> String {
-        DefaultFmts::by_id(4).unwrap().to_string()
+        DefaultFmts::id_fmt_or_general(4) //.unwrap_or("#,##0.00").to_string()
     }
     /// 9: `0%`
     pub(crate) fn percent_int() -> String {
-        DefaultFmts::by_id(9).unwrap().to_string()
+        DefaultFmts::id_fmt_or_general(9) //.unwrap_or("0%").to_string()
     }
 
     ///  10: `0.00%`
     pub(crate) fn percent_dec() -> String {
-        DefaultFmts::by_id(10).unwrap().to_string()
+        DefaultFmts::id_fmt_or_general(10) //.unwrap_or("0.00%").to_string()
     }
 
     /// 11: `0.00E+00`
     pub(crate) fn scientific_format() -> String {
-        DefaultFmts::by_id(11).unwrap().to_string()
+        DefaultFmts::id_fmt_or_general(11)
     }
 
-    /// 14: locale short date.
-    pub(crate) const SHORT_DATE_ID: i32 = 14;
-    /// 22: locale short date+time.
-    pub(crate) const SHORT_DATETIME_ID: i32 = 22;
+    // Formatter helper, otherwise we would need to do for each
+    // function above to satisfy clippy.
+    // DefaultFmts::by_id().unwrap_or("#,##0.00").to_string()
+    fn id_fmt_or_general(id: i32) -> String {
+        DEFAULT_NUM_FMTS
+            .iter()
+            .find(|&&(fid, _)| fid == id)
+            .map(|&(_, s)| s)
+            .unwrap_or("General")
+            .to_string()
+    }
 
     pub(crate) fn is_locale_date(id: i32) -> bool {
-        id == Self::SHORT_DATE_ID || id == Self::SHORT_DATETIME_ID
+        id == SHORT_DATE_ID || id == SHORT_DATETIME_ID
     }
 }
 

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -151,10 +151,9 @@ mod tests {
     /// break format detection throughout the codebase.
     #[test]
     fn builtin_num_fmts_index_matches_spec_ids() {
+        assert_eq!(DEFAULT_NUM_FMTS.len(), 45, "DEFAULT_NUM_FMTS length changed — update this assertion and verify all numFmtIds");
         assert_eq!(DEFAULT_NUM_FMTS[0], "general", "numFmtId 0 must be General");
         assert_eq!(DEFAULT_NUM_FMTS[9], "0%", "numFmtId 9 must be 0%");
-        // ID 14 is the ECMA-376 locale short date — used throughout the
-        // render pipeline to detect locale-derived date cells.
         assert_eq!(
             DEFAULT_NUM_FMTS[LOCALE_SHORT_DATE_FMT_ID as usize], "mm-dd-yy",
             "numFmtId 14 must be the ECMA-376 locale short date 'mm-dd-yy'"

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -3,16 +3,10 @@ use crate::{
     locale::get_locale,
 };
 
-/// Built-in number format strings indexed by their ECMA-376 numFmtId.
+/// ECMA-376 built-in number format strings; index == numFmtId.
 ///
-/// **ORDERING IS SPEC-MANDATED — do not insert, remove, or reorder entries.**
-/// The index in this array IS the numFmtId as defined in ECMA-376.
-/// Code throughout the codebase (and every `.xlsx` file on disk) uses these
-/// IDs by their numeric value, not by position in this array. Any accidental
-/// reordering will cause silent mis-formatting for any ID after the change.
-///
-/// The test `builtin_num_fmts_index_matches_spec_ids` guards the
-/// critical positions.
+/// **Do not insert, remove, or reorder** — the index IS the numFmtId.
+/// See `builtin_num_fmts_index_matches_spec_ids` for guards on critical positions.
 pub(crate) const DEFAULT_NUM_FMTS: &[&str] = &[
     "general",
     "0",
@@ -60,15 +54,6 @@ pub(crate) const DEFAULT_NUM_FMTS: &[&str] = &[
     "t0.00 %",
     "t#?/?",
 ];
-
-/// ECMA-376 numFmtId for the locale-derived short date.
-///
-/// The value `14` is mandated by the Office Open XML specification.
-/// https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/0e59abdb-7f4e-48fc-9b89-67832fa11789
-pub const SHORT_DATE_FMT_ID: i32 = 14;
-
-/// ECMA-376 numFmtId for the locale-derived short date+time ("m / d / yy h:mm").
-pub const SHORT_DATE_TIME_FMT_ID: i32 = 22;
 
 pub fn to_precision(value: f64, precision: usize) -> f64 {
     if value.is_infinite() || value.is_nan() {
@@ -145,17 +130,13 @@ pub fn format_number(value: f64, format_code: &str, locale: &str) -> Formatted {
 mod tests {
     use super::*;
 
-    /// Verify that critical ECMA-376 built-in numFmtIds are at the correct
-    /// positions in `DEFAULT_NUM_FMTS`.  The array index IS the numFmtId, so
-    /// inserting or removing any entry before these positions would silently
-    /// break format detection throughout the codebase.
     #[test]
     fn builtin_num_fmts_index_matches_spec_ids() {
         assert_eq!(DEFAULT_NUM_FMTS.len(), 45, "DEFAULT_NUM_FMTS length changed — update this assertion and verify all numFmtIds");
         assert_eq!(DEFAULT_NUM_FMTS[0], "general", "numFmtId 0 must be General");
         assert_eq!(DEFAULT_NUM_FMTS[9], "0%", "numFmtId 9 must be 0%");
         assert_eq!(
-            DEFAULT_NUM_FMTS[SHORT_DATE_FMT_ID as usize], "mm-dd-yy",
+            DEFAULT_NUM_FMTS[14], "mm-dd-yy",
             "numFmtId 14 must be the ECMA-376 locale short date 'mm-dd-yy'"
         );
         assert_eq!(

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -4,6 +4,16 @@ use crate::{
     types::NumFmt,
 };
 
+/// Built-in number format strings indexed by their ECMA-376 numFmtId.
+///
+/// **ORDERING IS SPEC-MANDATED — do not insert, remove, or reorder entries.**
+/// The index in this array IS the numFmtId as defined in ECMA-376.
+/// Code throughout the codebase (and every `.xlsx` file on disk) uses these
+/// IDs by their numeric value, not by position in this array. Any accidental
+/// reordering will cause silent mis-formatting for any ID after the change.
+/// 
+/// The test `builtin_num_fmts_index_matches_spec_ids` guards the
+/// critical positions.
 const DEFAULT_NUM_FMTS: &[&str] = &[
     "general",
     "0",
@@ -51,6 +61,22 @@ const DEFAULT_NUM_FMTS: &[&str] = &[
     "t0.00 %",
     "t#?/?",
 ];
+
+/// ECMA-376 numFmtId for the locale-derived short date.
+/// 
+/// The value `14` is mandated by the Office Open XML specification.
+/// https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/0e59abdb-7f4e-48fc-9b89-67832fa11789
+pub const LOCALE_SHORT_DATE_FMT_ID: i32 = 14;
+
+/// Returns `true` for ECMA-376 numFmtIds whose rendering is locale-derived
+/// rather than tied to a literal format string.
+///
+/// Currently only ID 14 (short date, "m/d/yy" in en-US).  ID 22 ("m/d/yy
+/// h:mm", short date+time) follows the same pattern and can be added here
+/// when date-time locale rendering is implemented.
+pub fn is_locale_short_date_id(id: i32) -> bool {
+    id == LOCALE_SHORT_DATE_FMT_ID
+}
 
 pub fn get_default_num_fmt_id(num_fmt: &str) -> Option<i32> {
     for (index, default_num_fmt) in DEFAULT_NUM_FMTS.iter().enumerate() {
@@ -161,4 +187,30 @@ pub fn format_number(value: f64, format_code: &str, locale: &str) -> Formatted {
         }
     };
     formatter::format::format_number(value, format_code, locale)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that critical ECMA-376 built-in numFmtIds are at the correct
+    /// positions in `DEFAULT_NUM_FMTS`.  The array index IS the numFmtId, so
+    /// inserting or removing any entry before these positions would silently
+    /// break format detection throughout the codebase.
+    #[test]
+    fn builtin_num_fmts_index_matches_spec_ids() {
+        assert_eq!(DEFAULT_NUM_FMTS[0], "general", "numFmtId 0 must be General");
+        assert_eq!(DEFAULT_NUM_FMTS[9], "0%", "numFmtId 9 must be 0%");
+        // ID 14 is the ECMA-376 locale short date — used throughout the
+        // render pipeline to detect locale-derived date cells.
+        assert_eq!(
+            DEFAULT_NUM_FMTS[LOCALE_SHORT_DATE_FMT_ID as usize], "mm-dd-yy",
+            "numFmtId 14 must be the ECMA-376 locale short date 'mm-dd-yy'"
+        );
+        assert_eq!(
+            DEFAULT_NUM_FMTS[22], "m / d / yy h:mm",
+            "numFmtId 22 must be the locale short date+time"
+        );
+    }
 }

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -1,7 +1,6 @@
 use crate::{
     formatter::{self, format::Formatted},
     locale::get_locale,
-    types::NumFmt,
 };
 
 /// Built-in number format strings indexed by their ECMA-376 numFmtId.
@@ -14,7 +13,7 @@ use crate::{
 ///
 /// The test `builtin_num_fmts_index_matches_spec_ids` guards the
 /// critical positions.
-const DEFAULT_NUM_FMTS: &[&str] = &[
+pub(crate) const DEFAULT_NUM_FMTS: &[&str] = &[
     "general",
     "0",
     "0.00",
@@ -70,46 +69,6 @@ pub const LOCALE_SHORT_DATE_FMT_ID: i32 = 14;
 
 /// ID 22 ("m/d/yy h:mm", short date+time)
 pub const LOCALE_SHORT_DATE_TIME_FMT_ID: i32 = 22;
-
-pub fn get_default_num_fmt_id(num_fmt: &str) -> Option<i32> {
-    for (index, default_num_fmt) in DEFAULT_NUM_FMTS.iter().enumerate() {
-        if default_num_fmt == &num_fmt {
-            return Some(index as i32);
-        };
-    }
-    None
-}
-
-pub fn get_num_fmt(num_fmt_id: i32, num_fmts: &[NumFmt]) -> String {
-    // Check if it defined
-    for num_fmt in num_fmts {
-        if num_fmt.num_fmt_id == num_fmt_id {
-            return num_fmt.format_code.clone();
-        }
-    }
-    // Return one of the default ones
-    if num_fmt_id < DEFAULT_NUM_FMTS.len() as i32 {
-        return DEFAULT_NUM_FMTS[num_fmt_id as usize].to_string();
-    }
-    // Return general
-    DEFAULT_NUM_FMTS[0].to_string()
-}
-
-pub fn get_new_num_fmt_index(num_fmts: &[NumFmt]) -> i32 {
-    let mut index = DEFAULT_NUM_FMTS.len() as i32;
-    let mut found = true;
-    while found {
-        found = false;
-        for num_fmt in num_fmts {
-            if num_fmt.num_fmt_id == index {
-                found = true;
-                index += 1;
-                break;
-            }
-        }
-    }
-    index
-}
 
 pub fn to_precision(value: f64, precision: usize) -> f64 {
     if value.is_infinite() || value.is_nan() {

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -65,10 +65,10 @@ pub(crate) const DEFAULT_NUM_FMTS: &[&str] = &[
 ///
 /// The value `14` is mandated by the Office Open XML specification.
 /// https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/0e59abdb-7f4e-48fc-9b89-67832fa11789
-pub const LOCALE_SHORT_DATE_FMT_ID: i32 = 14;
+pub const SHORT_DATE_FMT_ID: i32 = 14;
 
 /// ECMA-376 numFmtId for the locale-derived short date+time ("m / d / yy h:mm").
-pub const LOCALE_SHORT_DATE_TIME_FMT_ID: i32 = 22;
+pub const SHORT_DATE_TIME_FMT_ID: i32 = 22;
 
 pub fn to_precision(value: f64, precision: usize) -> f64 {
     if value.is_infinite() || value.is_nan() {
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(DEFAULT_NUM_FMTS[0], "general", "numFmtId 0 must be General");
         assert_eq!(DEFAULT_NUM_FMTS[9], "0%", "numFmtId 9 must be 0%");
         assert_eq!(
-            DEFAULT_NUM_FMTS[LOCALE_SHORT_DATE_FMT_ID as usize], "mm-dd-yy",
+            DEFAULT_NUM_FMTS[SHORT_DATE_FMT_ID as usize], "mm-dd-yy",
             "numFmtId 14 must be the ECMA-376 locale short date 'mm-dd-yy'"
         );
         assert_eq!(

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -3,57 +3,91 @@ use crate::{
     locale::get_locale,
 };
 
-/// ECMA-376 built-in number format strings; index == numFmtId.
+/// ECMA-376 built-in number format strings as `(numFmtId, format_code)` pairs.
 ///
-/// **Do not insert, remove, or reorder** — the index IS the numFmtId.
-/// See `builtin_num_fmts_index_matches_spec_ids` for guards on critical positions.
-pub(crate) const DEFAULT_NUM_FMTS: &[&str] = &[
-    "general",
-    "0",
-    "0.00",
-    "#,##0",
-    "#,##0.00",
-    "$#,##0; \\ - $#,##0",
-    "$#,##0; [Red] \\ - $#,##0",
-    "$#,##0.00; \\ - $#,##0.00",
-    "$#,##0.00; [Red] \\ - $#,##0.00",
-    "0%",
-    "0.00%",
-    "0.00E + 00",
-    "#?/?",
-    "#?? / ??",
-    "mm-dd-yy",
-    "d-mmm-yy",
-    "d-mmm",
-    "mmm-yy",
-    "h:mm AM / PM",
-    "h:mm:ss AM / PM",
-    "h:mm",
-    "h:mm:ss",
-    "m / d / yy h:mm",
-    "#,##0;()#,##0)",
-    "#,##0; [Red]()#,##0)",
-    "#,##0.00;()#,##0.00)",
-    "#,##0.00; [Red]()#,##0.00)",
-    "_()$”*#,##0.00 _); _()$”* \\()#,##0.00\\); _()$”* - ?? _); _()@_)",
-    "mm:ss",
-    "[h]:mm:ss",
-    "mmss .0",
-    "##0.0E + 0",
-    "@",
-    "[$ -404] e / m / d ",
-    "m / d / yy",
-    "[$ -404] e / m / d",
-    "[$ -404] e / / d",
-    "[$ -404] e / m / d",
-    "t0",
-    "t0.00",
-    "t#,##0",
-    "t#,##0.00",
-    "t0%",
-    "t0.00 %",
-    "t#?/?",
+/// **Do not change IDs** — the numFmtId values are part of the ECMA-376 spec.
+/// Entries can be reordered freely; IDs must remain stable.
+/// See `builtin_num_fmts_spec_ids_are_correct` for guards on critical entries.
+pub(crate) const NUM_FMTS: &[(i32, &str)] = &[
+    (0,  "general"),
+    (1,  "0"),
+    (2,  "0.00"),
+    (3,  "#,##0"),
+    (4,  "#,##0.00"),
+    (5,  r#"$#,##0; \ - $#,##0"#),
+    (6,  r#"$#,##0; [Red] \ - $#,##0"#),
+    (7,  r#"$#,##0.00; \ - $#,##0.00"#),
+    (8,  r#"$#,##0.00; [Red] \ - $#,##0.00"#),
+    (9,  "0%"),
+    (10, "0.00%"),
+    (11, "0.00E + 00"),
+    (12, "#?/?"),
+    (13, "#?? / ??"),
+    (14, "mm-dd-yy"),
+    (15, "d-mmm-yy"),
+    (16, "d-mmm"),
+    (17, "mmm-yy"),
+    (18, "h:mm AM / PM"),
+    (19, "h:mm:ss AM / PM"),
+    (20, "h:mm"),
+    (21, "h:mm:ss"),
+    (22, "m / d / yy h:mm"),
+    (23, "#,##0;()#,##0)"),
+    (24, "#,##0; [Red]()#,##0)"),
+    (25, "#,##0.00;()#,##0.00)"),
+    (26, "#,##0.00; [Red]()#,##0.00)"),
+    (27, r#"_()$”*#,##0.00 _); _()$”* \()#,##0.00\); _()$”* - ?? _); _()@_)"#),
+    (28, "mm:ss"),
+    (29, "[h]:mm:ss"),
+    (30, "mmss .0"),
+    (31, "##0.0E + 0"),
+    (32, "@"),
+    (33, "[$ -404] e / m / d "),
+    (34, "m / d / yy"),
+    (35, "[$ -404] e / m / d"),
+    (36, "[$ -404] e / / d"),
+    (37, "[$ -404] e / m / d"),
+    (38, "t0"),
+    (39, "t0.00"),
+    (40, "t#,##0"),
+    (41, "t#,##0.00"),
+    (42, "t0%"),
+    (43, "t0.00 %"),
+    (44, "t#?/?"),
 ];
+
+/// Zero-sized accessor for the built-in number format table.
+///
+/// Centralises all pattern matching over `NUM_FMTS` so call sites read clearly.
+pub(crate) struct BuiltinFmts;
+
+impl BuiltinFmts {
+    /// Format code for a built-in `numFmtId`, or `None` if not a built-in.
+    pub(crate) fn by_id(id: i32) -> Option<&'static str> {
+        NUM_FMTS.iter().find(|&&(fid, _)| fid == id).map(|&(_, s)| s)
+    }
+
+    /// Built-in `numFmtId` for a format code, or `None` if not a built-in.
+    pub(crate) fn by_code(code: &str) -> Option<i32> {
+        NUM_FMTS.iter().find(|&&(_, s)| s == code).map(|&(id, _)| id)
+    }
+
+    /// True if `id` belongs to the built-in table.
+    pub(crate) fn contains_id(id: i32) -> bool {
+        Self::by_id(id).is_some()
+    }
+
+    /// ECMA-376 numFmtId 14: locale short date.
+    pub(crate) const SHORT_DATE_ID: i32 = 14;
+    /// ECMA-376 numFmtId 22: locale short date+time.
+    pub(crate) const SHORT_DATETIME_ID: i32 = 22;
+
+    /// True if `id` is a locale date sentinel (14 or 22).
+    pub(crate) fn is_locale_date(id: i32) -> bool {
+        id == Self::SHORT_DATE_ID || id == Self::SHORT_DATETIME_ID
+    }
+
+}
 
 pub fn to_precision(value: f64, precision: usize) -> f64 {
     if value.is_infinite() || value.is_nan() {
@@ -131,17 +165,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn builtin_num_fmts_index_matches_spec_ids() {
-        assert_eq!(DEFAULT_NUM_FMTS.len(), 45, "DEFAULT_NUM_FMTS length changed — update this assertion and verify all numFmtIds");
-        assert_eq!(DEFAULT_NUM_FMTS[0], "general", "numFmtId 0 must be General");
-        assert_eq!(DEFAULT_NUM_FMTS[9], "0%", "numFmtId 9 must be 0%");
-        assert_eq!(
-            DEFAULT_NUM_FMTS[14], "mm-dd-yy",
-            "numFmtId 14 must be the ECMA-376 locale short date 'mm-dd-yy'"
-        );
-        assert_eq!(
-            DEFAULT_NUM_FMTS[22], "m / d / yy h:mm",
-            "numFmtId 22 must be the locale short date+time"
-        );
+    fn builtin_num_fmts_spec_ids_are_correct() {
+        assert_eq!(NUM_FMTS.len(), 45, "NUM_FMTS length changed — update and verify all numFmtIds");
+        assert_eq!(BuiltinFmts::by_id(0),  Some("general"),         "numFmtId 0 must be General");
+        assert_eq!(BuiltinFmts::by_id(9),  Some("0%"),              "numFmtId 9 must be 0%");
+        assert_eq!(BuiltinFmts::by_id(14), Some("mm-dd-yy"),        "numFmtId 14 must be the ECMA-376 locale short date");
+        assert_eq!(BuiltinFmts::by_id(22), Some("m / d / yy h:mm"), "numFmtId 22 must be the locale short date+time");
     }
 }

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -67,7 +67,7 @@ pub(crate) const DEFAULT_NUM_FMTS: &[&str] = &[
 /// https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/0e59abdb-7f4e-48fc-9b89-67832fa11789
 pub const LOCALE_SHORT_DATE_FMT_ID: i32 = 14;
 
-/// ID 22 ("m/d/yy h:mm", short date+time)
+/// ECMA-376 numFmtId for the locale-derived short date+time ("m / d / yy h:mm").
 pub const LOCALE_SHORT_DATE_TIME_FMT_ID: i32 = 22;
 
 pub fn to_precision(value: f64, precision: usize) -> f64 {

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -11,7 +11,7 @@ use crate::{
 /// Code throughout the codebase (and every `.xlsx` file on disk) uses these
 /// IDs by their numeric value, not by position in this array. Any accidental
 /// reordering will cause silent mis-formatting for any ID after the change.
-/// 
+///
 /// The test `builtin_num_fmts_index_matches_spec_ids` guards the
 /// critical positions.
 const DEFAULT_NUM_FMTS: &[&str] = &[
@@ -63,7 +63,7 @@ const DEFAULT_NUM_FMTS: &[&str] = &[
 ];
 
 /// ECMA-376 numFmtId for the locale-derived short date.
-/// 
+///
 /// The value `14` is mandated by the Office Open XML specification.
 /// https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/0e59abdb-7f4e-48fc-9b89-67832fa11789
 pub const LOCALE_SHORT_DATE_FMT_ID: i32 = 14;
@@ -188,7 +188,6 @@ pub fn format_number(value: f64, format_code: &str, locale: &str) -> Formatted {
     };
     formatter::format::format_number(value, format_code, locale)
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -68,15 +68,8 @@ const DEFAULT_NUM_FMTS: &[&str] = &[
 /// https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/0e59abdb-7f4e-48fc-9b89-67832fa11789
 pub const LOCALE_SHORT_DATE_FMT_ID: i32 = 14;
 
-/// Returns `true` for ECMA-376 numFmtIds whose rendering is locale-derived
-/// rather than tied to a literal format string.
-///
-/// Currently only ID 14 (short date, "m/d/yy" in en-US).  ID 22 ("m/d/yy
-/// h:mm", short date+time) follows the same pattern and can be added here
-/// when date-time locale rendering is implemented.
-pub fn is_locale_short_date_id(id: i32) -> bool {
-    id == LOCALE_SHORT_DATE_FMT_ID
-}
+/// ID 22 ("m/d/yy h:mm", short date+time)
+pub const LOCALE_SHORT_DATE_TIME_FMT_ID: i32 = 22;
 
 pub fn get_default_num_fmt_id(num_fmt: &str) -> Option<i32> {
     for (index, default_num_fmt) in DEFAULT_NUM_FMTS.iter().enumerate() {

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -4,68 +4,48 @@ use crate::{
 };
 
 /// ECMA-376 built-in number format strings as `(numFmtId, format_code)` pairs.
-///
+/// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.numberingformat?view=openxml-3.0.1
 /// **Do not change IDs** — the numFmtId values are part of the ECMA-376 spec.
-/// Entries can be reordered freely; IDs must remain stable.
-/// See `builtin_num_fmts_spec_ids_are_correct` for guards on critical entries.
 pub(crate) const DEFAULT_NUM_FMTS: &[(i32, &str)] = &[
-    (0, "general"),
+    (0, "General"),
     (1, "0"),
     (2, "0.00"),
     (3, "#,##0"),
     (4, "#,##0.00"),
-    (5, r#"$#,##0; \ - $#,##0"#),
-    (6, r#"$#,##0; [Red] \ - $#,##0"#),
-    (7, r#"$#,##0.00; \ - $#,##0.00"#),
-    (8, r#"$#,##0.00; [Red] \ - $#,##0.00"#),
+    // specification excludes IDs 5, 6, 7, and 8
     (9, "0%"),
     (10, "0.00%"),
-    (11, "0.00E + 00"),
-    (12, "#?/?"),
-    (13, "#?? / ??"),
+    (11, "0.00E+00"),
+    (12, "# ?/?"),
+    (13, "# ??/??"),
     (14, "mm-dd-yy"),
     (15, "d-mmm-yy"),
     (16, "d-mmm"),
     (17, "mmm-yy"),
-    (18, "h:mm AM / PM"),
-    (19, "h:mm:ss AM / PM"),
+    (18, "h:mm AM/PM"),
+    (19, "h:mm:ss AM/PM"),
     (20, "h:mm"),
     (21, "h:mm:ss"),
-    (22, "m / d / yy h:mm"),
-    (23, "#,##0;()#,##0)"),
-    (24, "#,##0; [Red]()#,##0)"),
-    (25, "#,##0.00;()#,##0.00)"),
-    (26, "#,##0.00; [Red]()#,##0.00)"),
-    (
-        27,
-        r#"_()$”*#,##0.00 _); _()$”* \()#,##0.00\); _()$”* - ?? _); _()@_)"#,
-    ),
-    (28, "mm:ss"),
-    (29, "[h]:mm:ss"),
-    (30, "mmss .0"),
-    (31, "##0.0E + 0"),
-    (32, "@"),
-    (33, "[$ -404] e / m / d "),
-    (34, "m / d / yy"),
-    (35, "[$ -404] e / m / d"),
-    (36, "[$ -404] e / / d"),
-    (37, "[$ -404] e / m / d"),
-    (38, "t0"),
-    (39, "t0.00"),
-    (40, "t#,##0"),
-    (41, "t#,##0.00"),
-    (42, "t0%"),
-    (43, "t0.00 %"),
-    (44, "t#?/?"),
+    (22, "m/d/yy h:mm"),
+    // 23 - 31 Japanese (ja-JP) specialized date and time formats
+    // 32 - 35 Chinese (zh-CN/zh-TW) and Korean (ko-KR) specialized number/date formats.
+    // 36 specific localized currency formats
+    (37, "#,##0 ;(#,##0)"),
+    (38, "#,##0 ;[Red](#,##0)"),
+    (39, "#,##0.00;(#,##0.00)"),
+    (40, "#,##0.00;[Red](#,##0.00)"),
+    // Accounting formats
+    // 41 - 44
+    (45, "mm:ss"),
+    (46, "[h]:mm:ss"),
+    (47, "mmss.0"),
+    (48, "##0.0E+0"),
+    (49, "@"),
 ];
 
-/// Zero-sized accessor for the built-in number format table.
-///
-/// Centralises all pattern matching over `NUM_FMTS` so call sites read clearly.
 pub(crate) struct DefaultFmts;
 
 impl DefaultFmts {
-    /// Format code for a built-in `numFmtId`, or `None` if not a built-in.
     pub(crate) fn by_id(id: i32) -> Option<&'static str> {
         DEFAULT_NUM_FMTS
             .iter()
@@ -73,7 +53,6 @@ impl DefaultFmts {
             .map(|&(_, s)| s)
     }
 
-    /// Built-in `numFmtId` for a format code, or `None` if not a built-in.
     pub(crate) fn by_code(code: &str) -> Option<i32> {
         DEFAULT_NUM_FMTS
             .iter()
@@ -86,12 +65,36 @@ impl DefaultFmts {
         Self::by_id(id).is_some()
     }
 
-    /// ECMA-376 numFmtId 14: locale short date.
+    ///
+    /// 3: `#,##0`
+    pub(crate) fn comma_int() -> String {
+        DefaultFmts::by_id(3).unwrap().to_string()
+    }
+
+    ///  4: `#,##0.00`
+    pub(crate) fn comma_dec() -> String {
+        DefaultFmts::by_id(4).unwrap().to_string()
+    }
+    /// 9: `0%`
+    pub(crate) fn percent_int() -> String {
+        DefaultFmts::by_id(9).unwrap().to_string()
+    }
+
+    ///  10: `0.00%`
+    pub(crate) fn percent_dec() -> String {
+        DefaultFmts::by_id(10).unwrap().to_string()
+    }
+
+    /// 11: `0.00E+00`
+    pub(crate) fn scientific_format() -> String {
+        DefaultFmts::by_id(11).unwrap().to_string()
+    }
+
+    /// 14: locale short date.
     pub(crate) const SHORT_DATE_ID: i32 = 14;
-    /// ECMA-376 numFmtId 22: locale short date+time.
+    /// 22: locale short date+time.
     pub(crate) const SHORT_DATETIME_ID: i32 = 22;
 
-    /// True if `id` is a locale date sentinel (14 or 22).
     pub(crate) fn is_locale_date(id: i32) -> bool {
         id == Self::SHORT_DATE_ID || id == Self::SHORT_DATETIME_ID
     }
@@ -175,13 +178,8 @@ mod tests {
     #[test]
     fn builtin_num_fmts_spec_ids_are_correct() {
         assert_eq!(
-            DEFAULT_NUM_FMTS.len(),
-            45,
-            "NUM_FMTS length changed — update and verify all numFmtIds"
-        );
-        assert_eq!(
             DefaultFmts::by_id(0),
-            Some("general"),
+            Some("General"),
             "numFmtId 0 must be General"
         );
         assert_eq!(DefaultFmts::by_id(9), Some("0%"), "numFmtId 9 must be 0%");
@@ -192,84 +190,148 @@ mod tests {
         );
         assert_eq!(
             DefaultFmts::by_id(22),
-            Some("m / d / yy h:mm"),
+            Some("m/d/yy h:mm"),
             "numFmtId 22 must be the locale short date+time"
         );
     }
 
     /// ECMA-376 §18.8.30 — canonical built-in format codes for the US (default) locale.
     ///
-    /// Reference: Apache POI `BuiltinFormats.java`, cross-checked with the spec.
-    /// IDs 23–36 are locale-specific (East-Asian date/time) and absent for US locale.
-    /// IDs 45–49 are the ECMA-376 time/special formats currently missing from this table.
-    ///
-    /// This test is intentionally RED until DEFAULT_NUM_FMTS is corrected.
+    /// Format codes data from:
+    /// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.numberingformat?view=openxml-3.0.1
+
     #[test]
-    #[ignore = "not yet implemented"]
-    fn builtin_num_fmts_ecma376_us_locale() {
-        let cases: &[(i32, &str)] = &[
-            (0, "general"),
-            (1, "0"),
-            (2, "0.00"),
-            (3, "#,##0"),
-            (4, "#,##0.00"),
-            // IDs 5–8: US-dollar currency, negative in parentheses with alignment gap.
-            (5, "$#,##0_);($#,##0)"),
-            (6, "$#,##0_);[Red]($#,##0)"),
-            (7, "$#,##0.00_);($#,##0.00)"),
-            (8, "$#,##0.00_);[Red]($#,##0.00)"),
-            (9, "0%"),
-            (10, "0.00%"),
-            (11, "0.00E+00"), // no spaces around +
-            (12, "# ?/?"),    // space before ?
-            (13, "# ??/??"),  // space before ?, no spaces around /
-            (14, "m/d/yy"),   // ECMA-376 locale short-date sentinel
-            (15, "d-mmm-yy"),
-            (16, "d-mmm"),
-            (17, "mmm-yy"),
-            (18, "h:mm AM/PM"), // no spaces around /
-            (19, "h:mm:ss AM/PM"),
-            (20, "h:mm"),
-            (21, "h:mm:ss"),
-            (22, "m/d/yy h:mm"), // no spaces around /
-            // 23–36: absent — locale-specific (East-Asian), not defined for US locale.
-            // 37–40: parenthesised accounting variants (no currency symbol).
-            (37, "#,##0_);(#,##0)"),
-            (38, "#,##0_);[Red](#,##0)"),
-            (39, "#,##0.00_);(#,##0.00)"),
-            (40, "#,##0.00_);[Red](#,##0.00)"),
-            // 41–44: fill-character accounting variants.
-            (41, r#"_(* #,##0_);_(* (#,##0);_(* "-"_);_(@_)"#),
-            (42, r#"_("$"* #,##0_);_("$"* (#,##0);_("$"* "-"_);_(@_)"#),
-            (43, r#"_(* #,##0.00_);_(* (#,##0.00);_(* "-"??_);_(@_)"#),
-            (
-                44,
-                r#"_("$"* #,##0.00_);_("$"* (#,##0.00);_("$"* "-"??_);_(@_)"#,
-            ),
-            // 45–49: time / special — currently missing from IronCalc's table.
-            (45, "mm:ss"),
-            (46, "[h]:mm:ss"),
-            (47, "mmss.0"),
-            (48, "##0.0E+0"),
-            (49, "@"),
-        ];
+    fn test_supported_num_fmt() {
+        let plain = "
+        0
 
-        for &(id, expected) in cases {
-            assert_eq!(
-                DefaultFmts::by_id(id),
-                Some(expected),
-                "numFmtId {id}: expected {expected:?}, got {:?}",
-                DefaultFmts::by_id(id)
-            );
-        }
+        General
 
-        // IDs 23–36 must be absent for US locale.
-        for id in 23_i32..=36 {
-            assert!(
-                DefaultFmts::by_id(id).is_none(),
-                "numFmtId {id} must be absent for US locale, got {:?}",
-                DefaultFmts::by_id(id)
-            );
+        1
+
+        0
+
+        2
+
+        0.00
+
+        3
+
+        #,##0
+
+        4
+
+        #,##0.00
+
+        9
+
+        0%
+
+        10
+
+        0.00%
+
+        11
+
+        0.00E+00
+
+        12
+
+        # ?/?
+
+        13
+
+        # ??/??
+
+        14
+
+        mm-dd-yy
+
+        15
+
+        d-mmm-yy
+
+        16
+
+        d-mmm
+
+        17
+
+        mmm-yy
+
+        18
+
+        h:mm AM/PM
+
+        19
+
+        h:mm:ss AM/PM
+
+        20
+
+        h:mm
+
+        21
+
+        h:mm:ss
+
+        22
+
+        m/d/yy h:mm
+
+        37
+
+        #,##0 ;(#,##0)
+
+        38
+
+        #,##0 ;[Red](#,##0)
+
+        39
+
+        #,##0.00;(#,##0.00)
+
+        40
+
+        #,##0.00;[Red](#,##0.00)
+
+        45
+
+        mm:ss
+
+        46
+
+        [h]:mm:ss
+
+        47
+
+        mmss.0
+
+        48
+
+        ##0.0E+0
+
+        49
+
+        @";
+
+        let lines: Vec<&str> = plain
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .collect();
+        let pairs: Vec<(i32, &str)> = lines
+            .chunks(2)
+            .filter_map(|p| match p {
+                [id, fmt] => id.parse::<i32>().ok().map(|n| (n, *fmt)),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(DEFAULT_NUM_FMTS.len(), pairs.len());
+
+        for &(id, expected) in pairs.iter() {
+            assert_eq!(DefaultFmts::by_id(id), Some(expected), "numFmtId {id}");
         }
     }
 }

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -341,4 +341,44 @@ mod tests {
             assert_eq!(DefaultFmts::by_id(id), Some(expected), "numFmtId {id}");
         }
     }
+
+    // Derive gap IDs from DEFAULT_NUM_FMTS — IDs in 0..ECMA_CUSTOM_FMT_MIN_ID
+    // that are absent from the table — and verify the boundary.
+    //     #[cfg(not(debug_assertions))]
+
+    #[test]
+    #[should_panic(expected = "is unknown")]
+    fn test_no_builtin_in_gap_ranges() {
+        use crate::constants::ECMA_CUSTOM_FMT_MIN_ID;
+        use crate::types::NumFmt;
+        use std::collections::HashSet;
+
+        let known: HashSet<i32> = DEFAULT_NUM_FMTS.iter().map(|&(id, _)| id).collect();
+
+        // Gap IDs are those absent from DEFAULT_NUM_FMTS within the built-in range.
+        // The highest gap must be ECMA_CUSTOM_FMT_MIN_ID - 1 = 163.
+        let gaps: Vec<i32> = (0..ECMA_CUSTOM_FMT_MIN_ID)
+            .filter(|id| !known.contains(id))
+            .collect();
+
+        for id in gaps {
+            dbg!(&id);
+            let fmt = NumFmt::from_id(id, &[]);
+            assert_eq!(
+                fmt.num_fmt_id, 0,
+                "gap numFmtId {id} must fall back to General (id 0)"
+            );
+            assert_eq!(
+                fmt.format_code, "General",
+                "gap numFmtId {id} must fall back to General format code"
+            );
+        }
+    }
+    #[test]
+    #[should_panic(expected = "is unknown")]
+    fn test_gap_id_panics_in_debug() {
+        use crate::types::NumFmt;
+
+        let _ = NumFmt::from_id(23, &[]); // one representative gap ID
+    }
 }

--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -8,17 +8,17 @@ use crate::{
 /// **Do not change IDs** — the numFmtId values are part of the ECMA-376 spec.
 /// Entries can be reordered freely; IDs must remain stable.
 /// See `builtin_num_fmts_spec_ids_are_correct` for guards on critical entries.
-pub(crate) const NUM_FMTS: &[(i32, &str)] = &[
-    (0,  "general"),
-    (1,  "0"),
-    (2,  "0.00"),
-    (3,  "#,##0"),
-    (4,  "#,##0.00"),
-    (5,  r#"$#,##0; \ - $#,##0"#),
-    (6,  r#"$#,##0; [Red] \ - $#,##0"#),
-    (7,  r#"$#,##0.00; \ - $#,##0.00"#),
-    (8,  r#"$#,##0.00; [Red] \ - $#,##0.00"#),
-    (9,  "0%"),
+pub(crate) const DEFAULT_NUM_FMTS: &[(i32, &str)] = &[
+    (0, "general"),
+    (1, "0"),
+    (2, "0.00"),
+    (3, "#,##0"),
+    (4, "#,##0.00"),
+    (5, r#"$#,##0; \ - $#,##0"#),
+    (6, r#"$#,##0; [Red] \ - $#,##0"#),
+    (7, r#"$#,##0.00; \ - $#,##0.00"#),
+    (8, r#"$#,##0.00; [Red] \ - $#,##0.00"#),
+    (9, "0%"),
     (10, "0.00%"),
     (11, "0.00E + 00"),
     (12, "#?/?"),
@@ -36,7 +36,10 @@ pub(crate) const NUM_FMTS: &[(i32, &str)] = &[
     (24, "#,##0; [Red]()#,##0)"),
     (25, "#,##0.00;()#,##0.00)"),
     (26, "#,##0.00; [Red]()#,##0.00)"),
-    (27, r#"_()$”*#,##0.00 _); _()$”* \()#,##0.00\); _()$”* - ?? _); _()@_)"#),
+    (
+        27,
+        r#"_()$”*#,##0.00 _); _()$”* \()#,##0.00\); _()$”* - ?? _); _()@_)"#,
+    ),
     (28, "mm:ss"),
     (29, "[h]:mm:ss"),
     (30, "mmss .0"),
@@ -59,17 +62,23 @@ pub(crate) const NUM_FMTS: &[(i32, &str)] = &[
 /// Zero-sized accessor for the built-in number format table.
 ///
 /// Centralises all pattern matching over `NUM_FMTS` so call sites read clearly.
-pub(crate) struct BuiltinFmts;
+pub(crate) struct DefaultFmts;
 
-impl BuiltinFmts {
+impl DefaultFmts {
     /// Format code for a built-in `numFmtId`, or `None` if not a built-in.
     pub(crate) fn by_id(id: i32) -> Option<&'static str> {
-        NUM_FMTS.iter().find(|&&(fid, _)| fid == id).map(|&(_, s)| s)
+        DEFAULT_NUM_FMTS
+            .iter()
+            .find(|&&(fid, _)| fid == id)
+            .map(|&(_, s)| s)
     }
 
     /// Built-in `numFmtId` for a format code, or `None` if not a built-in.
     pub(crate) fn by_code(code: &str) -> Option<i32> {
-        NUM_FMTS.iter().find(|&&(_, s)| s == code).map(|&(id, _)| id)
+        DEFAULT_NUM_FMTS
+            .iter()
+            .find(|&&(_, s)| s == code)
+            .map(|&(id, _)| id)
     }
 
     /// True if `id` belongs to the built-in table.
@@ -86,7 +95,6 @@ impl BuiltinFmts {
     pub(crate) fn is_locale_date(id: i32) -> bool {
         id == Self::SHORT_DATE_ID || id == Self::SHORT_DATETIME_ID
     }
-
 }
 
 pub fn to_precision(value: f64, precision: usize) -> f64 {
@@ -166,10 +174,102 @@ mod tests {
 
     #[test]
     fn builtin_num_fmts_spec_ids_are_correct() {
-        assert_eq!(NUM_FMTS.len(), 45, "NUM_FMTS length changed — update and verify all numFmtIds");
-        assert_eq!(BuiltinFmts::by_id(0),  Some("general"),         "numFmtId 0 must be General");
-        assert_eq!(BuiltinFmts::by_id(9),  Some("0%"),              "numFmtId 9 must be 0%");
-        assert_eq!(BuiltinFmts::by_id(14), Some("mm-dd-yy"),        "numFmtId 14 must be the ECMA-376 locale short date");
-        assert_eq!(BuiltinFmts::by_id(22), Some("m / d / yy h:mm"), "numFmtId 22 must be the locale short date+time");
+        assert_eq!(
+            DEFAULT_NUM_FMTS.len(),
+            45,
+            "NUM_FMTS length changed — update and verify all numFmtIds"
+        );
+        assert_eq!(
+            DefaultFmts::by_id(0),
+            Some("general"),
+            "numFmtId 0 must be General"
+        );
+        assert_eq!(DefaultFmts::by_id(9), Some("0%"), "numFmtId 9 must be 0%");
+        assert_eq!(
+            DefaultFmts::by_id(14),
+            Some("mm-dd-yy"),
+            "numFmtId 14 must be the ECMA-376 locale short date"
+        );
+        assert_eq!(
+            DefaultFmts::by_id(22),
+            Some("m / d / yy h:mm"),
+            "numFmtId 22 must be the locale short date+time"
+        );
+    }
+
+    /// ECMA-376 §18.8.30 — canonical built-in format codes for the US (default) locale.
+    ///
+    /// Reference: Apache POI `BuiltinFormats.java`, cross-checked with the spec.
+    /// IDs 23–36 are locale-specific (East-Asian date/time) and absent for US locale.
+    /// IDs 45–49 are the ECMA-376 time/special formats currently missing from this table.
+    ///
+    /// This test is intentionally RED until DEFAULT_NUM_FMTS is corrected.
+    #[test]
+    #[ignore = "not yet implemented"]
+    fn builtin_num_fmts_ecma376_us_locale() {
+        let cases: &[(i32, &str)] = &[
+            (0, "general"),
+            (1, "0"),
+            (2, "0.00"),
+            (3, "#,##0"),
+            (4, "#,##0.00"),
+            // IDs 5–8: US-dollar currency, negative in parentheses with alignment gap.
+            (5, "$#,##0_);($#,##0)"),
+            (6, "$#,##0_);[Red]($#,##0)"),
+            (7, "$#,##0.00_);($#,##0.00)"),
+            (8, "$#,##0.00_);[Red]($#,##0.00)"),
+            (9, "0%"),
+            (10, "0.00%"),
+            (11, "0.00E+00"), // no spaces around +
+            (12, "# ?/?"),    // space before ?
+            (13, "# ??/??"),  // space before ?, no spaces around /
+            (14, "m/d/yy"),   // ECMA-376 locale short-date sentinel
+            (15, "d-mmm-yy"),
+            (16, "d-mmm"),
+            (17, "mmm-yy"),
+            (18, "h:mm AM/PM"), // no spaces around /
+            (19, "h:mm:ss AM/PM"),
+            (20, "h:mm"),
+            (21, "h:mm:ss"),
+            (22, "m/d/yy h:mm"), // no spaces around /
+            // 23–36: absent — locale-specific (East-Asian), not defined for US locale.
+            // 37–40: parenthesised accounting variants (no currency symbol).
+            (37, "#,##0_);(#,##0)"),
+            (38, "#,##0_);[Red](#,##0)"),
+            (39, "#,##0.00_);(#,##0.00)"),
+            (40, "#,##0.00_);[Red](#,##0.00)"),
+            // 41–44: fill-character accounting variants.
+            (41, r#"_(* #,##0_);_(* (#,##0);_(* "-"_);_(@_)"#),
+            (42, r#"_("$"* #,##0_);_("$"* (#,##0);_("$"* "-"_);_(@_)"#),
+            (43, r#"_(* #,##0.00_);_(* (#,##0.00);_(* "-"??_);_(@_)"#),
+            (
+                44,
+                r#"_("$"* #,##0.00_);_("$"* (#,##0.00);_("$"* "-"??_);_(@_)"#,
+            ),
+            // 45–49: time / special — currently missing from IronCalc's table.
+            (45, "mm:ss"),
+            (46, "[h]:mm:ss"),
+            (47, "mmss.0"),
+            (48, "##0.0E+0"),
+            (49, "@"),
+        ];
+
+        for &(id, expected) in cases {
+            assert_eq!(
+                DefaultFmts::by_id(id),
+                Some(expected),
+                "numFmtId {id}: expected {expected:?}, got {:?}",
+                DefaultFmts::by_id(id)
+            );
+        }
+
+        // IDs 23–36 must be absent for US locale.
+        for id in 23_i32..=36 {
+            assert!(
+                DefaultFmts::by_id(id).is_none(),
+                "numFmtId {id} must be absent for US locale, got {:?}",
+                DefaultFmts::by_id(id)
+            );
+        }
     }
 }

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -54,6 +54,9 @@ impl Styles {
         };
         let num_fmt_id =
             NumFmt::get_or_register(&style.num_fmt.format_code, &mut self.num_fmts).num_fmt_id;
+        // A -1 sentinel must never reach CellXfs — get_or_register always
+        // produces a real ID (≥0).  Panic in debug builds to catch regressions.
+        debug_assert!(num_fmt_id >= 0, "num_fmt_id sentinel -1 must not reach CellXfs");
         self.cell_xfs.push(CellXfs {
             xf_id: 0,
             num_fmt_id,
@@ -85,6 +88,8 @@ impl Styles {
     }
 
     pub fn get_style_index(&self, style: &Style) -> Option<i32> {
+        // DISCLOSURE: This code change was suggested by Claude.
+        // Panic if our *_id out of bounds.
         // Resolve sub-table indices once.  If any component isn't registered yet,
         // no CellXfs can reference it — return None without scanning cell_xfs.
         let font_id = self.get_font_index(&style.font)?;
@@ -97,12 +102,12 @@ impl Styles {
         self.cell_xfs
             .iter()
             .position(|xf| {
-                xf.font_id == font_id
-                    && xf.fill_id == fill_id
-                    && xf.border_id == border_id
-                    && self.format_code_for_id(xf.num_fmt_id) == fmt_code
-                    && xf.alignment == style.alignment
-                    && xf.quote_prefix == style.quote_prefix
+                xf.alignment == style.alignment
+                && self.format_code_for_id(xf.num_fmt_id) == fmt_code
+                && xf.fill_id == fill_id
+                && xf.border_id == border_id
+                && xf.font_id == font_id
+                && xf.quote_prefix == style.quote_prefix
             })
             .map(|i| i as i32)
     }
@@ -172,6 +177,7 @@ impl Styles {
         Ok(self.get_style_index_or_create(&style))
     }
 
+
     /// Returns the raw `num_fmt_id` stored in `CellXfs` for the given style
     /// index, without converting through the format string.
     pub(crate) fn get_num_fmt_id(&self, index: i32) -> Result<i32, String> {
@@ -230,6 +236,7 @@ impl Styles {
         cell_xf.quote_prefix
     }
 
+
     pub(crate) fn get_style(&self, index: i32) -> Result<Style, String> {
         let cell_xf = &self
             .cell_xfs
@@ -242,24 +249,15 @@ impl Styles {
         let quote_prefix = cell_xf.quote_prefix;
         let alignment = cell_xf.alignment.clone();
 
+
+        // DISCLOSURE: This code change was suggested by Claude.
+        // Panic if our *_id out of bounds `self.fills[fill_id]`.
         Ok(Style {
             alignment,
             num_fmt: NumFmt::from_id(num_fmt_id, &self.num_fmts),
-            fill: self
-                .fills
-                .get(fill_id)
-                .ok_or_else(|| format!("Invalid fill_id {fill_id} in style index {index}"))?
-                .clone(),
-            font: self
-                .fonts
-                .get(font_id)
-                .ok_or_else(|| format!("Invalid font_id {font_id} in style index {index}"))?
-                .clone(),
-            border: self
-                .borders
-                .get(border_id)
-                .ok_or_else(|| format!("Invalid border_id {border_id} in style index {index}"))?
-                .clone(),
+            fill: self.fills.get(fill_id).cloned().unwrap_or_default(),
+            font: self.fonts.get(font_id).cloned().unwrap_or_default(),
+            border: self.borders.get(border_id).cloned().unwrap_or_default(),
             quote_prefix,
         })
     }

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -171,6 +171,7 @@ impl Styles {
         style.num_fmt = NumFmt::get_or_register(format_code, &mut self.num_fmts);
         Ok(self.get_style_index_or_create(&style))
     }
+
     /// Returns the raw `num_fmt_id` stored in `CellXfs` for the given style
     /// index, without converting through the format string.
     pub(crate) fn get_num_fmt_id(&self, index: i32) -> Result<i32, String> {

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -1,6 +1,6 @@
 use crate::{
     model::Model,
-    number_format::{get_default_num_fmt_id, get_new_num_fmt_index, get_num_fmt},
+    number_format::DEFAULT_NUM_FMTS,
     types::{Border, CellStyles, CellXfs, Fill, Font, NumFmt, Style, Styles},
 };
 
@@ -29,17 +29,6 @@ impl Styles {
         }
         None
     }
-    fn get_num_fmt_index(&self, format_code: &str) -> Option<i32> {
-        if let Some(index) = get_default_num_fmt_id(format_code) {
-            return Some(index);
-        }
-        for item in self.num_fmts.iter() {
-            if item.format_code == format_code {
-                return Some(item.num_fmt_id);
-            }
-        }
-        None
-    }
 
     pub fn create_new_style(&mut self, style: &Style) -> i32 {
         let font = &style.font;
@@ -63,17 +52,8 @@ impl Styles {
             self.borders.push(border.clone());
             self.borders.len() as i32 - 1
         };
-        let num_fmt = &style.num_fmt;
-        let num_fmt_id;
-        if let Some(index) = self.get_num_fmt_index(num_fmt) {
-            num_fmt_id = index;
-        } else {
-            num_fmt_id = get_new_num_fmt_index(&self.num_fmts);
-            self.num_fmts.push(NumFmt {
-                format_code: num_fmt.to_string(),
-                num_fmt_id,
-            });
-        }
+        let num_fmt_id =
+            NumFmt::get_or_register(&style.num_fmt.format_code, &mut self.num_fmts).num_fmt_id;
         self.cell_xfs.push(CellXfs {
             xf_id: 0,
             num_fmt_id,
@@ -92,27 +72,39 @@ impl Styles {
         self.cell_xfs.len() as i32 - 1
     }
 
-    pub fn get_style_index(&self, style: &Style) -> Option<i32> {
-        for (index, cell_xf) in self.cell_xfs.iter().enumerate() {
-            let border_id = cell_xf.border_id as usize;
-            let fill_id = cell_xf.fill_id as usize;
-            let font_id = cell_xf.font_id as usize;
-            let num_fmt_id = cell_xf.num_fmt_id;
-            let quote_prefix = cell_xf.quote_prefix;
-            if style
-                == &(Style {
-                    alignment: cell_xf.alignment.clone(),
-                    num_fmt: get_num_fmt(num_fmt_id, &self.num_fmts),
-                    fill: self.fills[fill_id].clone(),
-                    font: self.fonts[font_id].clone(),
-                    border: self.borders[border_id].clone(),
-                    quote_prefix,
-                })
-            {
-                return Some(index as i32);
-            }
+    /// Look up the format code for `id` without allocating — borrowed from
+    /// `self.num_fmts` for custom IDs or from the static built-in table.
+    pub(crate) fn format_code_for_id(&self, id: i32) -> &str {
+        if let Some(fmt) = self.num_fmts.iter().find(|f| f.num_fmt_id == id) {
+            return &fmt.format_code;
         }
-        None
+        if id >= 0 && (id as usize) < DEFAULT_NUM_FMTS.len() {
+            return DEFAULT_NUM_FMTS[id as usize];
+        }
+        DEFAULT_NUM_FMTS[0] // "general" fallback
+    }
+
+    pub fn get_style_index(&self, style: &Style) -> Option<i32> {
+        // Resolve sub-table indices once.  If any component isn't registered yet,
+        // no CellXfs can reference it — return None without scanning cell_xfs.
+        let font_id = self.get_font_index(&style.font)?;
+        let fill_id = self.get_fill_index(&style.fill)?;
+        let border_id = self.get_border_index(&style.border)?;
+        let fmt_code = style.num_fmt.format_code.as_str();
+
+        // Compare by integer ID for font/fill/border (cheap); format_code stays
+        // string-based because the incoming num_fmt_id may be the -1 sentinel.
+        self.cell_xfs
+            .iter()
+            .position(|xf| {
+                xf.font_id == font_id
+                    && xf.fill_id == fill_id
+                    && xf.border_id == border_id
+                    && self.format_code_for_id(xf.num_fmt_id) == fmt_code
+                    && xf.alignment == style.alignment
+                    && xf.quote_prefix == style.quote_prefix
+            })
+            .map(|i| i as i32)
     }
 
     pub(crate) fn get_style_index_or_create(&mut self, style: &Style) -> i32 {
@@ -171,10 +163,12 @@ impl Styles {
     pub(crate) fn get_style_with_format(
         &mut self,
         index: i32,
-        num_fmt: &str,
+        format_code: &str,
     ) -> Result<i32, String> {
         let mut style = self.get_style(index)?;
-        style.num_fmt = num_fmt.to_string();
+        // Resolve the canonical ID directly from Styles so the returned Style
+        // is fully resolved — no sentinel needed here since we own num_fmts.
+        style.num_fmt = NumFmt::get_or_register(format_code, &mut self.num_fmts);
         Ok(self.get_style_index_or_create(&style))
     }
     /// Returns the raw `num_fmt_id` stored in `CellXfs` for the given style
@@ -196,6 +190,14 @@ impl Styles {
         index: i32,
         new_id: i32,
     ) -> Result<i32, String> {
+        // Fail fast if the ID would produce a silent fallback to General format.
+        let is_builtin = new_id >= 0 && (new_id as usize) < DEFAULT_NUM_FMTS.len();
+        let is_registered = self.num_fmts.iter().any(|f| f.num_fmt_id == new_id);
+        if !is_builtin && !is_registered {
+            return Err(format!(
+                "num_fmt_id {new_id} is neither a built-in ECMA-376 ID nor registered in num_fmts"
+            ));
+        }
         let base = self
             .cell_xfs
             .get(index as usize)
@@ -231,7 +233,7 @@ impl Styles {
         let cell_xf = &self
             .cell_xfs
             .get(index as usize)
-            .ok_or("Invalid index provided".to_string())?;
+            .ok_or_else(|| format!("Invalid style index: {index}"))?;
         let border_id = cell_xf.border_id as usize;
         let fill_id = cell_xf.fill_id as usize;
         let font_id = cell_xf.font_id as usize;
@@ -241,10 +243,22 @@ impl Styles {
 
         Ok(Style {
             alignment,
-            num_fmt: get_num_fmt(num_fmt_id, &self.num_fmts),
-            fill: self.fills[fill_id].clone(),
-            font: self.fonts[font_id].clone(),
-            border: self.borders[border_id].clone(),
+            num_fmt: NumFmt::from_id(num_fmt_id, &self.num_fmts),
+            fill: self
+                .fills
+                .get(fill_id)
+                .ok_or_else(|| format!("Invalid fill_id {fill_id} in style index {index}"))?
+                .clone(),
+            font: self
+                .fonts
+                .get(font_id)
+                .ok_or_else(|| format!("Invalid font_id {font_id} in style index {index}"))?
+                .clone(),
+            border: self
+                .borders
+                .get(border_id)
+                .ok_or_else(|| format!("Invalid border_id {border_id} in style index {index}"))?
+                .clone(),
             quote_prefix,
         })
     }

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -91,7 +91,7 @@ impl Styles {
                 && if incoming_id >= 0 {
                     xf.num_fmt_id == incoming_id
                 } else {
-                    NumFmt::format_code_for_id(xf.num_fmt_id, &self.num_fmts) == fmt_code
+                    NumFmt::from_id(xf.num_fmt_id, &self.num_fmts).format_code.as_str() == fmt_code
                 }
                 && xf.fill_id == fill_id
                 && xf.border_id == border_id

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -1,6 +1,5 @@
 use crate::{
     model::Model,
-    number_format::DEFAULT_NUM_FMTS,
     types::{Border, CellStyles, CellXfs, Fill, Font, NumFmt, Style, Styles},
 };
 
@@ -75,17 +74,6 @@ impl Styles {
         self.cell_xfs.len() as i32 - 1
     }
 
-    /// Look up the format code for `id` without allocating — borrowed from
-    /// `self.num_fmts` for custom IDs or from the static built-in table.
-    pub(crate) fn format_code_for_id(&self, id: i32) -> &str {
-        if let Some(fmt) = self.num_fmts.iter().find(|f| f.num_fmt_id == id) {
-            return &fmt.format_code;
-        }
-        if id >= 0 && (id as usize) < DEFAULT_NUM_FMTS.len() {
-            return DEFAULT_NUM_FMTS[id as usize];
-        }
-        DEFAULT_NUM_FMTS[0] // "general" fallback
-    }
 
     pub fn get_style_index(&self, style: &Style) -> Option<i32> {
         // DISCLOSURE: This code change was suggested by Claude.
@@ -103,7 +91,7 @@ impl Styles {
             .iter()
             .position(|xf| {
                 xf.alignment == style.alignment
-                && self.format_code_for_id(xf.num_fmt_id) == fmt_code
+                && NumFmt::resolve_code(xf.num_fmt_id, &self.num_fmts) == fmt_code
                 && xf.fill_id == fill_id
                 && xf.border_id == border_id
                 && xf.font_id == font_id
@@ -198,9 +186,7 @@ impl Styles {
         new_id: i32,
     ) -> Result<i32, String> {
         // Fail fast if the ID would produce a silent fallback to General format.
-        let is_builtin = new_id >= 0 && (new_id as usize) < DEFAULT_NUM_FMTS.len();
-        let is_registered = self.num_fmts.iter().any(|f| f.num_fmt_id == new_id);
-        if !is_builtin && !is_registered {
+        if !NumFmt::is_known_id(new_id, &self.num_fmts) {
             return Err(format!(
                 "num_fmt_id {new_id} is neither a built-in ECMA-376 ID nor registered in num_fmts"
             ));

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -76,22 +76,28 @@ impl Styles {
 
 
     pub fn get_style_index(&self, style: &Style) -> Option<i32> {
-        // DISCLOSURE: This code change was suggested by Claude.
-        // Panic if our *_id out of bounds.
         // Resolve sub-table indices once.  If any component isn't registered yet,
         // no CellXfs can reference it — return None without scanning cell_xfs.
         let font_id = self.get_font_index(&style.font)?;
         let fill_id = self.get_fill_index(&style.fill)?;
         let border_id = self.get_border_index(&style.border)?;
+        let incoming_id = style.num_fmt.num_fmt_id;
         let fmt_code = style.num_fmt.format_code.as_str();
 
-        // Compare by integer ID for font/fill/border (cheap); format_code stays
-        // string-based because the incoming num_fmt_id may be the -1 sentinel.
         self.cell_xfs
             .iter()
             .position(|xf| {
                 xf.alignment == style.alignment
-                && NumFmt::resolve_code(xf.num_fmt_id, &self.num_fmts) == fmt_code
+                // Compare by integer ID when available.  String comparison would
+                // collapse locale-date IDs (14/22) into any custom format that
+                // happens to use the same code string (e.g. a custom "mm-dd-yy").
+                // Fall back to string only for the -1 sentinel, which means
+                // "custom format not yet registered in num_fmts".
+                && if incoming_id >= 0 {
+                    xf.num_fmt_id == incoming_id
+                } else {
+                    NumFmt::format_code_for_id(xf.num_fmt_id, &self.num_fmts) == fmt_code
+                }
                 && xf.fill_id == fill_id
                 && xf.border_id == border_id
                 && xf.font_id == font_id

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -178,8 +178,7 @@ impl Styles {
         Ok(self.get_style_index_or_create(&style))
     }
     /// Returns the raw `num_fmt_id` stored in `CellXfs` for the given style
-    /// index, without converting through the format string.  Used by render
-    /// functions so they can call `is_locale_short_date_id` directly.
+    /// index, without converting through the format string.
     pub(crate) fn get_num_fmt_id(&self, index: i32) -> Result<i32, String> {
         self.cell_xfs
             .get(index as usize)

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -53,8 +53,6 @@ impl Styles {
         };
         let num_fmt_id =
             NumFmt::get_or_register(&style.num_fmt.format_code, &mut self.num_fmts).num_fmt_id;
-        // A -1 sentinel must never reach CellXfs — get_or_register always
-        // produces a real ID (≥0).  Panic in debug builds to catch regressions.
         debug_assert!(num_fmt_id >= 0, "num_fmt_id sentinel -1 must not reach CellXfs");
         self.cell_xfs.push(CellXfs {
             xf_id: 0,
@@ -76,8 +74,6 @@ impl Styles {
 
 
     pub fn get_style_index(&self, style: &Style) -> Option<i32> {
-        // Resolve sub-table indices once.  If any component isn't registered yet,
-        // no CellXfs can reference it — return None without scanning cell_xfs.
         let font_id = self.get_font_index(&style.font)?;
         let fill_id = self.get_fill_index(&style.fill)?;
         let border_id = self.get_border_index(&style.border)?;
@@ -88,11 +84,8 @@ impl Styles {
             .iter()
             .position(|xf| {
                 xf.alignment == style.alignment
-                // Compare by integer ID when available.  String comparison would
-                // collapse locale-date IDs (14/22) into any custom format that
-                // happens to use the same code string (e.g. a custom "mm-dd-yy").
-                // Fall back to string only for the -1 sentinel, which means
-                // "custom format not yet registered in num_fmts".
+                // Compare by ID when available; string comparison collapses locale IDs 14/22
+                // with custom formats sharing the same code. Fall back for -1 sentinel only.
                 && if incoming_id >= 0 {
                     xf.num_fmt_id == incoming_id
                 } else {
@@ -165,15 +158,12 @@ impl Styles {
         format_code: &str,
     ) -> Result<i32, String> {
         let mut style = self.get_style(index)?;
-        // Resolve the canonical ID directly from Styles so the returned Style
-        // is fully resolved — no sentinel needed here since we own num_fmts.
         style.num_fmt = NumFmt::get_or_register(format_code, &mut self.num_fmts);
         Ok(self.get_style_index_or_create(&style))
     }
 
 
-    /// Returns the raw `num_fmt_id` stored in `CellXfs` for the given style
-    /// index, without converting through the format string.
+    /// Raw `num_fmt_id` from `CellXfs` at `index`.
     pub(crate) fn get_num_fmt_id(&self, index: i32) -> Result<i32, String> {
         self.cell_xfs
             .get(index as usize)
@@ -181,17 +171,13 @@ impl Styles {
             .ok_or_else(|| format!("Invalid style index: {index}"))
     }
 
-    /// Returns (or creates) a style that is identical to the one at `index`
-    /// but with `num_fmt_id` set to `new_id`.  Works at the `CellXfs` level so
-    /// that semantically-meaningful IDs like `LOCALE_SHORT_DATE_FMT_ID` (14)
-    /// are preserved exactly — the round-trip through format strings would
-    /// collapse them to the en-US literal `"mm-dd-yy"`.
+    /// Returns (or creates) a style like `index` but with `num_fmt_id` set to `new_id`.
+    /// Operates at the `CellXfs` level so IDs 14/22 are preserved without string round-trip.
     pub(crate) fn get_style_with_num_fmt_id(
         &mut self,
         index: i32,
         new_id: i32,
     ) -> Result<i32, String> {
-        // Fail fast if the ID would produce a silent fallback to General format.
         if !NumFmt::is_known_id(new_id, &self.num_fmts) {
             return Err(format!(
                 "num_fmt_id {new_id} is neither a built-in ECMA-376 ID nor registered in num_fmts"
@@ -206,8 +192,7 @@ impl Styles {
             num_fmt_id: new_id,
             ..base
         };
-        // Reuse an existing CellXfs entry if it already matches, to avoid
-        // bloating the styles table.
+        // Reuse an existing entry if possible.
         for (i, existing) in self.cell_xfs.iter().enumerate() {
             if *existing == target {
                 return Ok(i as i32);
@@ -242,8 +227,6 @@ impl Styles {
         let alignment = cell_xf.alignment.clone();
 
 
-        // DISCLOSURE: This code change was suggested by Claude.
-        // Panic if our *_id out of bounds `self.fills[fill_id]`.
         Ok(Style {
             alignment,
             num_fmt: NumFmt::from_id(num_fmt_id, &self.num_fmts),

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -53,7 +53,10 @@ impl Styles {
         };
         let num_fmt_id =
             NumFmt::get_or_register(&style.num_fmt.format_code, &mut self.num_fmts).num_fmt_id;
-        debug_assert!(num_fmt_id >= 0, "num_fmt_id sentinel -1 must not reach CellXfs");
+        debug_assert!(
+            num_fmt_id >= 0,
+            "num_fmt_id sentinel -1 must not reach CellXfs"
+        );
         self.cell_xfs.push(CellXfs {
             xf_id: 0,
             num_fmt_id,
@@ -71,7 +74,6 @@ impl Styles {
         });
         self.cell_xfs.len() as i32 - 1
     }
-
 
     pub fn get_style_index(&self, style: &Style) -> Option<i32> {
         let font_id = self.get_font_index(&style.font)?;
@@ -162,7 +164,6 @@ impl Styles {
         Ok(self.get_style_index_or_create(&style))
     }
 
-
     /// Raw `num_fmt_id` from `CellXfs` at `index`.
     pub(crate) fn get_num_fmt_id(&self, index: i32) -> Result<i32, String> {
         self.cell_xfs
@@ -213,7 +214,6 @@ impl Styles {
         cell_xf.quote_prefix
     }
 
-
     pub(crate) fn get_style(&self, index: i32) -> Result<Style, String> {
         let cell_xf = &self
             .cell_xfs
@@ -225,7 +225,6 @@ impl Styles {
         let num_fmt_id = cell_xf.num_fmt_id;
         let quote_prefix = cell_xf.quote_prefix;
         let alignment = cell_xf.alignment.clone();
-
 
         Ok(Style {
             alignment,

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -177,6 +177,45 @@ impl Styles {
         style.num_fmt = num_fmt.to_string();
         Ok(self.get_style_index_or_create(&style))
     }
+    /// Returns the raw `num_fmt_id` stored in `CellXfs` for the given style
+    /// index, without converting through the format string.  Used by render
+    /// functions so they can call `is_locale_short_date_id` directly.
+    pub(crate) fn get_num_fmt_id(&self, index: i32) -> Result<i32, String> {
+        self.cell_xfs
+            .get(index as usize)
+            .map(|xf| xf.num_fmt_id)
+            .ok_or_else(|| format!("Invalid style index: {index}"))
+    }
+
+    /// Returns (or creates) a style that is identical to the one at `index`
+    /// but with `num_fmt_id` set to `new_id`.  Works at the `CellXfs` level so
+    /// that semantically-meaningful IDs like `LOCALE_SHORT_DATE_FMT_ID` (14)
+    /// are preserved exactly — the round-trip through format strings would
+    /// collapse them to the en-US literal `"mm-dd-yy"`.
+    pub(crate) fn get_style_with_num_fmt_id(
+        &mut self,
+        index: i32,
+        new_id: i32,
+    ) -> Result<i32, String> {
+        let base = self
+            .cell_xfs
+            .get(index as usize)
+            .ok_or_else(|| format!("Invalid style index: {index}"))?
+            .clone();
+        let target = CellXfs {
+            num_fmt_id: new_id,
+            ..base
+        };
+        // Reuse an existing CellXfs entry if it already matches, to avoid
+        // bloating the styles table.
+        for (i, existing) in self.cell_xfs.iter().enumerate() {
+            if *existing == target {
+                return Ok(i as i32);
+            }
+        }
+        self.cell_xfs.push(target);
+        Ok(self.cell_xfs.len() as i32 - 1)
+    }
 
     pub(crate) fn get_style_without_quote_prefix(&mut self, index: i32) -> Result<i32, String> {
         let mut style = self.get_style(index)?;

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -86,6 +86,7 @@ mod test_implicit_intersection;
 mod test_issue_155;
 mod test_issue_483;
 mod test_issue_751;
+mod test_issue_761;
 mod test_language;
 mod test_ln;
 mod test_locale;

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -85,6 +85,7 @@ mod test_get_cell_content;
 mod test_implicit_intersection;
 mod test_issue_155;
 mod test_issue_483;
+mod test_issue_751;
 mod test_language;
 mod test_ln;
 mod test_locale;

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -45,6 +45,7 @@ mod test_model_is_empty_cell;
 mod test_move_formula;
 mod test_mround_trunc_int;
 mod test_networkdays_networkdaysintl;
+mod test_num_fmt_serde;
 mod test_quote_prefix;
 mod test_row_column_styles;
 mod test_set_user_input;

--- a/base/src/test/test_date_and_time.rs
+++ b/base/src/test/test_date_and_time.rs
@@ -4,7 +4,7 @@
 /// Either because Excel does not have that feature (i.e. wrong number of arguments)
 /// or because we differ from Excel throwing #NUM! on invalid dates
 /// We can also enter examples that illustrate/document a part of the function
-use crate::{cell::CellValue, test::util::new_empty_model};
+use crate::{cell::CellValue, model::Model, test::util::new_empty_model};
 
 // Excel uses a serial date system where Jan 1, 1900 = 1 (though it treats 1900 as a leap year)
 // Most test dates are documented inline, but we define boundary values here:
@@ -455,27 +455,33 @@ fn test_workday_function() {
 
     model.evaluate();
 
-    // Basic functionality
-    assert_eq!(model._get_text("A1"), *"44561"); // 1 day forward
-    assert_eq!(model._get_text("A2"), *"44560"); // 1 day backward
-    assert_eq!(model._get_text("A3"), *"44561"); // 0 days
-    assert_eq!(model._get_text("A4"), *"44567"); // 5 days forward
+    // Basic functionality — results are formatted as locale dates (en-US M/d/yy)
+    assert_eq!(model._get_text("A1"), *"12/31/21"); // Dec 31 2021, 1 day forward
+    assert_eq!(model._get_text("A2"), *"12/30/21"); // Dec 30 2021, 1 day backward
+    assert_eq!(model._get_text("A3"), *"12/31/21"); // 0 days
+    assert_eq!(model._get_text("A4"), *"1/6/22"); // Jan 6 2022, 5 days forward
 
     // With holidays
-    assert_eq!(model._get_text("A5"), *"44564"); // Skip holiday, go to Monday
-    assert_eq!(model._get_text("A6"), *"44566"); // Skip multiple holidays
+    assert_eq!(model._get_text("A5"), *"1/3/22"); // Jan 3 2022, skip Dec 31 holiday
+    assert_eq!(model._get_text("A6"), *"1/5/22"); // Jan 5 2022, skip multiple holidays
 
     // Weekend starts
-    assert_eq!(model._get_text("A7"), *"44564"); // From Saturday
-    assert_eq!(model._get_text("A8"), *"44564"); // From Sunday
+    assert_eq!(model._get_text("A7"), *"1/3/22"); // Jan 3 2022, from Saturday
+    assert_eq!(model._get_text("A8"), *"1/3/22"); // Jan 3 2022, from Sunday
 
     // Negative workdays
-    assert_eq!(model._get_text("A9"), *"44560"); // 3 days back
-    assert_eq!(model._get_text("A10"), *"44557"); // 5 days back with holidays
+    assert_eq!(model._get_text("A9"), *"12/30/21"); // Dec 30 2021, 3 days back
+    assert_eq!(model._get_text("A10"), *"12/27/21"); // Dec 27 2021, 5 days back with holidays
 
-    // Edge cases
-    assert_eq!(model._get_text("A11"), *"2"); // Early date
-    assert_eq!(model._get_text("A12"), *"100014"); // Large numbers
+    // Edge cases — use raw value to avoid dependence on far-future date strings
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A11"),
+        Ok(CellValue::Number(2.0))
+    ); // Early date
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A12"),
+        Ok(CellValue::Number(100014.0))
+    ); // Large numbers
 
     // Error cases
     assert_eq!(model._get_text("A13"), *"#ERROR!");
@@ -513,19 +519,19 @@ fn test_workday_intl_function() {
 
     model.evaluate();
 
-    // Weekend mask functionality
-    assert_eq!(model._get_text("A1"), *"44561"); // Standard weekend
-    assert_eq!(model._get_text("A2"), *"44561"); // Sun-Mon weekend
-    assert_eq!(model._get_text("A3"), *"44561"); // Sunday only
-    assert_eq!(model._get_text("A4"), *"44561"); // Mon-Tue weekend
+    // Weekend mask functionality — results formatted as locale dates (en-US M/d/yy)
+    assert_eq!(model._get_text("A1"), *"12/31/21"); // Dec 31 2021, standard weekend
+    assert_eq!(model._get_text("A2"), *"12/31/21"); // Dec 31 2021, Sun-Mon weekend
+    assert_eq!(model._get_text("A3"), *"12/31/21"); // Dec 31 2021, Sunday only
+    assert_eq!(model._get_text("A4"), *"12/31/21"); // Dec 31 2021, Mon-Tue weekend
 
     // With holidays
-    assert_eq!(model._get_text("A5"), *"44565"); // Skip holiday + standard weekend
-    assert_eq!(model._get_text("A6"), *"44564"); // Skip holiday + Fri-Sat weekend
+    assert_eq!(model._get_text("A5"), *"1/4/22"); // Jan 4 2022, skip holiday + standard weekend
+    assert_eq!(model._get_text("A6"), *"1/3/22"); // Jan 3 2022, skip holiday + Fri-Sat weekend
 
     // Edge cases
-    assert_eq!(model._get_text("A7"), *"44561"); // Zero days
-    assert_eq!(model._get_text("A8"), *"44564"); // Negative days
+    assert_eq!(model._get_text("A7"), *"12/31/21"); // Dec 31 2021, zero days
+    assert_eq!(model._get_text("A8"), *"1/3/22"); // Jan 3 2022, negative days
 
     // Error cases
     assert_eq!(model._get_text("A9"), *"#ERROR!");
@@ -600,4 +606,83 @@ fn test_isoweeknum_function() {
     // Error cases
     assert_eq!(model._get_text("A6"), *"#ERROR!");
     assert_eq!(model._get_text("A7"), *"#NUM!");
+}
+
+fn en_gb_model<'a>() -> Model<'a> {
+    Model::new_empty("model", "en-GB", "UTC", "en").unwrap()
+}
+
+#[test]
+fn edate_formats_as_locale_date() {
+    // =EDATE(DATE(2025,1,15), 1) → Feb 15 2025
+    let mut model = new_empty_model();
+    model._set("A1", "=EDATE(DATE(2025,1,15),1)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "2/15/25"); // en-US M/d/yy
+
+    model.set_locale("en-GB").unwrap();
+    assert_eq!(model._get_text("A1"), "15/02/2025"); // en-GB dd/MM/yyyy
+}
+
+#[test]
+fn eomonth_formats_as_locale_date() {
+    // =EOMONTH(DATE(2025,1,1), 0) → Jan 31 2025
+    let mut model = new_empty_model();
+    model._set("A1", "=EOMONTH(DATE(2025,1,1),0)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "1/31/25"); // en-US
+
+    model.set_locale("en-GB").unwrap();
+    assert_eq!(model._get_text("A1"), "31/01/2025"); // en-GB
+}
+
+#[test]
+fn workday_formats_as_locale_date() {
+    // =WORKDAY(DATE(2025,1,10), 5) → Jan 17 2025 (skipping Sat/Sun)
+    let mut model = new_empty_model();
+    model._set("A1", "=WORKDAY(DATE(2025,1,10),5)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "1/17/25"); // en-US
+
+    model.set_locale("en-GB").unwrap();
+    assert_eq!(model._get_text("A1"), "17/01/2025"); // en-GB
+}
+
+#[test]
+fn workday_intl_formats_as_locale_date() {
+    // =WORKDAY.INTL(DATE(2025,1,10), 5, 1) → same as WORKDAY with Sat/Sun weekend
+    let mut model = new_empty_model();
+    model._set("A1", "=WORKDAY.INTL(DATE(2025,1,10),5,1)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "1/17/25"); // en-US
+
+    model.set_locale("en-GB").unwrap();
+    assert_eq!(model._get_text("A1"), "17/01/2025"); // en-GB
+}
+
+#[test]
+fn datevalue_formats_as_locale_date() {
+    // =DATEVALUE("01/15/2025") in en-US → January 15, 2025
+    let mut model = new_empty_model();
+    model._set("A1", "=DATEVALUE(\"01/15/2025\")");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "1/15/25"); // en-US formatted as date
+
+    model.set_locale("en-GB").unwrap();
+    assert_eq!(model._get_text("A1"), "15/01/2025"); // same serial, day-first display
+}
+
+#[test]
+fn datevalue_locale_day_first_parsing() {
+    // In en-GB, "01/03/2025" is day-first → March 1, 2025
+    let mut model = en_gb_model();
+    model._set("A1", "=DATEVALUE(\"01/03/2025\")");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "01/03/2025"); // March 1 in en-GB
+
+    // Same string in en-US is month-first → January 3, 2025
+    let mut us_model = new_empty_model();
+    us_model._set("A1", "=DATEVALUE(\"01/03/2025\")");
+    us_model.evaluate();
+    assert_eq!(us_model._get_text("A1"), "1/3/25"); // January 3 in en-US
 }

--- a/base/src/test/test_date_and_time.rs
+++ b/base/src/test/test_date_and_time.rs
@@ -42,13 +42,14 @@ fn test_fn_date_arguments() {
     assert_eq!(model._get_text("A3"), *"#ERROR!");
     assert_eq!(model._get_text("A4"), *"#ERROR!");
 
-    assert_eq!(model._get_text("A5"), *"10/10/1974");
-    assert_eq!(model._get_text("A6"), *"1/21/1975");
-    assert_eq!(model._get_text("A7"), *"2/10/1976");
-    assert_eq!(model._get_text("A8"), *"3/2/1975");
+    // en-US locale short date is "m/d/yy" — numFmtId 14 renders with 2-digit year.
+    assert_eq!(model._get_text("A5"), *"10/10/74");
+    assert_eq!(model._get_text("A6"), *"1/21/75");
+    assert_eq!(model._get_text("A7"), *"2/10/76");
+    assert_eq!(model._get_text("A8"), *"3/2/75");
 
-    assert_eq!(model._get_text("A9"), *"3/1/1975");
-    assert_eq!(model._get_text("A10"), *"2/29/1976");
+    assert_eq!(model._get_text("A9"), *"3/1/75");
+    assert_eq!(model._get_text("A10"), *"2/29/76");
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A10"),
         Ok(CellValue::Number(27819.0))
@@ -74,10 +75,11 @@ fn test_date_out_of_range() {
 
     model.evaluate();
 
-    assert_eq!(model._get_text("A1"), *"12/10/2021");
-    assert_eq!(model._get_text("A2"), *"1/10/2023");
-    assert_eq!(model._get_text("B1"), *"4/30/2042");
-    assert_eq!(model._get_text("B2"), *"6/1/2025");
+    // en-US locale short date is "m/d/yy" — numFmtId 14 renders with 2-digit year.
+    assert_eq!(model._get_text("A1"), *"12/10/21");
+    assert_eq!(model._get_text("A2"), *"1/10/23");
+    assert_eq!(model._get_text("B1"), *"4/30/42");
+    assert_eq!(model._get_text("B2"), *"6/1/25");
 
     assert_eq!(model._get_text("C1"), *"#NUM!");
     assert_eq!(model._get_text("C2"), *"#NUM!");
@@ -195,8 +197,9 @@ fn test_date_early_dates() {
 
     model.evaluate();
 
-    // This is 1 in Excel, we agree with Google Docs
-    assert_eq!(model._get_text("A1"), *"1/1/1900");
+    // This is 1 in Excel, we agree with Google Docs.
+    // en-US "m/d/yy" renders 1900 as 2-digit "00".
+    assert_eq!(model._get_text("A1"), *"1/1/00");
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A1"),
         Ok(CellValue::Number(2.0))
@@ -204,7 +207,7 @@ fn test_date_early_dates() {
 
     // 1900 was not a leap year, this is a bug in EXCEL
     // This would be 60 in Excel
-    assert_eq!(model._get_text("A2"), *"2/28/1900");
+    assert_eq!(model._get_text("A2"), *"2/28/00");
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A2"),
         Ok(CellValue::Number(60.0))
@@ -212,10 +215,10 @@ fn test_date_early_dates() {
 
     // This does not agree with Excel, instead of mistakenly allowing
     // for Feb 29, it will auto-wrap to the next day after Feb 28.
-    assert_eq!(model._get_text("B2"), *"3/1/1900");
+    assert_eq!(model._get_text("B2"), *"3/1/00");
 
     // This agrees with Excel from he onward
-    assert_eq!(model._get_text("A3"), *"3/1/1900");
+    assert_eq!(model._get_text("A3"), *"3/1/00");
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A3"),
         Ok(CellValue::Number(61.0))

--- a/base/src/test/test_fn_datevalue_datedif.rs
+++ b/base/src/test/test_fn_datevalue_datedif.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
-use crate::test::util::new_empty_model;
-use crate::types::Cell;
+use crate::{model::Model, test::util::new_empty_model, types::Cell};
 
 // Helper to evaluate a formula and return the formatted text
 fn eval_formula(formula: &str) -> String {
@@ -59,11 +58,26 @@ fn test_datevalue_month_name() {
 
 #[test]
 fn test_datevalue_ambiguous_ddmm() {
-    // 01/02/2023 interpreted as MM/DD -> 2-Jan-2023
+    // 01/02/2023 in en-US (month-first locale): MM=01, DD=02 -> January 2, 2023
     assert_eq!(
         eval_formula_raw_number("=DATEVALUE(\"01/02/2023\")").unwrap(),
         44929.0
     );
+}
+
+#[test]
+fn test_datevalue_ambiguous_locale_day_first() {
+    // In en-GB (day-first locale), "01/02/2023" is DD/MM -> February 1, 2023
+    let mut model = Model::new_empty("model", "en-GB", "UTC", "en").unwrap();
+    model._set("A1", "=DATEVALUE(\"01/02/2023\")");
+    model.evaluate();
+    // February 1, 2023 = serial 44958
+    match model._get_cell("A1") {
+        crate::types::Cell::NumberCell { v, .. } => {
+            assert_eq!(*v, 44958.0, "en-GB must parse 01/02/2023 as February 1 (day-first)");
+        }
+        other => panic!("expected NumberCell, got {:?}", other),
+    }
 }
 
 #[test]

--- a/base/src/test/test_fn_datevalue_timevalue.rs
+++ b/base/src/test/test_fn_datevalue_timevalue.rs
@@ -15,7 +15,7 @@ fn datevalue_timevalue_arguments() {
 
     assert_eq!(model._get_text("A1"), *"#ERROR!");
     assert_eq!(model._get_text("A2"), *"#ERROR!");
-    assert_eq!(model._get_text("A3"), *"36526");
+    assert_eq!(model._get_text("A3"), *"1/1/00"); // Jan 1 2000, formatted as locale date
     assert_eq!(model._get_text("A4"), *"0.5");
     assert_eq!(model._get_text("A5"), *"#ERROR!");
     assert_eq!(model._get_text("A6"), *"#ERROR!");

--- a/base/src/test/test_general.rs
+++ b/base/src/test/test_general.rs
@@ -7,6 +7,7 @@ use crate::cell::CellValue;
 use crate::number_format::to_excel_precision_str;
 
 use crate::test::util::new_empty_model;
+use crate::types::NumFmt;
 
 #[test]
 fn test_empty_model() {
@@ -314,20 +315,20 @@ fn test_style_fmt_id() {
     let mut model = new_empty_model();
 
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = "#.##".to_string();
+    style.num_fmt = NumFmt::from_format_code("#.##");
     assert!(model.set_cell_style(0, 1, 1, &style).is_ok());
     let style = model.get_style_for_cell(0, 1, 1).unwrap();
-    assert_eq!(style.num_fmt, "#.##");
+    assert_eq!(style.num_fmt.format_code, "#.##");
 
     let mut style = model.get_style_for_cell(0, 10, 1).unwrap();
-    style.num_fmt = "$$#,##0.0000".to_string();
+    style.num_fmt = NumFmt::from_format_code("$$#,##0.0000");
     assert!(model.set_cell_style(0, 10, 1, &style).is_ok());
     let style = model.get_style_for_cell(0, 10, 1).unwrap();
-    assert_eq!(style.num_fmt, "$$#,##0.0000");
+    assert_eq!(style.num_fmt.format_code, "$$#,##0.0000");
 
     // Make sure old style is not touched
     let style = model.get_style_for_cell(0, 1, 1).unwrap();
-    assert_eq!(style.num_fmt, "#.##");
+    assert_eq!(style.num_fmt.format_code, "#.##");
 }
 
 #[test]
@@ -443,7 +444,7 @@ fn test_get_formatted_cell_value() {
 
     // change A5 format
     let mut style = model.get_style_for_cell(0, 5, 1).unwrap();
-    style.num_fmt = "$#,##0.00".to_string();
+    style.num_fmt = NumFmt::from_format_code("$#,##0.00");
     model.set_cell_style(0, 5, 1, &style).unwrap();
 
     model.evaluate();

--- a/base/src/test/test_general.rs
+++ b/base/src/test/test_general.rs
@@ -315,13 +315,13 @@ fn test_style_fmt_id() {
     let mut model = new_empty_model();
 
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code("#.##");
+    style.num_fmt = NumFmt::from_format_code("#.##", None);
     assert!(model.set_cell_style(0, 1, 1, &style).is_ok());
     let style = model.get_style_for_cell(0, 1, 1).unwrap();
     assert_eq!(style.num_fmt.format_code, "#.##");
 
     let mut style = model.get_style_for_cell(0, 10, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code("$$#,##0.0000");
+    style.num_fmt = NumFmt::from_format_code("$$#,##0.0000", None);
     assert!(model.set_cell_style(0, 10, 1, &style).is_ok());
     let style = model.get_style_for_cell(0, 10, 1).unwrap();
     assert_eq!(style.num_fmt.format_code, "$$#,##0.0000");
@@ -444,7 +444,8 @@ fn test_get_formatted_cell_value() {
 
     // change A5 format
     let mut style = model.get_style_for_cell(0, 5, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code("$#,##0.00");
+    let styles = &mut model.workbook.styles;
+    style.num_fmt = NumFmt::from_format_code("$#,##0.00", Some(&mut styles.num_fmts));
     model.set_cell_style(0, 5, 1, &style).unwrap();
 
     model.evaluate();

--- a/base/src/test/test_issue_623.rs
+++ b/base/src/test/test_issue_623.rs
@@ -10,6 +10,6 @@ fn issue_623() {
 
     model.evaluate();
 
-    assert_eq!(model._get_text("A1"), *"46007");
+    assert_eq!(model._get_text("A1"), *"12/16/25"); // Dec 16 2025 = serial 46007, formatted as locale date
     assert_eq!(model._get_text("A2"), *"#VALUE!");
 }

--- a/base/src/test/test_issue_751.rs
+++ b/base/src/test/test_issue_751.rs
@@ -1,0 +1,21 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+// Non-ASCII identifiers (e.g. =ä, =ы) must produce #NAME?, not #ERROR!.
+// Excel treats any unrecognised name — including ones with non-ASCII letters — as a
+// name error, never as a parse error.
+#[test]
+fn issue_751() {
+    let mut model = new_empty_model();
+    // Single non-ASCII letter (German umlaut)
+    model._set("A1", "=ä");
+    // Multi-character non-ASCII name (Cyrillic)
+    model._set("A2", "=привет");
+    // Mixed ASCII/non-ASCII
+    model._set("A3", "=fórmula");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "#NAME?");
+    assert_eq!(model._get_text("A2"), "#NAME?");
+    assert_eq!(model._get_text("A3"), "#NAME?");
+}

--- a/base/src/test/test_issue_751.rs
+++ b/base/src/test/test_issue_751.rs
@@ -1,21 +1,34 @@
 #![allow(clippy::unwrap_used)]
 
-use crate::test::util::new_empty_model;
+use crate::{test::util::new_empty_model, Model};
+
+pub fn new_german_empty_model<'a>() -> Model<'a> {
+    Model::new_empty("model", "en", "UTC", "de").unwrap()
+}
 
 // Non-ASCII identifiers (e.g. =ä, =ы) must produce #NAME?, not #ERROR!.
 // Excel treats any unrecognised name — including ones with non-ASCII letters — as a
 // name error, never as a parse error.
 #[test]
 fn issue_751() {
-    let mut model = new_empty_model();
+    let mut model = new_german_empty_model();
     // Single non-ASCII letter (German umlaut)
     model._set("A1", "=ä");
     // Multi-character non-ASCII name (Cyrillic)
     model._set("A2", "=привет");
     // Mixed ASCII/non-ASCII
     model._set("A3", "=fórmula");
+    
+    model._set("B1", "1");
+    model._set("B2", "2");
+    model._set("B3", "3");
+    model._set("B4", "4");
+    model._set("B5", "5");
+    model._set("B6", "=ZÄHLENWENN(B1:B5,\">2\")");
+
     model.evaluate();
     assert_eq!(model._get_text("A1"), "#NAME?");
     assert_eq!(model._get_text("A2"), "#NAME?");
     assert_eq!(model._get_text("A3"), "#NAME?");
+    assert_eq!(model._get_text("B6"), *"3");
 }

--- a/base/src/test/test_issue_751.rs
+++ b/base/src/test/test_issue_751.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
-use crate::{test::util::new_empty_model, Model};
+use crate::Model;
 
 pub fn new_german_empty_model<'a>() -> Model<'a> {
     Model::new_empty("model", "en", "UTC", "de").unwrap()
@@ -18,7 +18,7 @@ fn issue_751() {
     model._set("A2", "=привет");
     // Mixed ASCII/non-ASCII
     model._set("A3", "=fórmula");
-    
+
     model._set("B1", "1");
     model._set("B2", "2");
     model._set("B3", "3");

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -1,0 +1,422 @@
+#![allow(clippy::unwrap_used)]
+
+// Issue #761 — locale dates corrupt when double-click edited after a locale switch.
+//
+// Root cause: `get_localized_cell_content` (edit bar) and
+// `get_formatted_cell_value` (grid) both used the stored format *string*
+// (e.g. "m/d/yy" for en-US) rather than the locale's own short-date pattern.
+// In a day-first locale (e.g. en-GB) the edit bar would show a month-first
+// string; pressing Enter would then mis-parse the date and corrupt it.
+//
+// The fix: simple locale dates are stored with numFmtId 14
+// (LOCALE_SHORT_DATE_FMT_ID).  Both render functions detect ID 14 and derive
+// the format from `locale.dates.date_formats.short` at runtime.
+
+use crate::{
+    cell::CellValue,
+    model::Model,
+    number_format::{LOCALE_SHORT_DATE_FMT_ID},
+    test::util::new_empty_model,
+};
+
+fn en_gb_model<'a>() -> Model<'a> {
+    Model::new_empty("model", "en-GB", "UTC", "en").unwrap()
+}
+
+fn de_model<'a>() -> Model<'a> {
+    Model::new_empty("model", "de", "UTC", "en").unwrap()
+}
+
+// ── en-US ──────────────────────────────────────────────────────────────────
+
+/// Entering a locale date in en-US stores the correct serial and the edit bar
+/// shows the locale's short-date pattern ("m/d/yy").  Because the cell carries
+/// numFmtId 14, the edit bar is locale-derived; re-entering the shown string
+/// in en-US unambiguously reproduces the same date.
+#[test]
+fn en_us_round_trip_stable() {
+    let mut model = new_empty_model(); // en-US
+    model._set("A1", "4/3/2025"); // April 3, 2025 (month/day in en-US)
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(45750.0))
+    );
+    // en-US short-date format is "m/d/yy" — edit bar shows 2-digit year.
+    assert_eq!(model.get_localized_cell_content(0, 1, 1).unwrap(), "4/3/25");
+}
+
+// ── en-GB ──────────────────────────────────────────────────────────────────
+
+/// Same date (April 3, 2025) entered in en-GB (dd/mm/yyyy) must produce the
+/// same serial as in en-US and the edit bar must show the locale format.
+#[test]
+fn en_gb_round_trip_stable() {
+    let mut model = en_gb_model();
+    model._set("A1", "03/04/2025"); // April 3, 2025 (day/month in en-GB)
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(45750.0))
+    );
+    // en-GB short-date format is "dd/mm/yyyy" — same as the input string.
+    assert_eq!(
+        model.get_localized_cell_content(0, 1, 1).unwrap(),
+        "03/04/2025"
+    );
+}
+
+/// Grid display in en-GB must use the locale's "dd/mm/yyyy" pattern, not the
+/// en-US "m/d/yy" that is the stored format-string default for numFmtId 14.
+#[test]
+fn en_gb_display_uses_locale_format() {
+    let mut model = en_gb_model();
+    model._set("A1", "03/04/2025"); // April 3
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), "03/04/2025");
+}
+
+// ── numFmtId invariants ────────────────────────────────────────────────────
+
+/// After entering a locale date, the cell style must store numFmtId=14
+/// (LOCALE_SHORT_DATE_FMT_ID) — not a custom format string.  This is the
+/// structural guarantee that makes locale-derived rendering possible.
+#[test]
+fn locale_date_stored_as_num_fmt_id_14() {
+    let mut model = new_empty_model();
+    model._set("A1", "4/3/2025");
+    model.evaluate();
+
+    let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
+    let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
+    assert_eq!(
+        num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
+        "locale date must be stored as numFmtId {LOCALE_SHORT_DATE_FMT_ID}, got {num_fmt_id}"
+    );
+}
+
+/// ISO dates (yyyy/mm/dd) must use a literal format string, NOT numFmtId=14,
+/// because ISO format is locale-independent and must be preserved as-is.
+#[test]
+fn iso_date_is_not_stored_as_id_14() {
+    let mut model = new_empty_model();
+    model._set("A1", "2025/03/04"); // ISO: year first
+    model.evaluate();
+
+    let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
+    let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
+    assert_ne!(
+        num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
+        "ISO date must NOT use numFmtId 14 — it has a specific format string"
+    );
+    // The stored serial is still March 4, 2025 regardless of format.
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(45720.0))
+    );
+    // Grid display uses the literal format, not the locale pattern.
+    assert_eq!(model._get_text("A1"), "2025/03/04");
+}
+
+// ── Separator variants ─────────────────────────────────────────────────────
+
+/// Two-digit year input ("4/3/25") must parse as April 3, 2025 in en-US.
+/// The edit bar renders with the locale format "m/d/yy" — identical to the
+/// input — confirming the round-trip is stable.
+#[test]
+fn two_digit_year_input_en_us() {
+    let mut model = new_empty_model();
+    model._set("A1", "4/3/25"); // en-US: month/day/2-digit-year
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(45750.0))
+    );
+    // Edit bar uses "m/d/yy" — same as input, confirming round-trip stability.
+    assert_eq!(model.get_localized_cell_content(0, 1, 1).unwrap(), "4/3/25");
+}
+
+/// Hyphen separator ("03-04-2025") must be accepted in en-GB (day-first).
+/// The edit bar normalises separators to the locale's own pattern (slashes).
+#[test]
+fn hyphen_separator_en_gb() {
+    let mut model = en_gb_model();
+    model._set("A1", "03-04-2025"); // April 3, 2025 with hyphens
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(45750.0))
+    );
+    // Edit bar uses locale format "dd/mm/yyyy" regardless of input separator.
+    assert_eq!(
+        model.get_localized_cell_content(0, 1, 1).unwrap(),
+        "03/04/2025"
+    );
+}
+
+// ── German locale ──────────────────────────────────────────────────────────
+
+/// German locale uses dots as separators and day-first order ("dd.mm.yy").
+/// Both grid display and edit-bar must use this pattern.
+#[test]
+fn german_locale_round_trip() {
+    let mut model = de_model();
+    model._set("A1", "03.04.2025"); // April 3, 2025 in German dd.mm.yyyy
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(45750.0))
+    );
+    // German short-date format is "dd.mm.yy" (2-digit year).
+    assert_eq!(model._get_text("A1"), "03.04.25");
+    assert_eq!(
+        model.get_localized_cell_content(0, 1, 1).unwrap(),
+        "03.04.25"
+    );
+}
+
+// ── Manual format preservation ─────────────────────────────────────────────
+
+/// When a cell is pre-formatted with an explicit date format (e.g. "dd mmmm
+/// yyyy"), entering a new date must NOT overwrite that format with numFmtId 14.
+/// The `should_apply_format` guard protects date→date reassignments.
+#[test]
+fn manual_date_format_preserved_on_entry() {
+    let mut model = new_empty_model();
+
+    // Pre-format A1 with an explicit long date format.
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.num_fmt = "dd mmmm yyyy".to_string();
+    model.set_cell_style(0, 1, 1, &style).unwrap();
+
+    // Enter a locale date — must keep the explicit format, not switch to ID 14.
+    model._set("A1", "4/3/2025");
+    model.evaluate();
+
+    let style_after = model.get_style_for_cell(0, 1, 1).unwrap();
+    assert_eq!(
+        style_after.num_fmt, "dd mmmm yyyy",
+        "manual date format must be preserved when a date is re-entered"
+    );
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(45750.0))
+    );
+}
+
+
+// ── Invalid date inputs ─────────────────────────────────────────
+
+/// Month 13 is not a valid month.  `parse_date` must reject it and the input
+/// must be stored as a text string — not as a date cell with numFmtId=14.
+#[test]
+fn invalid_month_stored_as_text() {
+    let mut model = new_empty_model();
+    model._set("A1", "13/01/2025");
+    model.evaluate();
+
+    // Stored as a raw string, not as a number.
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::String("13/01/2025".to_string()))
+    );
+    // Must NOT have acquired ID-14 style.
+    let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
+    let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
+    assert_ne!(num_fmt_id, LOCALE_SHORT_DATE_FMT_ID);
+}
+
+/// February 29 does not exist in 2025 (not a leap year).  The input must be
+/// rejected by `date_to_serial_number` and stored as text.
+#[test]
+fn feb_29_non_leap_year_stored_as_text() {
+    let mut model = new_empty_model();
+    model._set("A1", "02/29/2025");
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::String("02/29/2025".to_string()))
+    );
+}
+
+/// April has 30 days; day 31 is out of range.  Must be stored as text.
+#[test]
+fn day_overflow_stored_as_text() {
+    let mut model = new_empty_model();
+    model._set("A1", "04/31/2025");
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::String("04/31/2025".to_string()))
+    );
+}
+
+// ── Format-side boundaries ─────────────────────────────────────
+
+/// Entering a plain number must not create a locale-date cell.
+/// `parse_formatted_number` returns `None` for the format spec, so no style
+/// change is applied and the cell retains its default (non-date) format.
+#[test]
+fn plain_number_does_not_create_date_cell() {
+    let mut model = new_empty_model();
+    model._set("A1", "42");
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(42.0))
+    );
+    let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
+    let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
+    assert_ne!(
+        num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
+        "a plain number must not acquire numFmtId 14"
+    );
+}
+
+/// Entering a non-date value (e.g. a percentage) into a cell already carrying
+/// numFmtId=14 must REPLACE the date format.  The `should_apply_format` guard
+/// only skips the assignment when BOTH the old AND new values are dates.
+#[test]
+fn non_date_entry_into_date_cell_replaces_format() {
+    let mut model = new_empty_model();
+
+    // Pre-format A1 as a locale-date cell.
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.num_fmt = "mm-dd-yy".to_string(); // → numFmtId=14
+    model.set_cell_style(0, 1, 1, &style).unwrap();
+
+    // "30%" is not a date — should_apply_format is true so the format changes.
+    model._set("A1", "30%");
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(0.3))
+    );
+    let style_after = model.get_style_for_cell(0, 1, 1).unwrap();
+    assert_eq!(
+        style_after.num_fmt, "#,##0%",
+        "percent entry must replace the locale-date format"
+    );
+}
+
+// ── Cross-locale rendering ────────────────────────────────────────────────
+
+/// The core issue 761 scenario: a date serial stored with numFmtId=14
+/// (as produced by en-US entry) must render with the *current* model's locale
+/// format — not with the en-US literal "m/d/yy" embedded in DEFAULT_NUM_FMTS.
+///
+/// Simulates: date entered in en-US → serialised → loaded in an en-GB model.
+/// "mm-dd-yy" is DEFAULT_NUM_FMTS[14], so `set_cell_style` stores numFmtId=14
+/// exactly as en-US entry would have done.
+#[test]
+fn cross_locale_serial_displays_as_locale_format() {
+    let serial = 45750.0; // April 3, 2025
+
+    let mut model = en_gb_model();
+
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.num_fmt = "mm-dd-yy".to_string(); // maps to numFmtId=14 in DEFAULT_NUM_FMTS
+    model.set_cell_style(0, 1, 1, &style).unwrap();
+    model.update_cell_with_number(0, 1, 1, serial).unwrap();
+    model.evaluate();
+
+    // Must show en-GB day-first format, NOT the en-US "4/3/25".
+    assert_eq!(model._get_text("A1"), "03/04/2025");
+    assert_eq!(
+        model.get_localized_cell_content(0, 1, 1).unwrap(),
+        "03/04/2025"
+    );
+}
+
+// ── Formula cell rendering ────────────────────────────────────────────────
+
+/// =DATE(2025,4,3) in a cell pre-formatted as numFmtId=14 must display with
+/// the locale's short-date pattern.  This exercises the formula-cell branch of
+/// `get_formatted_cell_value`, which applies the same ID-14 check as the
+/// raw-value path.
+#[test]
+fn formula_date_result_respects_locale_format() {
+    let mut model = en_gb_model();
+
+    // Pre-format B1 with ID 14 ("mm-dd-yy" → numFmtId=14).
+    let mut style = model.get_style_for_cell(0, 1, 2).unwrap();
+    style.num_fmt = "mm-dd-yy".to_string();
+    model.set_cell_style(0, 1, 2, &style).unwrap();
+
+    // `update_cell_with_formula` reads the current style index and preserves it.
+    model
+        .update_cell_with_formula(0, 1, 2, "=DATE(2025,4,3)".to_string())
+        .unwrap();
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!B1"),
+        Ok(CellValue::Number(45750.0))
+    );
+    // Grid display uses en-GB locale format for the ID-14 formula cell.
+    assert_eq!(model._get_text("B1"), "03/04/2025");
+}
+
+// ── Excel date functions ──────────────────────────────────────────────────
+
+/// YEAR(), MONTH(), DAY() on a locale-date cell must return the correct
+/// calendar components — proving the stored serial is semantically correct,
+/// not just that the display looks right.
+///
+/// This catches silent mis-parses (e.g. month and day swapped) that would
+/// produce the same display text but a wrong serial.
+#[test]
+fn date_functions_extract_correct_components() {
+    let mut model = new_empty_model(); // en-US: month/day order
+    model._set("A1", "4/3/2025"); // April 3, 2025
+    model._set("B1", "=YEAR(A1)");
+    model._set("C1", "=MONTH(A1)");
+    model._set("D1", "=DAY(A1)");
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!B1"),
+        Ok(CellValue::Number(2025.0))
+    );
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!C1"),
+        Ok(CellValue::Number(4.0)), // April — not 3 (would indicate month/day swap)
+    );
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!D1"),
+        Ok(CellValue::Number(3.0))
+    );
+}
+
+// ── Date arithmetic ───────────────────────────────────────────────────────
+
+/// Locale date cells must work as formula operands.  =A1+30 must add 30 days
+/// to the stored serial, proving ID-14 cells are plain numbers internally.
+/// =B1-A1 must recover the exact day count (no rounding or format interference).
+#[test]
+fn date_arithmetic_composes_correctly() {
+    let mut model = new_empty_model(); // en-US
+    model._set("A1", "4/3/2025"); // April 3, 2025 = serial 45750
+    model._set("B1", "=A1+30"); // May 3, 2025 = serial 45780
+    model._set("C1", "=B1-A1"); // difference must be exactly 30
+    model.evaluate();
+
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!B1"),
+        Ok(CellValue::Number(45780.0))
+    );
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!C1"),
+        Ok(CellValue::Number(30.0))
+    );
+}

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -395,6 +395,74 @@ fn date_functions_extract_correct_components() {
     );
 }
 
+/// Basic sanity check: =DATE(2025,10,11) in en-US must display October 11
+/// in month/day/year order.  This exercises the formula-cell display path
+/// and gives us a baseline before adding locale-sensitivity tests.
+#[test]
+fn date_functions_date_fn() {
+    let mut model = new_empty_model(); // en-US: month/day order
+    model._set("A1", "=DATE(2025,10,11)");
+    model.evaluate();
+
+    // en-US locale short date is "m/d/yy" — numFmtId 14 renders with 2-digit year.
+    assert_eq!(model._get_text("A1"), "10/11/25");
+}
+
+/// =DATE() must store numFmtId=14 (LOCALE_SHORT_DATE_FMT_ID) so that
+/// locale-aware rendering derives the display format at runtime rather than
+/// baking in the locale's literal string at evaluation time.
+///
+/// Bug: `units_fn_dates` currently stores a literal format string (e.g.
+/// "M/d/yyyy" for en-US) as a custom numFmtId ≥ 164.  When the file is
+/// opened in a different locale, the literal is used verbatim and the display
+/// is wrong until the cell is re-edited (which triggers re-evaluation and
+/// re-application of the then-current locale).
+///
+/// Fix: the formula-cell style assignment for date-returning functions must
+/// use numFmtId=14 instead of `get_style_with_format(…, literal)`.
+#[test]
+fn date_fn_stores_locale_fmt_id() {
+    let mut model = new_empty_model(); // en-US
+    model._set("A1", "=DATE(2025,10,11)");
+    model.evaluate();
+
+    let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
+    let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
+    assert_eq!(
+        num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
+        "=DATE() result must store numFmtId={LOCALE_SHORT_DATE_FMT_ID} (locale-aware), got {num_fmt_id}"
+    );
+}
+
+/// Locale-switch bug: =DATE() entered in en-US bakes a literal "m/d/yyyy"
+/// format at evaluation time.  After switching to en-GB via `set_locale`,
+/// the model re-evaluates but the style is NOT updated, so the cell still
+/// shows month-first "10/11/2025" instead of en-GB day-first "11/10/2025".
+///
+/// The cell only corrects itself once it is re-edited (which triggers a fresh
+/// `set_user_input` → `compute_node_units` → new style assignment cycle in
+/// the now-active locale).
+///
+/// Fix: store numFmtId=14 so that `get_formatted_cell_value` derives the
+/// display pattern from the active locale at render time, making locale
+/// switches take effect immediately without requiring a re-edit.
+#[test]
+fn date_fn_locale_switch_updates_display() {
+    let mut model = new_empty_model(); // start in en-US
+    model._set("A1", "=DATE(2025,10,11)");
+    model.evaluate();
+
+    // Sanity: en-US shows month-first October 11 (locale "m/d/yy" → 2-digit year).
+    assert_eq!(model._get_text("A1"), "10/11/25");
+
+    // Switch locale — set_locale re-evaluates internally but does NOT
+    // re-run compute_node_units, so the "m/d/yyyy" literal stays in place.
+    model.set_locale("en-GB").unwrap();
+
+    // Must now show en-GB day-first "11/10/2025".
+    assert_eq!(model._get_text("A1"), "11/10/2025");
+}
+
 // ── Date arithmetic ───────────────────────────────────────────────────────
 
 /// Locale date cells must work as formula operands.  =A1+30 must add 30 days

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -567,3 +567,55 @@ fn non_date_format_preserved_when_date_formula_entered() {
         Ok(CellValue::Number(45750.0))
     );
 }
+
+#[test]
+fn legacy_custom_num_fmt_renders_literal_not_locale() {
+    // Backward-compat: old workbooks may contain custom numFmtIds (≥ 164)
+    // with literal locale-like format codes saved from a different locale
+    // (e.g., en-US "m/d/yyyy" embedded in a workbook now opened in en-GB).
+    //
+    // Only sentinel IDs 14 and 22 derive their display pattern from the active
+    // locale at render time.  Any other ID — including user-defined custom IDs
+    // ≥ 164 — must render its frozen literal format code as-is, regardless of
+    // the model's current locale.
+    let serial = 45750.0; // April 3, 2025
+    let mut model = en_gb_model();
+
+    // Apply a US-style literal format.  set_cell_style will register it as a
+    // custom format (ID ≥ 164) because "m/d/yyyy" is not an ECMA-376 built-in.
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.num_fmt = NumFmt::from_format_code("m/d/yyyy");
+    model.set_cell_style(0, 1, 1, &style).unwrap();
+    model.update_cell_with_number(0, 1, 1, serial).unwrap();
+    model.evaluate();
+
+    // Verify the stored ID is not one of the locale sentinel IDs (14 or 22).
+    // IronCalc assigns user-defined IDs starting at builtins().len() (= 45).
+    let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
+    let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
+    assert_ne!(
+        num_fmt_id,
+        NumFmt::SHORT_DATE_ID,
+        "custom format 'm/d/yyyy' must not be stored as the locale-date sentinel {}",
+        NumFmt::SHORT_DATE_ID
+    );
+    assert_ne!(
+        num_fmt_id,
+        NumFmt::SHORT_DATETIME_ID,
+        "custom format 'm/d/yyyy' must not be stored as the locale-datetime sentinel {}",
+        NumFmt::SHORT_DATETIME_ID
+    );
+
+    // Must render the frozen literal "m/d/yyyy" (US-style → "4/3/2025"),
+    // NOT the en-GB locale pattern which would produce "03/04/2025".
+    assert_eq!(
+        model._get_text("A1"),
+        "4/3/2025",
+        "custom numFmt with 'm/d/yyyy' must render its literal code, not the en-GB locale pattern"
+    );
+    assert_eq!(
+        model.get_localized_cell_content(0, 1, 1).unwrap(),
+        "4/3/2025",
+        "edit-bar content must reflect the literal format code, not re-derive from locale"
+    );
+}

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -2,19 +2,21 @@
 
 // Issue #761 — locale dates corrupt when double-click edited after a locale switch.
 //
-// Root cause: `get_localized_cell_content` (edit bar) and
-// `get_formatted_cell_value` (grid) both used the stored format *string*
-// (e.g. "m/d/yy" for en-US) rather than the locale's own short-date pattern.
-// In a day-first locale (e.g. en-GB) the edit bar would show a month-first
+// Root cause: `get_localized_cell_content` (edit bar) and `get_formatted_cell_value`
+// (grid) both used the stored format string rather than the locale's own short-date
+// pattern. In a day-first locale (e.g. en-GB) the edit bar would show a month-first
 // string; pressing Enter would then mis-parse the date and corrupt it.
 //
-// The fix: simple locale dates are stored with numFmtId 14
-// (LOCALE_SHORT_DATE_FMT_ID).  Both render functions detect ID 14 and derive
-// the format from `locale.dates.date_formats.short` at runtime.
+// Fix: simple locale dates are stored with numFmtId 14 (LOCALE_SHORT_DATE_FMT_ID).
+// Both render functions detect ID 14 and derive the format from
+// `locale.dates.date_formats.short` at runtime.
 
 use crate::{
-    cell::CellValue, model::Model, number_format::LOCALE_SHORT_DATE_FMT_ID,
+    cell::CellValue,
+    model::Model,
+    number_format::LOCALE_SHORT_DATE_FMT_ID,
     test::util::new_empty_model,
+    types::{NumFmt, Styles},
 };
 
 fn en_gb_model<'a>() -> Model<'a> {
@@ -25,63 +27,46 @@ fn de_model<'a>() -> Model<'a> {
     Model::new_empty("model", "de", "UTC", "en").unwrap()
 }
 
-// ── en-US ──────────────────────────────────────────────────────────────────
-
-/// Entering a locale date in en-US stores the correct serial and the edit bar
-/// shows the locale's short-date pattern ("m/d/yy").  Because the cell carries
-/// numFmtId 14, the edit bar is locale-derived; re-entering the shown string
-/// in en-US unambiguously reproduces the same date.
 #[test]
 fn en_us_round_trip_stable() {
-    let mut model = new_empty_model(); // en-US
-    model._set("A1", "4/3/2025"); // April 3, 2025 (month/day in en-US)
+    // April 3, 2025 in en-US (month/day). Edit bar shows locale "m/d/yy".
+    let mut model = new_empty_model();
+    model._set("A1", "4/3/2025");
     model.evaluate();
 
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A1"),
         Ok(CellValue::Number(45750.0))
     );
-    // en-US short-date format is "m/d/yy" — edit bar shows 2-digit year.
     assert_eq!(model.get_localized_cell_content(0, 1, 1).unwrap(), "4/3/25");
 }
 
-// ── en-GB ──────────────────────────────────────────────────────────────────
-
-/// Same date (April 3, 2025) entered in en-GB (dd/mm/yyyy) must produce the
-/// same serial as in en-US and the edit bar must show the locale format.
 #[test]
 fn en_gb_round_trip_stable() {
+    // April 3, 2025 in en-GB (day/month). Edit bar shows locale "dd/mm/yyyy".
     let mut model = en_gb_model();
-    model._set("A1", "03/04/2025"); // April 3, 2025 (day/month in en-GB)
+    model._set("A1", "03/04/2025");
     model.evaluate();
 
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A1"),
         Ok(CellValue::Number(45750.0))
     );
-    // en-GB short-date format is "dd/mm/yyyy" — same as the input string.
     assert_eq!(
         model.get_localized_cell_content(0, 1, 1).unwrap(),
         "03/04/2025"
     );
 }
 
-/// Grid display in en-GB must use the locale's "dd/mm/yyyy" pattern, not the
-/// en-US "m/d/yy" that is the stored format-string default for numFmtId 14.
 #[test]
 fn en_gb_display_uses_locale_format() {
     let mut model = en_gb_model();
-    model._set("A1", "03/04/2025"); // April 3
+    model._set("A1", "03/04/2025");
     model.evaluate();
 
     assert_eq!(model._get_text("A1"), "03/04/2025");
 }
 
-// ── numFmtId invariants ────────────────────────────────────────────────────
-
-/// After entering a locale date, the cell style must store numFmtId=14
-/// (LOCALE_SHORT_DATE_FMT_ID) — not a custom format string.  This is the
-/// structural guarantee that makes locale-derived rendering possible.
 #[test]
 fn locale_date_stored_as_num_fmt_id_14() {
     let mut model = new_empty_model();
@@ -96,12 +81,11 @@ fn locale_date_stored_as_num_fmt_id_14() {
     );
 }
 
-/// ISO dates (yyyy/mm/dd) must use a literal format string, NOT numFmtId=14,
-/// because ISO format is locale-independent and must be preserved as-is.
 #[test]
 fn iso_date_is_not_stored_as_id_14() {
+    // ISO dates (year first) are locale-independent and keep a literal format string.
     let mut model = new_empty_model();
-    model._set("A1", "2025/03/04"); // ISO: year first
+    model._set("A1", "2025/03/04");
     model.evaluate();
 
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
@@ -110,68 +94,53 @@ fn iso_date_is_not_stored_as_id_14() {
         num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
         "ISO date must NOT use numFmtId 14 — it has a specific format string"
     );
-    // The stored serial is still March 4, 2025 regardless of format.
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A1"),
         Ok(CellValue::Number(45720.0))
     );
-    // Grid display uses the literal format, not the locale pattern.
     assert_eq!(model._get_text("A1"), "2025/03/04");
 }
 
-// ── Separator variants ─────────────────────────────────────────────────────
-
-/// Two-digit year input ("4/3/25") must parse as April 3, 2025 in en-US.
-/// The edit bar renders with the locale format "m/d/yy" — identical to the
-/// input — confirming the round-trip is stable.
 #[test]
 fn two_digit_year_input_en_us() {
     let mut model = new_empty_model();
-    model._set("A1", "4/3/25"); // en-US: month/day/2-digit-year
+    model._set("A1", "4/3/25");
     model.evaluate();
 
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A1"),
         Ok(CellValue::Number(45750.0))
     );
-    // Edit bar uses "m/d/yy" — same as input, confirming round-trip stability.
     assert_eq!(model.get_localized_cell_content(0, 1, 1).unwrap(), "4/3/25");
 }
 
-/// Hyphen separator ("03-04-2025") must be accepted in en-GB (day-first).
-/// The edit bar normalises separators to the locale's own pattern (slashes).
 #[test]
 fn hyphen_separator_en_gb() {
+    // Hyphens are accepted; the edit bar normalises to the locale's own separator.
     let mut model = en_gb_model();
-    model._set("A1", "03-04-2025"); // April 3, 2025 with hyphens
+    model._set("A1", "03-04-2025");
     model.evaluate();
 
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A1"),
         Ok(CellValue::Number(45750.0))
     );
-    // Edit bar uses locale format "dd/mm/yyyy" regardless of input separator.
     assert_eq!(
         model.get_localized_cell_content(0, 1, 1).unwrap(),
         "03/04/2025"
     );
 }
 
-// ── German locale ──────────────────────────────────────────────────────────
-
-/// German locale uses dots as separators and day-first order ("dd.mm.yy").
-/// Both grid display and edit-bar must use this pattern.
 #[test]
 fn german_locale_round_trip() {
     let mut model = de_model();
-    model._set("A1", "03.04.2025"); // April 3, 2025 in German dd.mm.yyyy
+    model._set("A1", "03.04.2025");
     model.evaluate();
 
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A1"),
         Ok(CellValue::Number(45750.0))
     );
-    // German short-date format is "dd.mm.yy" (2-digit year).
     assert_eq!(model._get_text("A1"), "03.04.25");
     assert_eq!(
         model.get_localized_cell_content(0, 1, 1).unwrap(),
@@ -179,27 +148,20 @@ fn german_locale_round_trip() {
     );
 }
 
-// ── Manual format preservation ─────────────────────────────────────────────
-
-/// When a cell is pre-formatted with an explicit date format (e.g. "dd mmmm
-/// yyyy"), entering a new date must NOT overwrite that format with numFmtId 14.
-/// The `should_apply_format` guard protects date→date reassignments.
 #[test]
 fn manual_date_format_preserved_on_entry() {
+    // A cell with an explicit date format must not have it overwritten with numFmtId 14.
     let mut model = new_empty_model();
-
-    // Pre-format A1 with an explicit long date format.
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = "dd mmmm yyyy".to_string();
+    style.num_fmt = NumFmt::from_format_code("dd mmmm yyyy");
     model.set_cell_style(0, 1, 1, &style).unwrap();
 
-    // Enter a locale date — must keep the explicit format, not switch to ID 14.
     model._set("A1", "4/3/2025");
     model.evaluate();
 
     let style_after = model.get_style_for_cell(0, 1, 1).unwrap();
     assert_eq!(
-        style_after.num_fmt, "dd mmmm yyyy",
+        style_after.num_fmt.format_code, "dd mmmm yyyy",
         "manual date format must be preserved when a date is re-entered"
     );
     assert_eq!(
@@ -208,29 +170,21 @@ fn manual_date_format_preserved_on_entry() {
     );
 }
 
-// ── Invalid date inputs ─────────────────────────────────────────
-
-/// Month 13 is not a valid month.  `parse_date` must reject it and the input
-/// must be stored as a text string — not as a date cell with numFmtId=14.
 #[test]
 fn invalid_month_stored_as_text() {
     let mut model = new_empty_model();
     model._set("A1", "13/01/2025");
     model.evaluate();
 
-    // Stored as a raw string, not as a number.
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A1"),
         Ok(CellValue::String("13/01/2025".to_string()))
     );
-    // Must NOT have acquired ID-14 style.
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_ne!(num_fmt_id, LOCALE_SHORT_DATE_FMT_ID);
 }
 
-/// February 29 does not exist in 2025 (not a leap year).  The input must be
-/// rejected by `date_to_serial_number` and stored as text.
 #[test]
 fn feb_29_non_leap_year_stored_as_text() {
     let mut model = new_empty_model();
@@ -243,7 +197,6 @@ fn feb_29_non_leap_year_stored_as_text() {
     );
 }
 
-/// April has 30 days; day 31 is out of range.  Must be stored as text.
 #[test]
 fn day_overflow_stored_as_text() {
     let mut model = new_empty_model();
@@ -256,11 +209,6 @@ fn day_overflow_stored_as_text() {
     );
 }
 
-// ── Format-side boundaries ─────────────────────────────────────
-
-/// Entering a plain number must not create a locale-date cell.
-/// `parse_formatted_number` returns `None` for the format spec, so no style
-/// change is applied and the cell retains its default (non-date) format.
 #[test]
 fn plain_number_does_not_create_date_cell() {
     let mut model = new_empty_model();
@@ -273,25 +221,17 @@ fn plain_number_does_not_create_date_cell() {
     );
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert_ne!(
-        num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
-        "a plain number must not acquire numFmtId 14"
-    );
+    assert_ne!(num_fmt_id, LOCALE_SHORT_DATE_FMT_ID);
 }
 
-/// Entering a non-date value (e.g. a percentage) into a cell already carrying
-/// numFmtId=14 must REPLACE the date format.  The `should_apply_format` guard
-/// only skips the assignment when BOTH the old AND new values are dates.
 #[test]
 fn non_date_entry_into_date_cell_replaces_format() {
+    // The should_apply_format guard only preserves date format when BOTH old and new are dates.
     let mut model = new_empty_model();
-
-    // Pre-format A1 as a locale-date cell.
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = "mm-dd-yy".to_string(); // → numFmtId=14
+    style.num_fmt = NumFmt::from_format_code("mm-dd-yy"); // → numFmtId=14
     model.set_cell_style(0, 1, 1, &style).unwrap();
 
-    // "30%" is not a date — should_apply_format is true so the format changes.
     model._set("A1", "30%");
     model.evaluate();
 
@@ -301,33 +241,23 @@ fn non_date_entry_into_date_cell_replaces_format() {
     );
     let style_after = model.get_style_for_cell(0, 1, 1).unwrap();
     assert_eq!(
-        style_after.num_fmt, "#,##0%",
+        style_after.num_fmt.format_code, "#,##0%",
         "percent entry must replace the locale-date format"
     );
 }
 
-// ── Cross-locale rendering ────────────────────────────────────────────────
-
-/// The core issue 761 scenario: a date serial stored with numFmtId=14
-/// (as produced by en-US entry) must render with the *current* model's locale
-/// format — not with the en-US literal "m/d/yy" embedded in DEFAULT_NUM_FMTS.
-///
-/// Simulates: date entered in en-US → serialised → loaded in an en-GB model.
-/// "mm-dd-yy" is DEFAULT_NUM_FMTS[14], so `set_cell_style` stores numFmtId=14
-/// exactly as en-US entry would have done.
 #[test]
 fn cross_locale_serial_displays_as_locale_format() {
+    // Core issue 761: a serial stored with numFmtId=14 in en-US must render
+    // with the en-GB pattern when the model locale is en-GB.
     let serial = 45750.0; // April 3, 2025
-
     let mut model = en_gb_model();
-
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = "mm-dd-yy".to_string(); // maps to numFmtId=14 in DEFAULT_NUM_FMTS
+    style.num_fmt = NumFmt::from_format_code("mm-dd-yy"); // → numFmtId=14
     model.set_cell_style(0, 1, 1, &style).unwrap();
     model.update_cell_with_number(0, 1, 1, serial).unwrap();
     model.evaluate();
 
-    // Must show en-GB day-first format, NOT the en-US "4/3/25".
     assert_eq!(model._get_text("A1"), "03/04/2025");
     assert_eq!(
         model.get_localized_cell_content(0, 1, 1).unwrap(),
@@ -335,22 +265,13 @@ fn cross_locale_serial_displays_as_locale_format() {
     );
 }
 
-// ── Formula cell rendering ────────────────────────────────────────────────
-
-/// =DATE(2025,4,3) in a cell pre-formatted as numFmtId=14 must display with
-/// the locale's short-date pattern.  This exercises the formula-cell branch of
-/// `get_formatted_cell_value`, which applies the same ID-14 check as the
-/// raw-value path.
 #[test]
 fn formula_date_result_respects_locale_format() {
     let mut model = en_gb_model();
-
-    // Pre-format B1 with ID 14 ("mm-dd-yy" → numFmtId=14).
     let mut style = model.get_style_for_cell(0, 1, 2).unwrap();
-    style.num_fmt = "mm-dd-yy".to_string();
+    style.num_fmt = NumFmt::from_format_code("mm-dd-yy"); // → numFmtId=14
     model.set_cell_style(0, 1, 2, &style).unwrap();
 
-    // `update_cell_with_formula` reads the current style index and preserves it.
     model
         .update_cell_with_formula(0, 1, 2, "=DATE(2025,4,3)".to_string())
         .unwrap();
@@ -360,21 +281,13 @@ fn formula_date_result_respects_locale_format() {
         model.get_cell_value_by_ref("Sheet1!B1"),
         Ok(CellValue::Number(45750.0))
     );
-    // Grid display uses en-GB locale format for the ID-14 formula cell.
     assert_eq!(model._get_text("B1"), "03/04/2025");
 }
 
-// ── Excel date functions ──────────────────────────────────────────────────
-
-/// YEAR(), MONTH(), DAY() on a locale-date cell must return the correct
-/// calendar components — proving the stored serial is semantically correct,
-/// not just that the display looks right.
-///
-/// This catches silent mis-parses (e.g. month and day swapped) that would
-/// produce the same display text but a wrong serial.
 #[test]
 fn date_functions_extract_correct_components() {
-    let mut model = new_empty_model(); // en-US: month/day order
+    // YEAR/MONTH/DAY on a locale-date cell prove the serial is semantically correct.
+    let mut model = new_empty_model();
     model._set("A1", "4/3/2025"); // April 3, 2025
     model._set("B1", "=YEAR(A1)");
     model._set("C1", "=MONTH(A1)");
@@ -395,34 +308,19 @@ fn date_functions_extract_correct_components() {
     );
 }
 
-/// Basic sanity check: =DATE(2025,10,11) in en-US must display October 11
-/// in month/day/year order.  This exercises the formula-cell display path
-/// and gives us a baseline before adding locale-sensitivity tests.
 #[test]
 fn date_functions_date_fn() {
-    let mut model = new_empty_model(); // en-US: month/day order
+    let mut model = new_empty_model();
     model._set("A1", "=DATE(2025,10,11)");
     model.evaluate();
 
-    // en-US locale short date is "m/d/yy" — numFmtId 14 renders with 2-digit year.
+    // en-US "m/d/yy" — numFmtId 14 renders with 2-digit year.
     assert_eq!(model._get_text("A1"), "10/11/25");
 }
 
-/// =DATE() must store numFmtId=14 (LOCALE_SHORT_DATE_FMT_ID) so that
-/// locale-aware rendering derives the display format at runtime rather than
-/// baking in the locale's literal string at evaluation time.
-///
-/// Bug: `units_fn_dates` currently stores a literal format string (e.g.
-/// "M/d/yyyy" for en-US) as a custom numFmtId ≥ 164.  When the file is
-/// opened in a different locale, the literal is used verbatim and the display
-/// is wrong until the cell is re-edited (which triggers re-evaluation and
-/// re-application of the then-current locale).
-///
-/// Fix: the formula-cell style assignment for date-returning functions must
-/// use numFmtId=14 instead of `get_style_with_format(…, literal)`.
 #[test]
 fn date_fn_stores_locale_fmt_id() {
-    let mut model = new_empty_model(); // en-US
+    let mut model = new_empty_model();
     model._set("A1", "=DATE(2025,10,11)");
     model.evaluate();
 
@@ -430,50 +328,159 @@ fn date_fn_stores_locale_fmt_id() {
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
         num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
-        "=DATE() result must store numFmtId={LOCALE_SHORT_DATE_FMT_ID} (locale-aware), got {num_fmt_id}"
+        "=DATE() result must store numFmtId={LOCALE_SHORT_DATE_FMT_ID}, got {num_fmt_id}"
     );
 }
 
-/// Locale-switch bug: =DATE() entered in en-US bakes a literal "m/d/yyyy"
-/// format at evaluation time.  After switching to en-GB via `set_locale`,
-/// the model re-evaluates but the style is NOT updated, so the cell still
-/// shows month-first "10/11/2025" instead of en-GB day-first "11/10/2025".
-///
-/// The cell only corrects itself once it is re-edited (which triggers a fresh
-/// `set_user_input` → `compute_node_units` → new style assignment cycle in
-/// the now-active locale).
-///
-/// Fix: store numFmtId=14 so that `get_formatted_cell_value` derives the
-/// display pattern from the active locale at render time, making locale
-/// switches take effect immediately without requiring a re-edit.
 #[test]
 fn date_fn_locale_switch_updates_display() {
-    let mut model = new_empty_model(); // start in en-US
+    let mut model = new_empty_model();
     model._set("A1", "=DATE(2025,10,11)");
     model.evaluate();
 
-    // Sanity: en-US shows month-first October 11 (locale "m/d/yy" → 2-digit year).
-    assert_eq!(model._get_text("A1"), "10/11/25");
+    assert_eq!(model._get_text("A1"), "10/11/25"); // en-US month-first
 
-    // Switch locale — set_locale re-evaluates internally but does NOT
-    // re-run compute_node_units, so the "m/d/yyyy" literal stays in place.
     model.set_locale("en-GB").unwrap();
 
-    // Must now show en-GB day-first "11/10/2025".
-    assert_eq!(model._get_text("A1"), "11/10/2025");
+    assert_eq!(model._get_text("A1"), "11/10/2025"); // en-GB day-first
 }
 
-// ── Date arithmetic ───────────────────────────────────────────────────────
+#[test]
+fn num_fmt_builtin_format_code_resolves_canonical_id() {
+    let general = NumFmt::from_format_code("general");
+    assert_eq!(general.num_fmt_id, 0, "\"general\" must map to numFmtId 0");
 
-/// Locale date cells must work as formula operands.  =A1+30 must add 30 days
-/// to the stored serial, proving ID-14 cells are plain numbers internally.
-/// =B1-A1 must recover the exact day count (no rounding or format interference).
+    let locale_date = NumFmt::from_format_code("mm-dd-yy");
+    assert_eq!(
+        locale_date.num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
+        "\"mm-dd-yy\" must map to LOCALE_SHORT_DATE_FMT_ID ({})",
+        LOCALE_SHORT_DATE_FMT_ID,
+    );
+}
+
+#[test]
+fn num_fmt_custom_format_code_has_placeholder_id() {
+    // Custom codes not in the built-in table use -1 as a sentinel until registered.
+    let custom = NumFmt::from_format_code("dd/mm/yyyy hh:mm:ss");
+    assert_eq!(custom.format_code, "dd/mm/yyyy hh:mm:ss");
+    assert_eq!(custom.num_fmt_id, -1);
+}
+
+#[test]
+fn set_cell_style_reuses_cell_xfs_for_same_custom_format() {
+    let mut model = new_empty_model();
+    let code = "dd/mm/yyyy hh:mm:ss";
+
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.num_fmt = NumFmt::from_format_code(code);
+    model.set_cell_style(0, 1, 1, &style).unwrap();
+    let xfs_len_after_first = model.workbook.styles.cell_xfs.len();
+
+    let mut style2 = model.get_style_for_cell(0, 2, 1).unwrap();
+    style2.num_fmt = NumFmt::from_format_code(code);
+    model.set_cell_style(0, 2, 1, &style2).unwrap();
+
+    assert_eq!(
+        model.workbook.styles.cell_xfs.len(),
+        xfs_len_after_first,
+        "second apply of the same custom format must reuse the existing CellXfs entry"
+    );
+}
+
+#[test]
+fn get_style_with_format_no_duplicate_cell_xfs() {
+    // Applying the same custom format twice via get_style_with_format must not duplicate CellXfs.
+    let mut model = new_empty_model();
+    let code = "dd/mm/yyyy hh:mm:ss";
+    let styles = &mut model.workbook.styles;
+
+    let idx1 = styles.get_style_with_format(0, code).unwrap();
+    let xfs_len_after_first = styles.cell_xfs.len();
+
+    let idx2 = styles.get_style_with_format(0, code).unwrap();
+
+    assert_eq!(styles.cell_xfs.len(), xfs_len_after_first);
+    assert_eq!(idx1, idx2);
+}
+
+#[test]
+fn format_code_for_id_returns_correct_code() {
+    let styles = Styles {
+        num_fmts: vec![NumFmt {
+            num_fmt_id: 164,
+            format_code: "dd/mm/yyyy hh:mm:ss".to_string(),
+        }],
+        ..Styles::default()
+    };
+
+    assert_eq!(styles.format_code_for_id(0), "general");
+    assert_eq!(styles.format_code_for_id(9), "0%");
+    assert_eq!(styles.format_code_for_id(LOCALE_SHORT_DATE_FMT_ID), "mm-dd-yy");
+    assert_eq!(styles.format_code_for_id(164), "dd/mm/yyyy hh:mm:ss");
+    assert_eq!(styles.format_code_for_id(999), "general"); // unknown → fallback
+}
+
+#[test]
+fn get_style_with_num_fmt_id_rejects_orphan_id() {
+    let mut model = new_empty_model();
+    let styles = &mut model.workbook.styles;
+
+    assert!(styles.get_style_with_num_fmt_id(0, 999).is_err());
+}
+
+#[test]
+fn get_style_with_num_fmt_id_accepts_builtin_id() {
+    let mut model = new_empty_model();
+    let styles = &mut model.workbook.styles;
+
+    assert!(styles
+        .get_style_with_num_fmt_id(0, LOCALE_SHORT_DATE_FMT_ID)
+        .is_ok());
+}
+
+#[test]
+fn get_style_with_num_fmt_id_accepts_registered_custom_id() {
+    let mut model = new_empty_model();
+    let styles = &mut model.workbook.styles;
+
+    let registered = NumFmt::get_or_register("dd/mm/yyyy hh:mm:ss", &mut styles.num_fmts);
+    assert!(registered.num_fmt_id >= 0);
+
+    assert!(styles
+        .get_style_with_num_fmt_id(0, registered.num_fmt_id)
+        .is_ok());
+}
+
+#[test]
+fn custom_format_sentinel_never_stored_in_cell_xfs() {
+    // from_format_code uses -1 as a sentinel; set_cell_style must resolve it before writing.
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.num_fmt = NumFmt::from_format_code("dd/mm/yyyy hh:mm:ss");
+    assert_eq!(style.num_fmt.num_fmt_id, -1, "sentinel must be -1 before registration");
+
+    model.set_cell_style(0, 1, 1, &style).unwrap();
+
+    let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
+    let stored_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
+    assert!(stored_id >= 0, "CellXfs must not store the -1 sentinel; got {stored_id}");
+
+    let entry = model
+        .workbook
+        .styles
+        .num_fmts
+        .iter()
+        .find(|f| f.num_fmt_id == stored_id);
+    assert!(entry.is_some(), "custom format must be registered in num_fmts");
+    assert_eq!(entry.unwrap().format_code, "dd/mm/yyyy hh:mm:ss");
+}
+
 #[test]
 fn date_arithmetic_composes_correctly() {
-    let mut model = new_empty_model(); // en-US
+    let mut model = new_empty_model();
     model._set("A1", "4/3/2025"); // April 3, 2025 = serial 45750
     model._set("B1", "=A1+30"); // May 3, 2025 = serial 45780
-    model._set("C1", "=B1-A1"); // difference must be exactly 30
+    model._set("C1", "=B1-A1"); // difference = 30
     model.evaluate();
 
     assert_eq!(

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -12,10 +12,7 @@
 // `locale.dates.date_formats.short` at runtime.
 
 use crate::{
-    cell::CellValue,
-    model::Model,
-    number_format::BuiltinFmts,
-    test::util::new_empty_model,
+    cell::CellValue, model::Model, number_format::DefaultFmts, test::util::new_empty_model,
     types::NumFmt,
 };
 
@@ -76,8 +73,10 @@ fn locale_date_stored_as_num_fmt_id_14() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id, BuiltinFmts::SHORT_DATE_ID,
-        "locale date must be stored as numFmtId {}, got {num_fmt_id}", BuiltinFmts::SHORT_DATE_ID
+        num_fmt_id,
+        DefaultFmts::SHORT_DATE_ID,
+        "locale date must be stored as numFmtId {}, got {num_fmt_id}",
+        DefaultFmts::SHORT_DATE_ID
     );
 }
 
@@ -91,7 +90,8 @@ fn iso_date_is_not_stored_as_id_14() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_ne!(
-        num_fmt_id, BuiltinFmts::SHORT_DATE_ID,
+        num_fmt_id,
+        DefaultFmts::SHORT_DATE_ID,
         "ISO date must NOT use numFmtId 14 — it has a specific format string"
     );
     assert_eq!(
@@ -182,7 +182,7 @@ fn invalid_month_stored_as_text() {
     );
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert_ne!(num_fmt_id, BuiltinFmts::SHORT_DATE_ID);
+    assert_ne!(num_fmt_id, DefaultFmts::SHORT_DATE_ID);
 }
 
 #[test]
@@ -221,7 +221,7 @@ fn plain_number_does_not_create_date_cell() {
     );
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert_ne!(num_fmt_id, BuiltinFmts::SHORT_DATE_ID);
+    assert_ne!(num_fmt_id, DefaultFmts::SHORT_DATE_ID);
 }
 
 #[test]
@@ -327,8 +327,10 @@ fn date_fn_stores_locale_fmt_id() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id, BuiltinFmts::SHORT_DATE_ID,
-        "=DATE() result must store numFmtId={}, got {num_fmt_id}", BuiltinFmts::SHORT_DATE_ID
+        num_fmt_id,
+        DefaultFmts::SHORT_DATE_ID,
+        "=DATE() result must store numFmtId={}, got {num_fmt_id}",
+        DefaultFmts::SHORT_DATE_ID
     );
 }
 
@@ -352,9 +354,10 @@ fn num_fmt_builtin_format_code_resolves_canonical_id() {
 
     let locale_date = NumFmt::from_format_code("mm-dd-yy");
     assert_eq!(
-        locale_date.num_fmt_id, BuiltinFmts::SHORT_DATE_ID,
+        locale_date.num_fmt_id,
+        DefaultFmts::SHORT_DATE_ID,
         "\"mm-dd-yy\" must map to NumFmt::LOCALE_DATE_ID ({})",
-        BuiltinFmts::SHORT_DATE_ID,
+        DefaultFmts::SHORT_DATE_ID,
     );
 }
 
@@ -405,16 +408,37 @@ fn get_style_with_format_no_duplicate_cell_xfs() {
 
 #[test]
 fn resolve_code_returns_correct_code() {
-    let num_fmts = vec![NumFmt {
-        num_fmt_id: 164,
-        format_code: "dd/mm/yyyy hh:mm:ss".to_string(),
-    }];
+    let num_fmts = vec![NumFmt::new(164, "dd/mm/yyyy hh:mm:ss".to_string())];
 
     assert_eq!(NumFmt::format_code_for_id(0, &num_fmts), "general");
     assert_eq!(NumFmt::format_code_for_id(9, &num_fmts), "0%");
-    assert_eq!(NumFmt::format_code_for_id(BuiltinFmts::SHORT_DATE_ID, &num_fmts), "mm-dd-yy");
-    assert_eq!(NumFmt::format_code_for_id(164, &num_fmts), "dd/mm/yyyy hh:mm:ss");
+    assert_eq!(
+        NumFmt::format_code_for_id(DefaultFmts::SHORT_DATE_ID, &num_fmts),
+        "mm-dd-yy"
+    );
+    assert_eq!(
+        NumFmt::format_code_for_id(164, &num_fmts),
+        "dd/mm/yyyy hh:mm:ss"
+    );
     assert_eq!(NumFmt::format_code_for_id(999, &num_fmts), "general"); // unknown → fallback
+}
+
+#[test]
+fn from_id_unknown_falls_back_to_general_not_empty() {
+    // from_id must return format_code = "general" for unknown IDs, not "" (empty string).
+    //
+    // Use id=-1 (negative unknown): the debug_assert in from_id guards only non-negative
+    // unknown IDs, so negative IDs exercise the fallback path without triggering it.
+    let fmt = NumFmt::from_id(-1, &[]);
+    assert_eq!(
+        fmt.num_fmt_id, 0,
+        "negative unknown ID must clamp to 0 (General)"
+    );
+    assert_eq!(
+        fmt.format_code, "general",
+        "unknown ID must produce format_code \"general\", not \"{}\"",
+        fmt.format_code
+    );
 }
 
 #[test]
@@ -431,7 +455,7 @@ fn get_style_with_num_fmt_id_accepts_builtin_id() {
     let styles = &mut model.workbook.styles;
 
     assert!(styles
-        .get_style_with_num_fmt_id(0, BuiltinFmts::SHORT_DATE_ID)
+        .get_style_with_num_fmt_id(0, DefaultFmts::SHORT_DATE_ID)
         .is_ok());
 }
 
@@ -492,8 +516,10 @@ fn now_fn_stores_locale_datetime_fmt_id() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id, BuiltinFmts::SHORT_DATETIME_ID,
-        "=NOW() result must store numFmtId={}, got {num_fmt_id}", BuiltinFmts::SHORT_DATETIME_ID
+        num_fmt_id,
+        DefaultFmts::SHORT_DATETIME_ID,
+        "=NOW() result must store numFmtId={}, got {num_fmt_id}",
+        DefaultFmts::SHORT_DATETIME_ID
     );
 }
 
@@ -596,15 +622,15 @@ fn legacy_custom_num_fmt_renders_literal_not_locale() {
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_ne!(
         num_fmt_id,
-        BuiltinFmts::SHORT_DATE_ID,
+        DefaultFmts::SHORT_DATE_ID,
         "custom format 'm/d/yyyy' must not be stored as the locale-date sentinel {}",
-        BuiltinFmts::SHORT_DATE_ID
+        DefaultFmts::SHORT_DATE_ID
     );
     assert_ne!(
         num_fmt_id,
-        BuiltinFmts::SHORT_DATETIME_ID,
+        DefaultFmts::SHORT_DATETIME_ID,
         "custom format 'm/d/yyyy' must not be stored as the locale-datetime sentinel {}",
-        BuiltinFmts::SHORT_DATETIME_ID
+        DefaultFmts::SHORT_DATETIME_ID
     );
 
     // Must render the frozen literal "m/d/yyyy" (US-style → "4/3/2025"),
@@ -618,6 +644,22 @@ fn legacy_custom_num_fmt_renders_literal_not_locale() {
         model.get_localized_cell_content(0, 1, 1).unwrap(),
         "4/3/2025",
         "edit-bar content must reflect the literal format code, not re-derive from locale"
+    );
+}
+
+#[test]
+fn format_code_for_id_unknown_returns_general() {
+    // format_code_for_id must return "general" for IDs that are neither built-in
+    // nor in the custom list — not "" (the Default for &str).
+    assert_eq!(
+        NumFmt::format_code_for_id(999, &[]),
+        "general",
+        "unknown numFmtId must fall back to \"general\", not \"\""
+    );
+    assert_eq!(
+        NumFmt::format_code_for_id(-1, &[]),
+        "general",
+        "negative sentinel must fall back to \"general\""
     );
 }
 

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -415,7 +415,10 @@ fn format_code_for_id_returns_correct_code() {
 
     assert_eq!(styles.format_code_for_id(0), "general");
     assert_eq!(styles.format_code_for_id(9), "0%");
-    assert_eq!(styles.format_code_for_id(LOCALE_SHORT_DATE_FMT_ID), "mm-dd-yy");
+    assert_eq!(
+        styles.format_code_for_id(LOCALE_SHORT_DATE_FMT_ID),
+        "mm-dd-yy"
+    );
     assert_eq!(styles.format_code_for_id(164), "dd/mm/yyyy hh:mm:ss");
     assert_eq!(styles.format_code_for_id(999), "general"); // unknown → fallback
 }
@@ -457,13 +460,19 @@ fn custom_format_sentinel_never_stored_in_cell_xfs() {
     let mut model = new_empty_model();
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
     style.num_fmt = NumFmt::from_format_code("dd/mm/yyyy hh:mm:ss");
-    assert_eq!(style.num_fmt.num_fmt_id, -1, "sentinel must be -1 before registration");
+    assert_eq!(
+        style.num_fmt.num_fmt_id, -1,
+        "sentinel must be -1 before registration"
+    );
 
     model.set_cell_style(0, 1, 1, &style).unwrap();
 
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let stored_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert!(stored_id >= 0, "CellXfs must not store the -1 sentinel; got {stored_id}");
+    assert!(
+        stored_id >= 0,
+        "CellXfs must not store the -1 sentinel; got {stored_id}"
+    );
 
     let entry = model
         .workbook
@@ -471,7 +480,10 @@ fn custom_format_sentinel_never_stored_in_cell_xfs() {
         .num_fmts
         .iter()
         .find(|f| f.num_fmt_id == stored_id);
-    assert!(entry.is_some(), "custom format must be registered in num_fmts");
+    assert!(
+        entry.is_some(),
+        "custom format must be registered in num_fmts"
+    );
     assert_eq!(entry.unwrap().format_code, "dd/mm/yyyy hh:mm:ss");
 }
 

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -150,7 +150,7 @@ fn manual_date_format_preserved_on_entry() {
     // A cell with an explicit date format must not have it overwritten with numFmtId 14.
     let mut model = new_empty_model();
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code("dd mmmm yyyy");
+    style.num_fmt = NumFmt::from_format_code("dd mmmm yyyy", None);
     model.set_cell_style(0, 1, 1, &style).unwrap();
 
     model._set("A1", "4/3/2025");
@@ -226,7 +226,7 @@ fn non_date_entry_into_date_cell_replaces_format() {
     // The should_apply_format guard only preserves date format when BOTH old and new are dates.
     let mut model = new_empty_model();
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code("mm-dd-yy"); // → numFmtId=14
+    style.num_fmt = NumFmt::from_format_code("mm-dd-yy", None); // → numFmtId=14
     model.set_cell_style(0, 1, 1, &style).unwrap();
 
     model._set("A1", "30%");
@@ -250,7 +250,7 @@ fn cross_locale_serial_displays_as_locale_format() {
     let serial = 45750.0; // April 3, 2025
     let mut model = en_gb_model();
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code("mm-dd-yy"); // → numFmtId=14
+    style.num_fmt = NumFmt::from_format_code("mm-dd-yy", None); // → numFmtId=14
     model.set_cell_style(0, 1, 1, &style).unwrap();
     model.update_cell_with_number(0, 1, 1, serial).unwrap();
     model.evaluate();
@@ -266,7 +266,7 @@ fn cross_locale_serial_displays_as_locale_format() {
 fn formula_date_result_respects_locale_format() {
     let mut model = en_gb_model();
     let mut style = model.get_style_for_cell(0, 1, 2).unwrap();
-    style.num_fmt = NumFmt::from_format_code("mm-dd-yy"); // → numFmtId=14
+    style.num_fmt = NumFmt::from_format_code("mm-dd-yy", None); // → numFmtId=14
     model.set_cell_style(0, 1, 2, &style).unwrap();
 
     model
@@ -345,10 +345,10 @@ fn date_fn_locale_switch_updates_display() {
 
 #[test]
 fn num_fmt_builtin_format_code_resolves_canonical_id() {
-    let general = NumFmt::from_format_code("General");
+    let general = NumFmt::from_format_code("General", None);
     assert_eq!(general.num_fmt_id, 0, "\"general\" must map to numFmtId 0");
 
-    let locale_date = NumFmt::from_format_code("mm-dd-yy");
+    let locale_date = NumFmt::from_format_code("mm-dd-yy", None);
     assert_eq!(
         locale_date.num_fmt_id, SHORT_DATE_ID,
         "\"mm-dd-yy\" must map to NumFmt::LOCALE_DATE_ID ({})",
@@ -359,7 +359,7 @@ fn num_fmt_builtin_format_code_resolves_canonical_id() {
 #[test]
 fn num_fmt_custom_format_code_has_placeholder_id() {
     // Custom codes not in the built-in table use -1 as a sentinel until registered.
-    let custom = NumFmt::from_format_code("dd/mm/yyyy hh:mm:ss");
+    let custom = NumFmt::from_format_code("dd/mm/yyyy hh:mm:ss", None);
     assert_eq!(custom.format_code, "dd/mm/yyyy hh:mm:ss");
     assert_eq!(custom.num_fmt_id, -1);
 }
@@ -370,12 +370,12 @@ fn set_cell_style_reuses_cell_xfs_for_same_custom_format() {
     let code = "dd/mm/yyyy hh:mm:ss";
 
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code(code);
+    style.num_fmt = NumFmt::from_format_code(code, None);
     model.set_cell_style(0, 1, 1, &style).unwrap();
     let xfs_len_after_first = model.workbook.styles.cell_xfs.len();
 
     let mut style2 = model.get_style_for_cell(0, 2, 1).unwrap();
-    style2.num_fmt = NumFmt::from_format_code(code);
+    style2.num_fmt = NumFmt::from_format_code(code, None);
     model.set_cell_style(0, 2, 1, &style2).unwrap();
 
     assert_eq!(
@@ -453,7 +453,7 @@ fn custom_format_sentinel_never_stored_in_cell_xfs() {
     // from_format_code uses -1 as a sentinel; set_cell_style must resolve it before writing.
     let mut model = new_empty_model();
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code("dd/mm/yyyy hh:mm:ss");
+    style.num_fmt = NumFmt::from_format_code("dd/mm/yyyy hh:mm:ss", None);
     assert_eq!(
         style.num_fmt.num_fmt_id, -1,
         "sentinel must be -1 before registration"
@@ -553,7 +553,7 @@ fn non_date_format_preserved_when_date_formula_entered() {
     // an explicit numeric format with the locale-date ID.
     let mut model = new_empty_model();
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code("#,##0");
+    style.num_fmt = NumFmt::from_format_code("#,##0", None);
     model.set_cell_style(0, 1, 1, &style).unwrap();
 
     model._set("A1", "=DATE(2025,4,3)");
@@ -586,7 +586,7 @@ fn legacy_custom_num_fmt_renders_literal_not_locale() {
     // Apply a US-style literal format.  set_cell_style will register it as a
     // custom format (ID ≥ 164) because "m/d/yyyy" is not an ECMA-376 built-in.
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.num_fmt = NumFmt::from_format_code("m/d/yyyy");
+    style.num_fmt = NumFmt::from_format_code("m/d/yyyy", None);
     model.set_cell_style(0, 1, 1, &style).unwrap();
     model.update_cell_with_number(0, 1, 1, serial).unwrap();
     model.evaluate();

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -14,7 +14,7 @@
 use crate::{
     cell::CellValue,
     model::Model,
-    number_format::LOCALE_SHORT_DATE_FMT_ID,
+    number_format::{LOCALE_SHORT_DATE_FMT_ID, LOCALE_SHORT_DATE_TIME_FMT_ID},
     test::util::new_empty_model,
     types::{NumFmt, Styles},
 };
@@ -485,6 +485,52 @@ fn custom_format_sentinel_never_stored_in_cell_xfs() {
         "custom format must be registered in num_fmts"
     );
     assert_eq!(entry.unwrap().format_code, "dd/mm/yyyy hh:mm:ss");
+}
+
+#[test]
+fn now_fn_stores_locale_datetime_fmt_id() {
+    // =NOW() must store numFmtId=22 (LOCALE_SHORT_DATE_TIME_FMT_ID) so that
+    // locale switches can re-derive the datetime pattern at render time.
+    let mut model = new_empty_model();
+    model._set("A1", "=NOW()");
+    model.evaluate();
+
+    let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
+    let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
+    assert_eq!(
+        num_fmt_id, LOCALE_SHORT_DATE_TIME_FMT_ID,
+        "=NOW() result must store numFmtId={LOCALE_SHORT_DATE_TIME_FMT_ID}, got {num_fmt_id}"
+    );
+}
+
+#[test]
+fn now_fn_locale_switch_updates_display() {
+    // numFmtId 22 (LOCALE_SHORT_DATE_TIME_FMT_ID) must derive its format from
+    // the active locale, not the literal built-in format string — the same
+    // guarantee that date (numFmtId 14) provides.
+    //
+    // The meridiem token (AM/PM vs 24-hour) distinguishes the two locales
+    // reliably regardless of the current date/time value:
+    //   en-US time_formats.short = "h:mm a"  → rendered as "h:mm AM/PM"
+    //   en-GB time_formats.short = "HH:mm"   → 24-hour, no meridiem token
+    let mut model_us = new_empty_model(); // en-US
+    model_us._set("A1", "=NOW()");
+    model_us.evaluate();
+    let us_display = model_us._get_text("A1");
+
+    let mut model_gb = en_gb_model();
+    model_gb._set("A1", "=NOW()");
+    model_gb.evaluate();
+    let gb_display = model_gb._get_text("A1");
+
+    assert!(
+        us_display.contains("AM") || us_display.contains("PM"),
+        "en-US datetime must contain AM/PM meridiem token; got: {us_display}"
+    );
+    assert!(
+        !gb_display.contains("AM") && !gb_display.contains("PM"),
+        "en-GB datetime must use 24-hour format (no AM/PM); got: {gb_display}"
+    );
 }
 
 #[test]

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -14,6 +14,7 @@
 use crate::{
     cell::CellValue,
     model::Model,
+    number_format::BuiltinFmts,
     test::util::new_empty_model,
     types::NumFmt,
 };
@@ -75,8 +76,8 @@ fn locale_date_stored_as_num_fmt_id_14() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id, NumFmt::SHORT_DATE_ID,
-        "locale date must be stored as numFmtId {}, got {num_fmt_id}", NumFmt::SHORT_DATE_ID
+        num_fmt_id, BuiltinFmts::SHORT_DATE_ID,
+        "locale date must be stored as numFmtId {}, got {num_fmt_id}", BuiltinFmts::SHORT_DATE_ID
     );
 }
 
@@ -90,7 +91,7 @@ fn iso_date_is_not_stored_as_id_14() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_ne!(
-        num_fmt_id, NumFmt::SHORT_DATE_ID,
+        num_fmt_id, BuiltinFmts::SHORT_DATE_ID,
         "ISO date must NOT use numFmtId 14 — it has a specific format string"
     );
     assert_eq!(
@@ -181,7 +182,7 @@ fn invalid_month_stored_as_text() {
     );
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert_ne!(num_fmt_id, NumFmt::SHORT_DATE_ID);
+    assert_ne!(num_fmt_id, BuiltinFmts::SHORT_DATE_ID);
 }
 
 #[test]
@@ -220,7 +221,7 @@ fn plain_number_does_not_create_date_cell() {
     );
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert_ne!(num_fmt_id, NumFmt::SHORT_DATE_ID);
+    assert_ne!(num_fmt_id, BuiltinFmts::SHORT_DATE_ID);
 }
 
 #[test]
@@ -326,8 +327,8 @@ fn date_fn_stores_locale_fmt_id() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id, NumFmt::SHORT_DATE_ID,
-        "=DATE() result must store numFmtId={}, got {num_fmt_id}", NumFmt::SHORT_DATE_ID
+        num_fmt_id, BuiltinFmts::SHORT_DATE_ID,
+        "=DATE() result must store numFmtId={}, got {num_fmt_id}", BuiltinFmts::SHORT_DATE_ID
     );
 }
 
@@ -351,9 +352,9 @@ fn num_fmt_builtin_format_code_resolves_canonical_id() {
 
     let locale_date = NumFmt::from_format_code("mm-dd-yy");
     assert_eq!(
-        locale_date.num_fmt_id, NumFmt::SHORT_DATE_ID,
+        locale_date.num_fmt_id, BuiltinFmts::SHORT_DATE_ID,
         "\"mm-dd-yy\" must map to NumFmt::LOCALE_DATE_ID ({})",
-        NumFmt::SHORT_DATE_ID,
+        BuiltinFmts::SHORT_DATE_ID,
     );
 }
 
@@ -411,7 +412,7 @@ fn resolve_code_returns_correct_code() {
 
     assert_eq!(NumFmt::format_code_for_id(0, &num_fmts), "general");
     assert_eq!(NumFmt::format_code_for_id(9, &num_fmts), "0%");
-    assert_eq!(NumFmt::format_code_for_id(NumFmt::SHORT_DATE_ID, &num_fmts), "mm-dd-yy");
+    assert_eq!(NumFmt::format_code_for_id(BuiltinFmts::SHORT_DATE_ID, &num_fmts), "mm-dd-yy");
     assert_eq!(NumFmt::format_code_for_id(164, &num_fmts), "dd/mm/yyyy hh:mm:ss");
     assert_eq!(NumFmt::format_code_for_id(999, &num_fmts), "general"); // unknown → fallback
 }
@@ -430,7 +431,7 @@ fn get_style_with_num_fmt_id_accepts_builtin_id() {
     let styles = &mut model.workbook.styles;
 
     assert!(styles
-        .get_style_with_num_fmt_id(0, NumFmt::SHORT_DATE_ID)
+        .get_style_with_num_fmt_id(0, BuiltinFmts::SHORT_DATE_ID)
         .is_ok());
 }
 
@@ -491,8 +492,8 @@ fn now_fn_stores_locale_datetime_fmt_id() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id, NumFmt::SHORT_DATETIME_ID,
-        "=NOW() result must store numFmtId={}, got {num_fmt_id}", NumFmt::SHORT_DATETIME_ID
+        num_fmt_id, BuiltinFmts::SHORT_DATETIME_ID,
+        "=NOW() result must store numFmtId={}, got {num_fmt_id}", BuiltinFmts::SHORT_DATETIME_ID
     );
 }
 
@@ -590,20 +591,20 @@ fn legacy_custom_num_fmt_renders_literal_not_locale() {
     model.evaluate();
 
     // Verify the stored ID is not one of the locale sentinel IDs (14 or 22).
-    // IronCalc assigns user-defined IDs starting at builtins().len() (= 45).
+    // ECMA-376 §18.8.30: custom IDs must be ≥ 164; IronCalc starts there.
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_ne!(
         num_fmt_id,
-        NumFmt::SHORT_DATE_ID,
+        BuiltinFmts::SHORT_DATE_ID,
         "custom format 'm/d/yyyy' must not be stored as the locale-date sentinel {}",
-        NumFmt::SHORT_DATE_ID
+        BuiltinFmts::SHORT_DATE_ID
     );
     assert_ne!(
         num_fmt_id,
-        NumFmt::SHORT_DATETIME_ID,
+        BuiltinFmts::SHORT_DATETIME_ID,
         "custom format 'm/d/yyyy' must not be stored as the locale-datetime sentinel {}",
-        NumFmt::SHORT_DATETIME_ID
+        BuiltinFmts::SHORT_DATETIME_ID
     );
 
     // Must render the frozen literal "m/d/yyyy" (US-style → "4/3/2025"),
@@ -617,5 +618,18 @@ fn legacy_custom_num_fmt_renders_literal_not_locale() {
         model.get_localized_cell_content(0, 1, 1).unwrap(),
         "4/3/2025",
         "edit-bar content must reflect the literal format code, not re-derive from locale"
+    );
+}
+
+#[test]
+fn custom_fmt_id_is_in_ecma_custom_range() {
+    // ECMA-376 §18.8.30: custom numFmtIds must be ≥ 164.
+    // IDs 0–163 are reserved for built-in formats; assigning lower IDs corrupts XLSX output.
+    let mut num_fmts: Vec<NumFmt> = vec![];
+    let fmt = NumFmt::get_or_register("0.000%", &mut num_fmts);
+    assert!(
+        fmt.num_fmt_id >= 164,
+        "custom numFmtId {} is below the ECMA-376 minimum of 164",
+        fmt.num_fmt_id
     );
 }

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -8,7 +8,10 @@
 // string.
 
 use crate::{
-    cell::CellValue, model::Model, number_format::DefaultFmts, test::util::new_empty_model,
+    cell::CellValue,
+    constants::{SHORT_DATETIME_ID, SHORT_DATE_ID},
+    model::Model,
+    test::util::new_empty_model,
     types::NumFmt,
 };
 
@@ -69,10 +72,9 @@ fn locale_date_stored_as_num_fmt_id_14() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id,
-        DefaultFmts::SHORT_DATE_ID,
+        num_fmt_id, SHORT_DATE_ID,
         "locale date must be stored as numFmtId {}, got {num_fmt_id}",
-        DefaultFmts::SHORT_DATE_ID
+        SHORT_DATE_ID
     );
 }
 
@@ -86,8 +88,7 @@ fn iso_date_is_not_stored_as_id_14() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_ne!(
-        num_fmt_id,
-        DefaultFmts::SHORT_DATE_ID,
+        num_fmt_id, SHORT_DATE_ID,
         "ISO date must NOT use numFmtId 14 — it has a specific format string"
     );
     assert_eq!(
@@ -178,7 +179,7 @@ fn invalid_month_stored_as_text() {
     );
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert_ne!(num_fmt_id, DefaultFmts::SHORT_DATE_ID);
+    assert_ne!(num_fmt_id, SHORT_DATE_ID);
 }
 
 #[test]
@@ -217,7 +218,7 @@ fn plain_number_does_not_create_date_cell() {
     );
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert_ne!(num_fmt_id, DefaultFmts::SHORT_DATE_ID);
+    assert_ne!(num_fmt_id, SHORT_DATE_ID);
 }
 
 #[test]
@@ -323,10 +324,9 @@ fn date_fn_stores_locale_fmt_id() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id,
-        DefaultFmts::SHORT_DATE_ID,
+        num_fmt_id, SHORT_DATE_ID,
         "=DATE() result must store numFmtId={}, got {num_fmt_id}",
-        DefaultFmts::SHORT_DATE_ID
+        SHORT_DATE_ID
     );
 }
 
@@ -350,10 +350,9 @@ fn num_fmt_builtin_format_code_resolves_canonical_id() {
 
     let locale_date = NumFmt::from_format_code("mm-dd-yy");
     assert_eq!(
-        locale_date.num_fmt_id,
-        DefaultFmts::SHORT_DATE_ID,
+        locale_date.num_fmt_id, SHORT_DATE_ID,
         "\"mm-dd-yy\" must map to NumFmt::LOCALE_DATE_ID ({})",
-        DefaultFmts::SHORT_DATE_ID,
+        SHORT_DATE_ID,
     );
 }
 
@@ -409,7 +408,7 @@ fn resolve_code_returns_correct_code() {
     assert_eq!(NumFmt::format_code_for_id(0, &num_fmts), "General");
     assert_eq!(NumFmt::format_code_for_id(9, &num_fmts), "0%");
     assert_eq!(
-        NumFmt::format_code_for_id(DefaultFmts::SHORT_DATE_ID, &num_fmts),
+        NumFmt::format_code_for_id(SHORT_DATE_ID, &num_fmts),
         "mm-dd-yy"
     );
     assert_eq!(
@@ -450,9 +449,7 @@ fn get_style_with_num_fmt_id_accepts_builtin_id() {
     let mut model = new_empty_model();
     let styles = &mut model.workbook.styles;
 
-    assert!(styles
-        .get_style_with_num_fmt_id(0, DefaultFmts::SHORT_DATE_ID)
-        .is_ok());
+    assert!(styles.get_style_with_num_fmt_id(0, SHORT_DATE_ID).is_ok());
 }
 
 #[test]
@@ -512,10 +509,9 @@ fn now_fn_stores_locale_datetime_fmt_id() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id,
-        DefaultFmts::SHORT_DATETIME_ID,
+        num_fmt_id, SHORT_DATETIME_ID,
         "=NOW() result must store numFmtId={}, got {num_fmt_id}",
-        DefaultFmts::SHORT_DATETIME_ID
+        SHORT_DATETIME_ID
     );
 }
 
@@ -617,16 +613,14 @@ fn legacy_custom_num_fmt_renders_literal_not_locale() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_ne!(
-        num_fmt_id,
-        DefaultFmts::SHORT_DATE_ID,
+        num_fmt_id, SHORT_DATE_ID,
         "custom format 'm/d/yyyy' must not be stored as the locale-date sentinel {}",
-        DefaultFmts::SHORT_DATE_ID
+        SHORT_DATE_ID
     );
     assert_ne!(
-        num_fmt_id,
-        DefaultFmts::SHORT_DATETIME_ID,
+        num_fmt_id, SHORT_DATETIME_ID,
         "custom format 'm/d/yyyy' must not be stored as the locale-datetime sentinel {}",
-        DefaultFmts::SHORT_DATETIME_ID
+        SHORT_DATETIME_ID
     );
 
     // Must render the frozen literal "m/d/yyyy" (US-style → "4/3/2025"),

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -16,7 +16,7 @@ use crate::{
     model::Model,
     number_format::{LOCALE_SHORT_DATE_FMT_ID, LOCALE_SHORT_DATE_TIME_FMT_ID},
     test::util::new_empty_model,
-    types::{NumFmt, Styles},
+    types::NumFmt,
 };
 
 fn en_gb_model<'a>() -> Model<'a> {
@@ -404,23 +404,17 @@ fn get_style_with_format_no_duplicate_cell_xfs() {
 }
 
 #[test]
-fn format_code_for_id_returns_correct_code() {
-    let styles = Styles {
-        num_fmts: vec![NumFmt {
-            num_fmt_id: 164,
-            format_code: "dd/mm/yyyy hh:mm:ss".to_string(),
-        }],
-        ..Styles::default()
-    };
+fn resolve_code_returns_correct_code() {
+    let num_fmts = vec![NumFmt {
+        num_fmt_id: 164,
+        format_code: "dd/mm/yyyy hh:mm:ss".to_string(),
+    }];
 
-    assert_eq!(styles.format_code_for_id(0), "general");
-    assert_eq!(styles.format_code_for_id(9), "0%");
-    assert_eq!(
-        styles.format_code_for_id(LOCALE_SHORT_DATE_FMT_ID),
-        "mm-dd-yy"
-    );
-    assert_eq!(styles.format_code_for_id(164), "dd/mm/yyyy hh:mm:ss");
-    assert_eq!(styles.format_code_for_id(999), "general"); // unknown → fallback
+    assert_eq!(NumFmt::resolve_code(0, &num_fmts), "general");
+    assert_eq!(NumFmt::resolve_code(9, &num_fmts), "0%");
+    assert_eq!(NumFmt::resolve_code(LOCALE_SHORT_DATE_FMT_ID, &num_fmts), "mm-dd-yy");
+    assert_eq!(NumFmt::resolve_code(164, &num_fmts), "dd/mm/yyyy hh:mm:ss");
+    assert_eq!(NumFmt::resolve_code(999, &num_fmts), "general"); // unknown → fallback
 }
 
 #[test]

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -13,9 +13,7 @@
 // the format from `locale.dates.date_formats.short` at runtime.
 
 use crate::{
-    cell::CellValue,
-    model::Model,
-    number_format::{LOCALE_SHORT_DATE_FMT_ID},
+    cell::CellValue, model::Model, number_format::LOCALE_SHORT_DATE_FMT_ID,
     test::util::new_empty_model,
 };
 
@@ -209,7 +207,6 @@ fn manual_date_format_preserved_on_entry() {
         Ok(CellValue::Number(45750.0))
     );
 }
-
 
 // ── Invalid date inputs ─────────────────────────────────────────
 

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -5,11 +5,7 @@
 // Root cause: `get_localized_cell_content` (edit bar) and `get_formatted_cell_value`
 // (grid) both used the stored format string rather than the locale's own short-date
 // pattern. In a day-first locale (e.g. en-GB) the edit bar would show a month-first
-// string; pressing Enter would then mis-parse the date and corrupt it.
-//
-// Fix: simple locale dates are stored with numFmtId 14 (`NumFmt::LOCALE_DATE_ID`).
-// Both render functions detect ID 14 and derive the format from
-// `locale.dates.date_formats.short` at runtime.
+// string.
 
 use crate::{
     cell::CellValue, model::Model, number_format::DefaultFmts, test::util::new_empty_model,
@@ -241,7 +237,7 @@ fn non_date_entry_into_date_cell_replaces_format() {
     );
     let style_after = model.get_style_for_cell(0, 1, 1).unwrap();
     assert_eq!(
-        style_after.num_fmt.format_code, "#,##0%",
+        style_after.num_fmt.format_code, "0%",
         "percent entry must replace the locale-date format"
     );
 }
@@ -349,7 +345,7 @@ fn date_fn_locale_switch_updates_display() {
 
 #[test]
 fn num_fmt_builtin_format_code_resolves_canonical_id() {
-    let general = NumFmt::from_format_code("general");
+    let general = NumFmt::from_format_code("General");
     assert_eq!(general.num_fmt_id, 0, "\"general\" must map to numFmtId 0");
 
     let locale_date = NumFmt::from_format_code("mm-dd-yy");
@@ -410,7 +406,7 @@ fn get_style_with_format_no_duplicate_cell_xfs() {
 fn resolve_code_returns_correct_code() {
     let num_fmts = vec![NumFmt::new(164, "dd/mm/yyyy hh:mm:ss".to_string())];
 
-    assert_eq!(NumFmt::format_code_for_id(0, &num_fmts), "general");
+    assert_eq!(NumFmt::format_code_for_id(0, &num_fmts), "General");
     assert_eq!(NumFmt::format_code_for_id(9, &num_fmts), "0%");
     assert_eq!(
         NumFmt::format_code_for_id(DefaultFmts::SHORT_DATE_ID, &num_fmts),
@@ -420,12 +416,12 @@ fn resolve_code_returns_correct_code() {
         NumFmt::format_code_for_id(164, &num_fmts),
         "dd/mm/yyyy hh:mm:ss"
     );
-    assert_eq!(NumFmt::format_code_for_id(999, &num_fmts), "general"); // unknown → fallback
+    assert_eq!(NumFmt::format_code_for_id(999, &num_fmts), "General"); // unknown → fallback
 }
 
 #[test]
 fn from_id_unknown_falls_back_to_general_not_empty() {
-    // from_id must return format_code = "general" for unknown IDs, not "" (empty string).
+    // from_id must return format_code = "General" for unknown IDs, not "" (empty string).
     //
     // Use id=-1 (negative unknown): the debug_assert in from_id guards only non-negative
     // unknown IDs, so negative IDs exercise the fallback path without triggering it.
@@ -435,7 +431,7 @@ fn from_id_unknown_falls_back_to_general_not_empty() {
         "negative unknown ID must clamp to 0 (General)"
     );
     assert_eq!(
-        fmt.format_code, "general",
+        fmt.format_code, "General",
         "unknown ID must produce format_code \"general\", not \"{}\"",
         fmt.format_code
     );
@@ -649,17 +645,17 @@ fn legacy_custom_num_fmt_renders_literal_not_locale() {
 
 #[test]
 fn format_code_for_id_unknown_returns_general() {
-    // format_code_for_id must return "general" for IDs that are neither built-in
+    // format_code_for_id must return "General" for IDs that are neither built-in
     // nor in the custom list — not "" (the Default for &str).
     assert_eq!(
         NumFmt::format_code_for_id(999, &[]),
-        "general",
-        "unknown numFmtId must fall back to \"general\", not \"\""
+        "General",
+        "unknown numFmtId must fall back to \"General\", not \"\""
     );
     assert_eq!(
         NumFmt::format_code_for_id(-1, &[]),
-        "general",
-        "negative sentinel must fall back to \"general\""
+        "General",
+        "negative sentinel must fall back to \"General\""
     );
 }
 

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -7,14 +7,13 @@
 // pattern. In a day-first locale (e.g. en-GB) the edit bar would show a month-first
 // string; pressing Enter would then mis-parse the date and corrupt it.
 //
-// Fix: simple locale dates are stored with numFmtId 14 (LOCALE_SHORT_DATE_FMT_ID).
+// Fix: simple locale dates are stored with numFmtId 14 (`NumFmt::LOCALE_DATE_ID`).
 // Both render functions detect ID 14 and derive the format from
 // `locale.dates.date_formats.short` at runtime.
 
 use crate::{
     cell::CellValue,
     model::Model,
-    number_format::{LOCALE_SHORT_DATE_FMT_ID, LOCALE_SHORT_DATE_TIME_FMT_ID},
     test::util::new_empty_model,
     types::NumFmt,
 };
@@ -76,8 +75,8 @@ fn locale_date_stored_as_num_fmt_id_14() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
-        "locale date must be stored as numFmtId {LOCALE_SHORT_DATE_FMT_ID}, got {num_fmt_id}"
+        num_fmt_id, NumFmt::SHORT_DATE_ID,
+        "locale date must be stored as numFmtId {}, got {num_fmt_id}", NumFmt::SHORT_DATE_ID
     );
 }
 
@@ -91,7 +90,7 @@ fn iso_date_is_not_stored_as_id_14() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_ne!(
-        num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
+        num_fmt_id, NumFmt::SHORT_DATE_ID,
         "ISO date must NOT use numFmtId 14 — it has a specific format string"
     );
     assert_eq!(
@@ -182,7 +181,7 @@ fn invalid_month_stored_as_text() {
     );
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert_ne!(num_fmt_id, LOCALE_SHORT_DATE_FMT_ID);
+    assert_ne!(num_fmt_id, NumFmt::SHORT_DATE_ID);
 }
 
 #[test]
@@ -221,7 +220,7 @@ fn plain_number_does_not_create_date_cell() {
     );
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
-    assert_ne!(num_fmt_id, LOCALE_SHORT_DATE_FMT_ID);
+    assert_ne!(num_fmt_id, NumFmt::SHORT_DATE_ID);
 }
 
 #[test]
@@ -327,8 +326,8 @@ fn date_fn_stores_locale_fmt_id() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
-        "=DATE() result must store numFmtId={LOCALE_SHORT_DATE_FMT_ID}, got {num_fmt_id}"
+        num_fmt_id, NumFmt::SHORT_DATE_ID,
+        "=DATE() result must store numFmtId={}, got {num_fmt_id}", NumFmt::SHORT_DATE_ID
     );
 }
 
@@ -352,9 +351,9 @@ fn num_fmt_builtin_format_code_resolves_canonical_id() {
 
     let locale_date = NumFmt::from_format_code("mm-dd-yy");
     assert_eq!(
-        locale_date.num_fmt_id, LOCALE_SHORT_DATE_FMT_ID,
-        "\"mm-dd-yy\" must map to LOCALE_SHORT_DATE_FMT_ID ({})",
-        LOCALE_SHORT_DATE_FMT_ID,
+        locale_date.num_fmt_id, NumFmt::SHORT_DATE_ID,
+        "\"mm-dd-yy\" must map to NumFmt::LOCALE_DATE_ID ({})",
+        NumFmt::SHORT_DATE_ID,
     );
 }
 
@@ -410,11 +409,11 @@ fn resolve_code_returns_correct_code() {
         format_code: "dd/mm/yyyy hh:mm:ss".to_string(),
     }];
 
-    assert_eq!(NumFmt::resolve_code(0, &num_fmts), "general");
-    assert_eq!(NumFmt::resolve_code(9, &num_fmts), "0%");
-    assert_eq!(NumFmt::resolve_code(LOCALE_SHORT_DATE_FMT_ID, &num_fmts), "mm-dd-yy");
-    assert_eq!(NumFmt::resolve_code(164, &num_fmts), "dd/mm/yyyy hh:mm:ss");
-    assert_eq!(NumFmt::resolve_code(999, &num_fmts), "general"); // unknown → fallback
+    assert_eq!(NumFmt::format_code_for_id(0, &num_fmts), "general");
+    assert_eq!(NumFmt::format_code_for_id(9, &num_fmts), "0%");
+    assert_eq!(NumFmt::format_code_for_id(NumFmt::SHORT_DATE_ID, &num_fmts), "mm-dd-yy");
+    assert_eq!(NumFmt::format_code_for_id(164, &num_fmts), "dd/mm/yyyy hh:mm:ss");
+    assert_eq!(NumFmt::format_code_for_id(999, &num_fmts), "general"); // unknown → fallback
 }
 
 #[test]
@@ -431,7 +430,7 @@ fn get_style_with_num_fmt_id_accepts_builtin_id() {
     let styles = &mut model.workbook.styles;
 
     assert!(styles
-        .get_style_with_num_fmt_id(0, LOCALE_SHORT_DATE_FMT_ID)
+        .get_style_with_num_fmt_id(0, NumFmt::SHORT_DATE_ID)
         .is_ok());
 }
 
@@ -483,7 +482,7 @@ fn custom_format_sentinel_never_stored_in_cell_xfs() {
 
 #[test]
 fn now_fn_stores_locale_datetime_fmt_id() {
-    // =NOW() must store numFmtId=22 (LOCALE_SHORT_DATE_TIME_FMT_ID) so that
+    // =NOW() must store numFmtId=22 (NumFmt::LOCALE_DATETIME_ID) so that
     // locale switches can re-derive the datetime pattern at render time.
     let mut model = new_empty_model();
     model._set("A1", "=NOW()");
@@ -492,14 +491,14 @@ fn now_fn_stores_locale_datetime_fmt_id() {
     let style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let num_fmt_id = model.workbook.styles.cell_xfs[style_index as usize].num_fmt_id;
     assert_eq!(
-        num_fmt_id, LOCALE_SHORT_DATE_TIME_FMT_ID,
-        "=NOW() result must store numFmtId={LOCALE_SHORT_DATE_TIME_FMT_ID}, got {num_fmt_id}"
+        num_fmt_id, NumFmt::SHORT_DATETIME_ID,
+        "=NOW() result must store numFmtId={}, got {num_fmt_id}", NumFmt::SHORT_DATETIME_ID
     );
 }
 
 #[test]
 fn now_fn_locale_switch_updates_display() {
-    // numFmtId 22 (LOCALE_SHORT_DATE_TIME_FMT_ID) must derive its format from
+    // numFmtId 22 (NumFmt::LOCALE_DATETIME_ID) must derive its format from
     // the active locale, not the literal built-in format string — the same
     // guarantee that date (numFmtId 14) provides.
     //
@@ -542,5 +541,29 @@ fn date_arithmetic_composes_correctly() {
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!C1"),
         Ok(CellValue::Number(30.0))
+    );
+}
+
+#[test]
+fn non_date_format_preserved_when_date_formula_entered() {
+    // A cell with an explicit non-date format (#,##0) must keep that format
+    // when a =DATE(...) formula is entered.  units_fn_dates must not overwrite
+    // an explicit numeric format with the locale-date ID.
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.num_fmt = NumFmt::from_format_code("#,##0");
+    model.set_cell_style(0, 1, 1, &style).unwrap();
+
+    model._set("A1", "=DATE(2025,4,3)");
+    model.evaluate();
+
+    let style_after = model.get_style_for_cell(0, 1, 1).unwrap();
+    assert_eq!(
+        style_after.num_fmt.format_code, "#,##0",
+        "explicit non-date format must be preserved when a DATE formula is entered"
+    );
+    assert_eq!(
+        model.get_cell_value_by_ref("Sheet1!A1"),
+        Ok(CellValue::Number(45750.0))
     );
 }

--- a/base/src/test/test_issue_761.rs
+++ b/base/src/test/test_issue_761.rs
@@ -402,23 +402,6 @@ fn get_style_with_format_no_duplicate_cell_xfs() {
 }
 
 #[test]
-fn resolve_code_returns_correct_code() {
-    let num_fmts = vec![NumFmt::new(164, "dd/mm/yyyy hh:mm:ss".to_string())];
-
-    assert_eq!(NumFmt::format_code_for_id(0, &num_fmts), "General");
-    assert_eq!(NumFmt::format_code_for_id(9, &num_fmts), "0%");
-    assert_eq!(
-        NumFmt::format_code_for_id(SHORT_DATE_ID, &num_fmts),
-        "mm-dd-yy"
-    );
-    assert_eq!(
-        NumFmt::format_code_for_id(164, &num_fmts),
-        "dd/mm/yyyy hh:mm:ss"
-    );
-    assert_eq!(NumFmt::format_code_for_id(999, &num_fmts), "General"); // unknown → fallback
-}
-
-#[test]
 fn from_id_unknown_falls_back_to_general_not_empty() {
     // from_id must return format_code = "General" for unknown IDs, not "" (empty string).
     //
@@ -634,22 +617,6 @@ fn legacy_custom_num_fmt_renders_literal_not_locale() {
         model.get_localized_cell_content(0, 1, 1).unwrap(),
         "4/3/2025",
         "edit-bar content must reflect the literal format code, not re-derive from locale"
-    );
-}
-
-#[test]
-fn format_code_for_id_unknown_returns_general() {
-    // format_code_for_id must return "General" for IDs that are neither built-in
-    // nor in the custom list — not "" (the Default for &str).
-    assert_eq!(
-        NumFmt::format_code_for_id(999, &[]),
-        "General",
-        "unknown numFmtId must fall back to \"General\", not \"\""
-    );
-    assert_eq!(
-        NumFmt::format_code_for_id(-1, &[]),
-        "General",
-        "negative sentinel must fall back to \"General\""
     );
 }
 

--- a/base/src/test/test_now.rs
+++ b/base/src/test/test_now.rs
@@ -20,7 +20,7 @@ fn arguments() {
         "#ERROR!",
         "Wrong number of arguments"
     );
-    assert_eq!(model._get_text("A2"), *"3/20/2023, 2:44 PM");
+    assert_eq!(model._get_text("A2"), *"3/20/23, 2:44 PM");
     assert_eq!(
         model._get_text("A3"),
         "#VALUE!",
@@ -35,5 +35,5 @@ fn returns_date_time() {
     model._set("A1", "=NOW()");
     model.evaluate();
     let text = model._get_text("A1");
-    assert_eq!(text, *"3/20/2023, 1:44 PM");
+    assert_eq!(text, *"3/20/23, 1:44 PM");
 }

--- a/base/src/test/test_num_fmt_serde.rs
+++ b/base/src/test/test_num_fmt_serde.rs
@@ -110,3 +110,27 @@ fn deser_struct_missing_format_code_is_error() {
     let result: Result<NumFmt, _> = serde_json::from_str(json);
     assert!(result.is_err());
 }
+
+// ---------------------------------------------------------------------------
+// Validation — custom format codes with stored_id in/out of ECMA custom range
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deser_rejects_builtin_range_id_for_custom_format_code() {
+    // stored_id=5 is a built-in range ID; format_code "0.000##" is not a built-in.
+    // Accepting a built-in-range ID for a custom code would create an inconsistent
+    // NumFmt where the id and code disagree — corrupt on XLSX export.
+    let json = r#"{"num_fmt_id": 5, "format_code": "0.000##"}"#;
+    let fmt: NumFmt = serde_json::from_str(json).unwrap();
+    assert_eq!(fmt.format_code, "0.000##");
+    assert_eq!(fmt.num_fmt_id, -1, "built-in-range stored_id must be discarded for a custom code");
+}
+
+#[test]
+fn deser_accepts_custom_range_id_for_custom_format_code() {
+    // stored_id=180 is in the ECMA-376 custom range (≥ 164) — round-trip must preserve it.
+    let json = r#"{"num_fmt_id": 180, "format_code": "0.000##"}"#;
+    let fmt: NumFmt = serde_json::from_str(json).unwrap();
+    assert_eq!(fmt.num_fmt_id, 180);
+    assert_eq!(fmt.format_code, "0.000##");
+}

--- a/base/src/test/test_num_fmt_serde.rs
+++ b/base/src/test/test_num_fmt_serde.rs
@@ -1,0 +1,89 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::types::NumFmt;
+
+// ---------------------------------------------------------------------------
+// Deserialization — legacy string form (pre-NumFmt-struct era)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deser_legacy_string_builtin() {
+    // "mm-dd-yy" is ECMA-376 built-in ID 14 — must round-trip to the canonical ID.
+    let json = r#""mm-dd-yy""#;
+    let fmt: NumFmt = serde_json::from_str(json).unwrap();
+    assert_eq!(fmt.num_fmt_id, 14);
+    assert_eq!(fmt.format_code, "mm-dd-yy");
+}
+
+#[test]
+fn deser_legacy_string_custom() {
+    // A format code not in the built-in table gets sentinel -1.
+    let json = r#""dd mmmm yyyy""#;
+    let fmt: NumFmt = serde_json::from_str(json).unwrap();
+    assert_eq!(fmt.num_fmt_id, -1);
+    assert_eq!(fmt.format_code, "dd mmmm yyyy");
+}
+
+#[test]
+fn deser_legacy_string_general() {
+    let json = r#""general""#;
+    let fmt: NumFmt = serde_json::from_str(json).unwrap();
+    assert_eq!(fmt.num_fmt_id, 0);
+    assert_eq!(fmt.format_code, "general");
+}
+
+// ---------------------------------------------------------------------------
+// Deserialization — current struct form
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deser_struct_form() {
+    let json = r#"{"num_fmt_id":14,"format_code":"mm-dd-yy"}"#;
+    let fmt: NumFmt = serde_json::from_str(json).unwrap();
+    assert_eq!(fmt.num_fmt_id, 14);
+    assert_eq!(fmt.format_code, "mm-dd-yy");
+}
+
+#[test]
+fn deser_struct_extra_fields_ignored() {
+    // Forward-compat: unknown fields must not cause an error.
+    let json = r#"{"num_fmt_id":0,"format_code":"general","future_field":true}"#;
+    let fmt: NumFmt = serde_json::from_str(json).unwrap();
+    assert_eq!(fmt.num_fmt_id, 0);
+    assert_eq!(fmt.format_code, "general");
+}
+
+// ---------------------------------------------------------------------------
+// Serialization — target: emit format_code string only (fails until Task 2)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "fails until Task 2 implements custom Serialize"]
+fn ser_emits_format_code_string() {
+    let fmt = NumFmt { num_fmt_id: 14, format_code: "mm-dd-yy".to_string() };
+    let json = serde_json::to_string(&fmt).unwrap();
+    assert_eq!(json, r#""mm-dd-yy""#);
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: serialize → deserialize → same value
+// ---------------------------------------------------------------------------
+// NOTE: This test passes with both the old struct-emit serializer and the new
+// string-emit serializer (Task 2), since the deserializer accepts both forms.
+
+#[test]
+fn round_trip_builtin() {
+    let original = NumFmt { num_fmt_id: 14, format_code: "mm-dd-yy".to_string() };
+    let json = serde_json::to_string(&original).unwrap();
+    let restored: NumFmt = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored.num_fmt_id, original.num_fmt_id);
+    assert_eq!(restored.format_code, original.format_code);
+}
+
+#[test]
+fn round_trip_general() {
+    let original = NumFmt::default();
+    let json = serde_json::to_string(&original).unwrap();
+    let restored: NumFmt = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored.num_fmt_id, original.num_fmt_id);
+}

--- a/base/src/test/test_num_fmt_serde.rs
+++ b/base/src/test/test_num_fmt_serde.rs
@@ -2,10 +2,6 @@
 
 use crate::types::NumFmt;
 
-// ---------------------------------------------------------------------------
-// Deserialization — legacy string form (pre-NumFmt-struct era)
-// ---------------------------------------------------------------------------
-
 #[test]
 fn deser_legacy_string_builtin() {
     // "mm-dd-yy" is ECMA-376 built-in ID 14 — must round-trip to the canonical ID.
@@ -26,15 +22,11 @@ fn deser_legacy_string_custom() {
 
 #[test]
 fn deser_legacy_string_general() {
-    let json = r#""general""#;
+    let json = r#""General""#;
     let fmt: NumFmt = serde_json::from_str(json).unwrap();
     assert_eq!(fmt.num_fmt_id, 0);
-    assert_eq!(fmt.format_code, "general");
+    assert_eq!(fmt.format_code, "General");
 }
-
-// ---------------------------------------------------------------------------
-// Deserialization — current struct form
-// ---------------------------------------------------------------------------
 
 #[test]
 fn deser_struct_form() {
@@ -47,15 +39,11 @@ fn deser_struct_form() {
 #[test]
 fn deser_struct_extra_fields_ignored() {
     // Forward-compat: unknown fields must not cause an error.
-    let json = r#"{"num_fmt_id":0,"format_code":"general","future_field":true}"#;
+    let json = r#"{"num_fmt_id":0,"format_code":"General","future_field":true}"#;
     let fmt: NumFmt = serde_json::from_str(json).unwrap();
     assert_eq!(fmt.num_fmt_id, 0);
-    assert_eq!(fmt.format_code, "general");
+    assert_eq!(fmt.format_code, "General");
 }
-
-// ---------------------------------------------------------------------------
-// Serialization — target: emit format_code string only (fails until Task 2)
-// ---------------------------------------------------------------------------
 
 #[test]
 fn ser_emits_format_code_string() {
@@ -64,12 +52,8 @@ fn ser_emits_format_code_string() {
     assert_eq!(json, r#""mm-dd-yy""#);
 }
 
-// ---------------------------------------------------------------------------
-// Round-trip: serialize → deserialize → same value
-// ---------------------------------------------------------------------------
 // NOTE: This test passes with both the old struct-emit serializer and the new
 // string-emit serializer (Task 2), since the deserializer accepts both forms.
-
 #[test]
 fn round_trip_builtin() {
     let original = NumFmt::new(14, "mm-dd-yy".to_string());
@@ -86,10 +70,6 @@ fn round_trip_general() {
     let restored: NumFmt = serde_json::from_str(&json).unwrap();
     assert_eq!(restored.num_fmt_id, original.num_fmt_id);
 }
-
-// ---------------------------------------------------------------------------
-// Validation — struct form with inconsistent id/code
-// ---------------------------------------------------------------------------
 
 #[test]
 fn deser_struct_inconsistent_id_falls_back_to_code() {
@@ -110,10 +90,6 @@ fn deser_struct_missing_format_code_is_error() {
     let result: Result<NumFmt, _> = serde_json::from_str(json);
     assert!(result.is_err());
 }
-
-// ---------------------------------------------------------------------------
-// Validation — custom format codes with stored_id in/out of ECMA custom range
-// ---------------------------------------------------------------------------
 
 #[test]
 fn deser_rejects_builtin_range_id_for_custom_format_code() {

--- a/base/src/test/test_num_fmt_serde.rs
+++ b/base/src/test/test_num_fmt_serde.rs
@@ -86,3 +86,27 @@ fn round_trip_general() {
     let restored: NumFmt = serde_json::from_str(&json).unwrap();
     assert_eq!(restored.num_fmt_id, original.num_fmt_id);
 }
+
+// ---------------------------------------------------------------------------
+// Validation — struct form with inconsistent id/code
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deser_struct_inconsistent_id_falls_back_to_code() {
+    // num_fmt_id 14 maps to "mm-dd-yy", not "0.00%".
+    // When the two disagree, format_code wins (it is the source of truth).
+    let json = r#"{"num_fmt_id":14,"format_code":"0.00%"}"#;
+    let fmt: NumFmt = serde_json::from_str(json).unwrap();
+    // format_code is preserved as-is; num_fmt_id is re-derived from it.
+    assert_eq!(fmt.format_code, "0.00%");
+    // "0.00%" is ECMA-376 built-in ID 10.
+    assert_eq!(fmt.num_fmt_id, 10);
+}
+
+#[test]
+fn deser_struct_missing_format_code_is_error() {
+    // format_code is required; a struct with only num_fmt_id must fail.
+    let json = r#"{"num_fmt_id":14}"#;
+    let result: Result<NumFmt, _> = serde_json::from_str(json);
+    assert!(result.is_err());
+}

--- a/base/src/test/test_num_fmt_serde.rs
+++ b/base/src/test/test_num_fmt_serde.rs
@@ -58,7 +58,6 @@ fn deser_struct_extra_fields_ignored() {
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "fails until Task 2 implements custom Serialize"]
 fn ser_emits_format_code_string() {
     let fmt = NumFmt { num_fmt_id: 14, format_code: "mm-dd-yy".to_string() };
     let json = serde_json::to_string(&fmt).unwrap();

--- a/base/src/test/test_num_fmt_serde.rs
+++ b/base/src/test/test_num_fmt_serde.rs
@@ -59,7 +59,7 @@ fn deser_struct_extra_fields_ignored() {
 
 #[test]
 fn ser_emits_format_code_string() {
-    let fmt = NumFmt { num_fmt_id: 14, format_code: "mm-dd-yy".to_string() };
+    let fmt = NumFmt::new(14, "mm-dd-yy".to_string());
     let json = serde_json::to_string(&fmt).unwrap();
     assert_eq!(json, r#""mm-dd-yy""#);
 }
@@ -72,7 +72,7 @@ fn ser_emits_format_code_string() {
 
 #[test]
 fn round_trip_builtin() {
-    let original = NumFmt { num_fmt_id: 14, format_code: "mm-dd-yy".to_string() };
+    let original = NumFmt::new(14, "mm-dd-yy".to_string());
     let json = serde_json::to_string(&original).unwrap();
     let restored: NumFmt = serde_json::from_str(&json).unwrap();
     assert_eq!(restored.num_fmt_id, original.num_fmt_id);
@@ -123,7 +123,10 @@ fn deser_rejects_builtin_range_id_for_custom_format_code() {
     let json = r#"{"num_fmt_id": 5, "format_code": "0.000##"}"#;
     let fmt: NumFmt = serde_json::from_str(json).unwrap();
     assert_eq!(fmt.format_code, "0.000##");
-    assert_eq!(fmt.num_fmt_id, -1, "built-in-range stored_id must be discarded for a custom code");
+    assert_eq!(
+        fmt.num_fmt_id, -1,
+        "built-in-range stored_id must be discarded for a custom code"
+    );
 }
 
 #[test]

--- a/base/src/test/test_number_format.rs
+++ b/base/src/test/test_number_format.rs
@@ -42,7 +42,6 @@ fn test_leading_comma_text() {
 }
 
 #[test]
-#[ignore = "not yet implemented"]
 fn test_wrong_locale() {
     let formatted = format_number(2.3, "General", "ens");
     assert_eq!(formatted.text, "#ERROR!".to_string());

--- a/base/src/test/test_set_functions_error_handling.rs
+++ b/base/src/test/test_set_functions_error_handling.rs
@@ -410,7 +410,7 @@ fn workbook_styles_get_style_error_handling() {
     // case 1 : Invalid index
     assert_eq!(
         model.workbook.styles.get_style(15),
-        Err("Invalid index provided".to_string())
+        Err("Invalid style index: 15".to_string())
     );
 }
 
@@ -421,7 +421,7 @@ fn workbook_styles_get_style_without_quote_prefix_error_handling() {
     // case 1 : Invalid index
     assert_eq!(
         model.workbook.styles.get_style_without_quote_prefix(15),
-        Err("Invalid index provided".to_string())
+        Err("Invalid style index: 15".to_string())
     );
 }
 
@@ -435,7 +435,7 @@ fn workbook_styles_get_style_with_format_error_handling() {
             .workbook
             .styles
             .get_style_with_format(15, "dummy_num_format"),
-        Err("Invalid index provided".to_string())
+        Err("Invalid style index: 15".to_string())
     );
 }
 
@@ -446,6 +446,6 @@ fn workbook_styles_get_style_with_quote_prefix_handling() {
     // case 1 : Invalid index
     assert_eq!(
         model.workbook.styles.get_style_with_quote_prefix(15),
-        Err("Invalid index provided".to_string())
+        Err("Invalid style index: 15".to_string())
     );
 }

--- a/base/src/test/test_set_user_input.rs
+++ b/base/src/test/test_set_user_input.rs
@@ -529,16 +529,18 @@ fn input_dates() {
 
     model.evaluate();
 
-    assert_eq!(model._get_text("A1"), "4/3/2025");
+    // Locale short date (numFmtId 14) renders using locale's own pattern
+    // (en: "m/d/yy"), so 4-digit input is stored but displayed 2-digit.
+    assert_eq!(model._get_text("A1"), "4/3/25");
     assert_eq!(
         model.get_cell_value_by_ref("Sheet1!A1"),
         Ok(CellValue::Number(45750.0))
     );
 
-    // further date assignments do not change the format
+    // Further date assignments do not change the format; still locale short.
     model
         .set_user_input(0, 1, 1, "08-08-2028".to_string())
         .unwrap();
     model.evaluate();
-    assert_eq!(model._get_text("A1"), "8/8/2028");
+    assert_eq!(model._get_text("A1"), "8/8/28");
 }

--- a/base/src/test/test_styles.rs
+++ b/base/src/test/test_styles.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
 use crate::test::util::new_empty_model;
-use crate::types::Style;
+use crate::types::{NumFmt, Style};
 
 #[test]
 fn test_model_set_cells_with_values_styles() {
@@ -13,14 +13,14 @@ fn test_model_set_cells_with_values_styles() {
     let style_base = model.get_style_for_cell(0, 1, 1).unwrap();
     let mut style = style_base.clone();
     style.font.b = true;
-    style.num_fmt = "#,##0.00".to_string();
+    style.num_fmt = NumFmt::from_format_code("#,##0.00");
     assert!(model.set_cell_style(0, 1, 1, &style).is_ok());
 
     let mut style = style_base;
-    style.num_fmt = "#,##0.00".to_string();
+    style.num_fmt = NumFmt::from_format_code("#,##0.00");
     assert!(model.set_cell_style(0, 2, 1, &style).is_ok());
     let style: Style = model.get_style_for_cell(0, 2, 1).unwrap();
-    assert_eq!(style.num_fmt, "#,##0.00".to_string());
+    assert_eq!(style.num_fmt.format_code, "#,##0.00");
 }
 
 #[test]

--- a/base/src/test/test_styles.rs
+++ b/base/src/test/test_styles.rs
@@ -13,11 +13,11 @@ fn test_model_set_cells_with_values_styles() {
     let style_base = model.get_style_for_cell(0, 1, 1).unwrap();
     let mut style = style_base.clone();
     style.font.b = true;
-    style.num_fmt = NumFmt::from_format_code("#,##0.00");
+    style.num_fmt = NumFmt::from_format_code("#,##0.00", None);
     assert!(model.set_cell_style(0, 1, 1, &style).is_ok());
 
     let mut style = style_base;
-    style.num_fmt = NumFmt::from_format_code("#,##0.00");
+    style.num_fmt = NumFmt::from_format_code("#,##0.00", None);
     assert!(model.set_cell_style(0, 2, 1, &style).is_ok());
     let style: Style = model.get_style_for_cell(0, 2, 1).unwrap();
     assert_eq!(style.num_fmt.format_code, "#,##0.00");

--- a/base/src/test/test_today.rs
+++ b/base/src/test/test_today.rs
@@ -14,7 +14,8 @@ fn today_basic() {
     model._set("A2", "=TEXT(A1, \"yyyy/m/d\")");
     model.evaluate();
 
-    assert_eq!(model._get_text("A1"), *"11/8/2022");
+    // en-US locale "m/d/yy" via numFmtId 14 — 2-digit year.
+    assert_eq!(model._get_text("A1"), *"11/8/22");
     assert_eq!(model._get_text("A2"), *"2022/11/8");
 }
 
@@ -32,7 +33,7 @@ fn now_basic_utc() {
     model._set("A2", "=NOW()");
     model.evaluate();
 
-    assert_eq!(model._get_text("A1"), *"3/20/2023");
+    assert_eq!(model._get_text("A1"), *"3/20/23");
     // 45005.572511574
     assert_eq!(model._get_text("A2"), *"3/20/2023, 1:44 PM");
 }
@@ -45,7 +46,7 @@ fn now_basic_europe_berlin() {
     model._set("A2", "=NOW()");
     model.evaluate();
 
-    assert_eq!(model._get_text("A1"), *"3/20/2023");
+    assert_eq!(model._get_text("A1"), *"3/20/23");
     // This is UTC + 1 hour: 45005.572511574 + 1/24
     assert_eq!(model._get_text("A2"), *"3/20/2023, 2:44 PM");
 }

--- a/base/src/test/test_today.rs
+++ b/base/src/test/test_today.rs
@@ -35,7 +35,7 @@ fn now_basic_utc() {
 
     assert_eq!(model._get_text("A1"), *"3/20/23");
     // 45005.572511574
-    assert_eq!(model._get_text("A2"), *"3/20/2023, 1:44 PM");
+    assert_eq!(model._get_text("A2"), *"3/20/23, 1:44 PM");
 }
 
 #[test]
@@ -48,5 +48,5 @@ fn now_basic_europe_berlin() {
 
     assert_eq!(model._get_text("A1"), *"3/20/23");
     // This is UTC + 1 hour: 45005.572511574 + 1/24
-    assert_eq!(model._get_text("A2"), *"3/20/2023, 2:44 PM");
+    assert_eq!(model._get_text("A2"), *"3/20/23, 2:44 PM");
 }

--- a/base/src/test/user_model/test_styles.rs
+++ b/base/src/test/user_model/test_styles.rs
@@ -202,23 +202,23 @@ fn basic_format() {
     };
 
     let style = model.get_cell_style(0, 1, 1).unwrap();
-    assert_eq!(style.num_fmt, "general");
+    assert_eq!(style.num_fmt.format_code, "general");
 
     model
         .update_range_style(&range, "num_fmt", "$#,##0.0000")
         .unwrap();
     let style = model.get_cell_style(0, 1, 1).unwrap();
-    assert_eq!(style.num_fmt, "$#,##0.0000");
+    assert_eq!(style.num_fmt.format_code, "$#,##0.0000");
 
     model.undo().unwrap();
 
     let style = model.get_cell_style(0, 1, 1).unwrap();
-    assert_eq!(style.num_fmt, "general");
+    assert_eq!(style.num_fmt.format_code, "general");
 
     model.redo().unwrap();
 
     let style = model.get_cell_style(0, 1, 1).unwrap();
-    assert_eq!(style.num_fmt, "$#,##0.0000");
+    assert_eq!(style.num_fmt.format_code, "$#,##0.0000");
 
     let send_queue = model.flush_send_queue();
 
@@ -226,7 +226,7 @@ fn basic_format() {
     model2.apply_external_diffs(&send_queue).unwrap();
 
     let style = model2.get_cell_style(0, 1, 1).unwrap();
-    assert_eq!(style.num_fmt, "$#,##0.0000");
+    assert_eq!(style.num_fmt.format_code, "$#,##0.0000");
 }
 
 #[test]

--- a/base/src/test/user_model/test_styles.rs
+++ b/base/src/test/user_model/test_styles.rs
@@ -202,7 +202,7 @@ fn basic_format() {
     };
 
     let style = model.get_cell_style(0, 1, 1).unwrap();
-    assert_eq!(style.num_fmt.format_code, "general");
+    assert_eq!(style.num_fmt.format_code, "General");
 
     model
         .update_range_style(&range, "num_fmt", "$#,##0.0000")
@@ -213,7 +213,7 @@ fn basic_format() {
     model.undo().unwrap();
 
     let style = model.get_cell_style(0, 1, 1).unwrap();
-    assert_eq!(style.num_fmt.format_code, "general");
+    assert_eq!(style.num_fmt.format_code, "General");
 
     model.redo().unwrap();
 

--- a/base/src/test/user_model/test_user_input_dates_quote.rs
+++ b/base/src/test/user_model/test_user_input_dates_quote.rs
@@ -23,7 +23,7 @@ fn dates_format() {
     user_model.set_user_input(0, 2, 1, "2024-06-01").unwrap();
     // format A1 as date
     let style = user_model.get_cell_style(0, 2, 1).unwrap();
-    assert_eq!(style.num_fmt, "yyyy-mm-dd");
+    assert_eq!(style.num_fmt.format_code, "yyyy-mm-dd");
     let range = Area {
         sheet: 0,
         row: 1,

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
 
 use crate::expressions::token::Error;
+use crate::number_format::DEFAULT_NUM_FMTS;
 
 fn default_as_false() -> bool {
     false
@@ -17,7 +18,8 @@ pub struct Metadata {
     pub application: String,
     pub app_version: String,
     pub creator: String,
-    pub last_modified_by: String,
+    pub last_modified_by: String, // Search custom formats first (by their stored ID, not position).
+
     pub created: String,       // "2020-08-06T21:20:53Z",
     pub last_modified: String, //"2020-11-20T16:24:35"
 }
@@ -320,31 +322,18 @@ impl Default for Styles {
     }
 }
 
-#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone, Default)]
 pub struct Style {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alignment: Option<Alignment>,
-    pub num_fmt: String,
+    pub num_fmt: NumFmt,
     pub fill: Fill,
     pub font: Font,
     pub border: Border,
     pub quote_prefix: bool,
 }
 
-impl Default for Style {
-    fn default() -> Self {
-        Style {
-            alignment: None,
-            num_fmt: "general".to_string(),
-            fill: Fill::default(),
-            font: Font::default(),
-            border: Border::default(),
-            quote_prefix: false,
-        }
-    }
-}
-
-#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct NumFmt {
     pub num_fmt_id: i32,
     pub format_code: String,
@@ -356,6 +345,80 @@ impl Default for NumFmt {
             num_fmt_id: 0,
             format_code: "general".to_string(),
         }
+    }
+}
+
+impl NumFmt {
+    /// Return the ECMA-376 built-in `numFmtId` for `code`, or `None` if the
+    /// code is not in the built-in table.
+    pub(crate) fn builtin_id(code: &str) -> Option<i32> {
+        DEFAULT_NUM_FMTS
+            .iter()
+            .position(|&s| s == code)
+            .map(|i| i as i32)
+    }
+
+    /// Build a `NumFmt` from a known `num_fmt_id`.
+    ///
+    /// Looks up the format code from the workbook's custom list first,
+    /// then falls back to the ECMA-376 built-in table. Unknown IDs resolve
+    /// to General (ID 0).
+    pub fn from_id(id: i32, custom_fmts: &[NumFmt]) -> Self {
+        if let Some(fmt) = custom_fmts.iter().find(|f| f.num_fmt_id == id) {
+            return fmt.clone();
+        }
+        // Clamp out-of-range IDs to 0 (General); built-in IDs use their own value.
+        let resolved = if id >= 0 && (id as usize) < DEFAULT_NUM_FMTS.len() {
+            id
+        } else {
+            0
+        };
+        NumFmt {
+            num_fmt_id: resolved,
+            format_code: DEFAULT_NUM_FMTS[resolved as usize].to_string(),
+        }
+    }
+
+    /// Build a `NumFmt` from a format code string.
+    ///
+    /// For ECMA-376 built-in codes the canonical ID is resolved immediately.
+    /// For custom codes (not in the built-in table) `num_fmt_id` is `-1` — an
+    /// unambiguous sentinel distinct from all valid IDs (which are ≥ 0).
+    /// `Styles::get_style_index_or_create` re-derives the real ID from
+    /// `format_code` at persist time, and `Styles::get_style_index` compares
+    /// styles by `format_code`, so deduplication is correct regardless.
+    pub fn from_format_code(code: &str) -> Self {
+        let num_fmt_id = Self::builtin_id(code).unwrap_or(-1);
+        NumFmt {
+            num_fmt_id,
+            format_code: code.to_string(),
+        }
+    }
+
+    /// Returns a fully-resolved `NumFmt`, registering a new custom entry in
+    /// `num_fmts` if the code isn't already there.  Use this when you have
+    /// mutable access to the styles registry (e.g. inside `Styles` methods).
+    pub fn get_or_register(code: &str, num_fmts: &mut Vec<NumFmt>) -> Self {
+        if let Some(id) = Self::builtin_id(code) {
+            return NumFmt {
+                num_fmt_id: id,
+                format_code: code.to_string(),
+            };
+        }
+        if let Some(existing) = num_fmts.iter().find(|f| f.format_code == code) {
+            return existing.clone();
+        }
+        // Find the lowest custom ID (≥ built-in table length) not already in use.
+        let mut new_id = DEFAULT_NUM_FMTS.len() as i32;
+        while num_fmts.iter().any(|f| f.num_fmt_id == new_id) {
+            new_id += 1;
+        }
+        let fmt = NumFmt {
+            num_fmt_id: new_id,
+            format_code: code.to_string(),
+        };
+        num_fmts.push(fmt.clone());
+        fmt
     }
 }
 

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -450,9 +450,14 @@ impl NumFmt {
         let (num_fmt_id, format_code) = match DefaultFmts::by_id(id) {
             Some(code) => (id, code),
             None => {
-                // Gap IDs (49–163) not in custom_fmts silently fall back (debug builds only).
+                // Unknown IDs fall back to General. See number_format.rs for gap ID ranges.notes.
+                // Panic in debug if the ID is not a known ECMA-376 gap (bug guard).
                 debug_assert!(
-                    id < 0,
+                    id < 0
+                        || !((5..=8).contains(&id)
+                        || (23..=36).contains(&id)
+                        || (41..=44).contains(&id)
+                        || (50..ECMA_CUSTOM_FMT_MIN_ID).contains(&id)),
                     "num_fmt_id {id} is unknown (not a built-in ECMA-376 ID and not in custom_fmts); \
                      silently falling back to General (0)"
                 );

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -2,6 +2,7 @@ use bitcode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
 
+use crate::constants::ECMA_CUSTOM_FMT_MIN_ID;
 use crate::expressions::token::Error;
 use crate::number_format::DefaultFmts;
 
@@ -387,7 +388,7 @@ impl<'de> Deserialize<'de> for NumFmt {
                 // Anything else (e.g. a built-in-range ID paired with a custom code)
                 // is suspect — discard the stored ID and keep the derived value.
                 let num_fmt_id = if stored_id == derived.num_fmt_id
-                    || (derived.num_fmt_id == -1 && stored_id >= NumFmt::ECMA_CUSTOM_FMT_MIN_ID)
+                    || (derived.num_fmt_id == -1 && stored_id >= ECMA_CUSTOM_FMT_MIN_ID)
                 {
                     stored_id
                 } else {
@@ -445,7 +446,7 @@ impl NumFmt {
                     "num_fmt_id {id} is unknown (not a built-in ECMA-376 ID and not in custom_fmts); \
                      silently falling back to General (0)"
                 );
-                (0, DefaultFmts::by_id(0).unwrap())
+                (0, DefaultFmts::by_id(0).unwrap_or("General"))
             }
         };
         NumFmt {
@@ -473,12 +474,8 @@ impl NumFmt {
             .iter()
             .find(|f| f.num_fmt_id == id)
             .map(|f| f.format_code.as_str())
-            .unwrap_or(DefaultFmts::by_id(0).unwrap())
+            .unwrap_or(DefaultFmts::by_id(0).unwrap_or("General"))
     }
-
-    /// ECMA-376 §18.8.30: custom numFmtIds must be ≥ 164.
-    /// IDs 0–163 are reserved for built-in formats; assigning lower IDs corrupts XLSX readers.
-    const ECMA_CUSTOM_FMT_MIN_ID: i32 = 164;
 
     /// Returns the `NumFmt` for `code`, registering it in `num_fmts` if it is not yet present.
     ///
@@ -495,7 +492,7 @@ impl NumFmt {
             return existing.clone();
         }
         // ECMA-376 custom IDs must be ≥ 164; find the lowest unused one.
-        let mut new_id = Self::ECMA_CUSTOM_FMT_MIN_ID;
+        let mut new_id = ECMA_CUSTOM_FMT_MIN_ID;
         while num_fmts.iter().any(|f| f.num_fmt_id == new_id) {
             new_id += 1;
         }

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -375,10 +375,22 @@ impl<'de> Deserialize<'de> for NumFmt {
                         _ => { let _: serde::de::IgnoredAny = map.next_value()?; }
                     }
                 }
-                Ok(NumFmt {
-                    num_fmt_id: num_fmt_id.ok_or_else(|| de::Error::missing_field("num_fmt_id"))?,
-                    format_code: format_code.ok_or_else(|| de::Error::missing_field("format_code"))?,
-                })
+                let format_code = format_code
+                    .ok_or_else(|| de::Error::missing_field("format_code"))?;
+                // Re-derive num_fmt_id from format_code so the two fields are always
+                // consistent.  If the incoming id disagrees (e.g. a hand-edited file),
+                // format_code is treated as the source of truth.
+                let derived = NumFmt::from_format_code(&format_code);
+                // Accept the stored id only if it matches what we'd derive — this lets
+                // custom IDs (≥ 164) round-trip correctly when both fields are present.
+                let stored_id = num_fmt_id.unwrap_or(derived.num_fmt_id);
+                let fmt = if stored_id == derived.num_fmt_id || derived.num_fmt_id == -1 {
+                    NumFmt { num_fmt_id: stored_id, format_code }
+                } else {
+                    // Mismatch — trust format_code, discard stale id.
+                    derived
+                };
+                Ok(fmt)
             }
         }
 

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
 
 use crate::expressions::token::Error;
-use crate::number_format::DEFAULT_NUM_FMTS;
+use crate::number_format::{
+    DEFAULT_NUM_FMTS, LOCALE_SHORT_DATE_FMT_ID, LOCALE_SHORT_DATE_TIME_FMT_ID,
+};
 
 fn default_as_false() -> bool {
     false
@@ -348,10 +350,41 @@ impl Default for NumFmt {
 }
 
 impl NumFmt {
+    /// ECMA-376 numFmtId for the locale-derived short date (e.g. "m/d/yy" in en-US).
+    pub(crate) const LOCALE_DATE_ID: i32 = LOCALE_SHORT_DATE_FMT_ID;
+    /// ECMA-376 numFmtId for the locale-derived short date+time (e.g. "m/d/yy h:mm").
+    pub(crate) const LOCALE_DATETIME_ID: i32 = LOCALE_SHORT_DATE_TIME_FMT_ID;
+
+    /// Return `true` if `id` is one of the two locale-derived format IDs (14 or 22).
+    pub(crate) fn is_locale_date_id(id: i32) -> bool {
+        id == Self::LOCALE_DATE_ID || id == Self::LOCALE_DATETIME_ID
+    }
+
+    /// The ECMA-376 built-in format strings, indexed by numFmtId.
+    ///
+    /// Prefer this accessor over importing `DEFAULT_NUM_FMTS` directly —
+    /// callers get `.iter()`, `.len()`, and `.get(i)` without depending on
+    /// the private constant.
+    pub(crate) fn builtins() -> &'static [&'static str] {
+        DEFAULT_NUM_FMTS
+    }
+
+    /// Return `true` if `id` is a valid ECMA-376 built-in numFmtId.
+    pub(crate) fn is_builtin_id(id: i32) -> bool {
+        usize::try_from(id).is_ok_and(|i| i < Self::builtins().len())
+    }
+
+    /// Return `true` if `id` is either a built-in ECMA-376 ID or registered
+    /// in `custom_fmts`.  Use this to validate an ID before storing it in a
+    /// `CellXfs` entry.
+    pub(crate) fn is_known_id(id: i32, custom_fmts: &[NumFmt]) -> bool {
+        Self::is_builtin_id(id) || custom_fmts.iter().any(|f| f.num_fmt_id == id)
+    }
+
     /// Return the ECMA-376 built-in `numFmtId` for `code`, or `None` if the
     /// code is not in the built-in table.
     pub(crate) fn builtin_id(code: &str) -> Option<i32> {
-        DEFAULT_NUM_FMTS
+        Self::builtins()
             .iter()
             .position(|&s| s == code)
             .map(|i| i as i32)
@@ -366,15 +399,15 @@ impl NumFmt {
         if let Some(fmt) = custom_fmts.iter().find(|f| f.num_fmt_id == id) {
             return fmt.clone();
         }
-        // Clamp out-of-range IDs to 0 (General); built-in IDs use their own value.
-        let resolved = if id >= 0 && (id as usize) < DEFAULT_NUM_FMTS.len() {
-            id
-        } else {
-            0
-        };
+        // Clamp out-of-range / negative IDs to 0 (General).
+        let resolved = usize::try_from(id)
+            .ok()
+            .filter(|&i| i < Self::builtins().len())
+            .map(|i| i as i32)
+            .unwrap_or(0);
         NumFmt {
             num_fmt_id: resolved,
-            format_code: DEFAULT_NUM_FMTS[resolved as usize].to_string(),
+            format_code: Self::resolve_code(resolved, &[]).to_string(),
         }
     }
 
@@ -396,7 +429,23 @@ impl NumFmt {
     }
 
 
-    /// Covers functions `get_num_fmt()` and `get_new_num_fmt_index()` previously in file number_format.rs 
+    /// Resolve a `num_fmt_id` to its format code string.
+    ///
+    /// Checks `custom_fmts` first (workbook-specific entries), then falls back
+    /// to the ECMA-376 built-in table.  Unknown or negative IDs return `"general"`.
+    pub(crate) fn resolve_code(id: i32, custom_fmts: &[NumFmt]) -> &str {
+        custom_fmts
+            .iter()
+            .find(|f| f.num_fmt_id == id)
+            .map(|f| f.format_code.as_str())
+            .or_else(|| {
+                let i: usize = id.try_into().ok()?;
+                Self::builtins().get(i).copied()
+            })
+            .unwrap_or(Self::builtins()[0])
+    }
+
+    /// Covers functions `get_num_fmt()` and `get_new_num_fmt_index()` previously in file number_format.rs
     /// `Styles` methods .
     pub fn get_or_register(code: &str, num_fmts: &mut Vec<NumFmt>) -> Self {
         if let Some(id) = Self::builtin_id(code) {
@@ -409,7 +458,7 @@ impl NumFmt {
             return existing.clone();
         }
         // Find the lowest custom ID (≥ built-in table length) not already in use.
-        let mut new_id = DEFAULT_NUM_FMTS.len() as i32;
+        let mut new_id = Self::builtins().len() as i32;
         while num_fmts.iter().any(|f| f.num_fmt_id == new_id) {
             new_id += 1;
         }

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -404,7 +404,7 @@ impl<'de> Deserialize<'de> for NumFmt {
     }
 }
 
-// Serialize as format_code string; Deserialize handles both this and the legacy struct form.
+// Serialize as format_code string.
 impl Serialize for NumFmt {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.format_code)
@@ -418,7 +418,6 @@ impl Default for NumFmt {
 }
 
 impl NumFmt {
-    /// Construct a `NumFmt` directly from a known id/code pair (e.g. XLSX import).
     pub fn new(num_fmt_id: i32, format_code: String) -> Self {
         NumFmt {
             num_fmt_id,
@@ -431,7 +430,7 @@ impl NumFmt {
         DefaultFmts::contains_id(id) || custom_fmts.iter().any(|f| f.num_fmt_id == id)
     }
 
-    /// Build a `NumFmt` from a `num_fmt_id`; unknown IDs fall back to General (0).
+    /// Build a `NumFmt` from a `num_fmt_id`; unknown IDs fall back to General.
     pub fn from_id(id: i32, custom_fmts: &[NumFmt]) -> Self {
         if let Some(fmt) = custom_fmts.iter().find(|f| f.num_fmt_id == id) {
             return fmt.clone();
@@ -446,7 +445,7 @@ impl NumFmt {
                     "num_fmt_id {id} is unknown (not a built-in ECMA-376 ID and not in custom_fmts); \
                      silently falling back to General (0)"
                 );
-                (0, "general")
+                (0, DefaultFmts::by_id(0).unwrap())
             }
         };
         NumFmt {
@@ -455,7 +454,7 @@ impl NumFmt {
         }
     }
 
-    /// Build a `NumFmt` from a format code; resolves to the built-in ID, or
+    /// format code resolves to the built-in ID, or
     /// `-1` as a sentinel for custom codes (real ID assigned at persist time).
     pub fn from_format_code(code: &str) -> Self {
         let num_fmt_id = DefaultFmts::by_code(code).unwrap_or(-1);
@@ -465,7 +464,7 @@ impl NumFmt {
         }
     }
 
-    /// Resolve a `num_fmt_id` to its format code; unknown/negative IDs return `"general"`.
+    /// Resolve format code; unknown/negative IDs return `"General"`.
     pub(crate) fn format_code_for_id(id: i32, custom_fmts: &[NumFmt]) -> &str {
         if let Some(code) = DefaultFmts::by_id(id) {
             return code;
@@ -474,7 +473,7 @@ impl NumFmt {
             .iter()
             .find(|f| f.num_fmt_id == id)
             .map(|f| f.format_code.as_str())
-            .unwrap_or("general")
+            .unwrap_or(DefaultFmts::by_id(0).unwrap())
     }
 
     /// ECMA-376 §18.8.30: custom numFmtIds must be ≥ 164.
@@ -483,7 +482,7 @@ impl NumFmt {
 
     /// Returns the `NumFmt` for `code`, registering it in `num_fmts` if it is not yet present.
     ///
-    /// Built-in codes resolve immediately with their ECMA-376 ID.
+    /// Built-in codes resolve immediately with their ID.
     /// Custom codes are assigned an ID ≥ 164 on first registration and re-used thereafter.
     pub fn get_or_register(code: &str, num_fmts: &mut Vec<NumFmt>) -> Self {
         if let Some(id) = DefaultFmts::by_code(code) {

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, fmt::Display};
 
 use crate::expressions::token::Error;
 use crate::number_format::{
-    DEFAULT_NUM_FMTS, LOCALE_SHORT_DATE_FMT_ID, LOCALE_SHORT_DATE_TIME_FMT_ID,
+    DEFAULT_NUM_FMTS, SHORT_DATE_FMT_ID, SHORT_DATE_TIME_FMT_ID,
 };
 
 fn default_as_false() -> bool {
@@ -334,10 +334,56 @@ pub struct Style {
     pub quote_prefix: bool,
 }
 
-#[derive(Serialize, Deserialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub struct NumFmt {
     pub num_fmt_id: i32,
     pub format_code: String,
+}
+
+// Custom deserializer so that workbooks serialized before the `String` →
+// `NumFmt` migration can still be loaded.  Old JSON has `"num_fmt": "mm/dd/yy"`;
+// new JSON has `"num_fmt": {"num_fmt_id": 14, "format_code": "mm/dd/yy"}`.
+impl<'de> Deserialize<'de> for NumFmt {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::{self, MapAccess, Visitor};
+
+        struct NumFmtVisitor;
+
+        impl<'de> Visitor<'de> for NumFmtVisitor {
+            type Value = NumFmt;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a format-code string (legacy) or a NumFmt object")
+            }
+
+            // Legacy path: `num_fmt` was serialized as a plain format-code string.
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<NumFmt, E> {
+                Ok(NumFmt::from_format_code(value))
+            }
+
+            fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<NumFmt, M::Error> {
+                let mut num_fmt_id: Option<i32> = None;
+                let mut format_code: Option<String> = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "num_fmt_id" => num_fmt_id = Some(map.next_value()?),
+                        "format_code" => format_code = Some(map.next_value()?),
+                        _ => { let _: serde::de::IgnoredAny = map.next_value()?; }
+                    }
+                }
+                Ok(NumFmt {
+                    num_fmt_id: num_fmt_id.ok_or_else(|| de::Error::missing_field("num_fmt_id"))?,
+                    format_code: format_code.ok_or_else(|| de::Error::missing_field("format_code"))?,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(NumFmtVisitor)
+    }
 }
 
 impl Default for NumFmt {
@@ -350,28 +396,51 @@ impl Default for NumFmt {
 }
 
 impl NumFmt {
-    /// ECMA-376 numFmtId for the locale-derived short date (e.g. "m/d/yy" in en-US).
-    pub(crate) const LOCALE_DATE_ID: i32 = LOCALE_SHORT_DATE_FMT_ID;
-    /// ECMA-376 numFmtId for the locale-derived short date+time (e.g. "m/d/yy h:mm").
-    pub(crate) const LOCALE_DATETIME_ID: i32 = LOCALE_SHORT_DATE_TIME_FMT_ID;
-
-    /// Return `true` if `id` is one of the two locale-derived format IDs (14 or 22).
-    pub(crate) fn is_locale_date_id(id: i32) -> bool {
-        id == Self::LOCALE_DATE_ID || id == Self::LOCALE_DATETIME_ID
+    /// Construct a `NumFmt` from a known `num_fmt_id` and `format_code`.
+    ///
+    /// Prefer [`NumFmt::from_id`], [`NumFmt::from_format_code`], or
+    /// [`NumFmt::get_or_register`] when working within the engine.  This
+    /// constructor exists for callers (e.g. XLSX import) that already hold a
+    /// validated id/code pair from an external source and need to build the
+    /// struct directly.
+    pub fn new(num_fmt_id: i32, format_code: String) -> Self {
+        NumFmt {
+            num_fmt_id,
+            format_code,
+        }
     }
 
+    /// ECMA-376 numFmtId for the locale-derived short date (e.g. "m/d/yy" in en-US).
+    pub(crate) const SHORT_DATE_ID: i32 = SHORT_DATE_FMT_ID;
+    /// ECMA-376 numFmtId for the locale-derived short date+time (e.g. "m/d/yy h:mm").
+    pub(crate) const SHORT_DATETIME_ID: i32 = SHORT_DATE_TIME_FMT_ID;
+    
     /// The ECMA-376 built-in format strings, indexed by numFmtId.
     ///
     /// Prefer this accessor over importing `DEFAULT_NUM_FMTS` directly —
     /// callers get `.iter()`, `.len()`, and `.get(i)` without depending on
     /// the private constant.
-    pub(crate) fn builtins() -> &'static [&'static str] {
+    fn builtins() -> &'static [&'static str] {
         DEFAULT_NUM_FMTS
     }
 
+    /// Return the ECMA-376 built-in `numFmtId` for `code`, or `None` if the
+    /// code is not in the built-in table.
+    fn builtin_id(code: &str) -> Option<i32> {
+        Self::builtins()
+            .iter()
+            .position(|&s| s == code)
+            .map(|i| i as i32)
+    }
+
     /// Return `true` if `id` is a valid ECMA-376 built-in numFmtId.
-    pub(crate) fn is_builtin_id(id: i32) -> bool {
+    fn is_builtin_id(id: i32) -> bool {
         usize::try_from(id).is_ok_and(|i| i < Self::builtins().len())
+    }
+    
+    /// Return `true` if `id` is one of the two locale-derived format IDs (14 or 22).
+    pub(crate) fn is_locale_date_id(id: i32) -> bool {
+        id == Self::SHORT_DATE_ID || id == Self::SHORT_DATETIME_ID
     }
 
     /// Return `true` if `id` is either a built-in ECMA-376 ID or registered
@@ -379,15 +448,6 @@ impl NumFmt {
     /// `CellXfs` entry.
     pub(crate) fn is_known_id(id: i32, custom_fmts: &[NumFmt]) -> bool {
         Self::is_builtin_id(id) || custom_fmts.iter().any(|f| f.num_fmt_id == id)
-    }
-
-    /// Return the ECMA-376 built-in `numFmtId` for `code`, or `None` if the
-    /// code is not in the built-in table.
-    pub(crate) fn builtin_id(code: &str) -> Option<i32> {
-        Self::builtins()
-            .iter()
-            .position(|&s| s == code)
-            .map(|i| i as i32)
     }
 
     /// Build a `NumFmt` from a known `num_fmt_id`.
@@ -405,9 +465,17 @@ impl NumFmt {
             .filter(|&i| i < Self::builtins().len())
             .map(|i| i as i32)
             .unwrap_or(0);
+        // IDs in the ECMA-376 gap (49–163) or any positive ID not registered in
+        // custom_fmts will silently fall back to General.  Flag this in debug
+        // builds — it most likely indicates a misconfigured xlsx import.
+        debug_assert!(
+            id < 0 || resolved == id,
+            "num_fmt_id {id} is unknown (not a built-in ECMA-376 ID and not in custom_fmts); \
+             silently falling back to General (0)"
+        );
         NumFmt {
             num_fmt_id: resolved,
-            format_code: Self::resolve_code(resolved, &[]).to_string(),
+            format_code: Self::format_code_for_id(resolved, &[]).to_string(),
         }
     }
 
@@ -420,7 +488,6 @@ impl NumFmt {
     /// `format_code` at persist time, and `Styles::get_style_index` compares
     /// styles by `format_code`, so deduplication is correct regardless.
     pub fn from_format_code(code: &str) -> Self {
-        // Only 
         let num_fmt_id = Self::builtin_id(code).unwrap_or(-1);
         NumFmt {
             num_fmt_id,
@@ -428,20 +495,22 @@ impl NumFmt {
         }
     }
 
-
     /// Resolve a `num_fmt_id` to its format code string.
     ///
-    /// Checks `custom_fmts` first (workbook-specific entries), then falls back
-    /// to the ECMA-376 built-in table.  Unknown or negative IDs return `"general"`.
-    pub(crate) fn resolve_code(id: i32, custom_fmts: &[NumFmt]) -> &str {
+    /// Checks the ECMA-376 built-in table first (O(1) bounds check), then
+    /// falls back to a linear scan of `custom_fmts` (workbook-specific entries).
+    /// Unknown or negative IDs — including the `-1` sentinel used by
+    /// `from_format_code` — return `"general"` (ID 0).
+    pub(crate) fn format_code_for_id<'a>(id: i32, custom_fmts: &'a [NumFmt]) -> &'a str {
+        // Fast path: most IDs are ECMA-376 builtins.  A single bounds check
+        // avoids the custom_fmts scan for the common case.
+        if let Some(i) = usize::try_from(id).ok().filter(|&i| i < Self::builtins().len()) {
+            return Self::builtins()[i];
+        }
         custom_fmts
             .iter()
             .find(|f| f.num_fmt_id == id)
             .map(|f| f.format_code.as_str())
-            .or_else(|| {
-                let i: usize = id.try_into().ok()?;
-                Self::builtins().get(i).copied()
-            })
             .unwrap_or(Self::builtins()[0])
     }
 

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -424,12 +424,9 @@ impl NumFmt {
         }
     }
 
-    fn builtin_id(code: &str) -> Option<i32>  { BuiltinFmts::by_code(code) }
-    fn is_builtin_id(id: i32) -> bool         { BuiltinFmts::contains_id(id) }
-
     /// True if `id` is a built-in or registered custom format ID.
     pub(crate) fn is_known_id(id: i32, custom_fmts: &[NumFmt]) -> bool {
-        Self::is_builtin_id(id) || custom_fmts.iter().any(|f| f.num_fmt_id == id)
+        BuiltinFmts::contains_id(id) || custom_fmts.iter().any(|f| f.num_fmt_id == id)
     }
 
     /// Build a `NumFmt` from a `num_fmt_id`; unknown IDs fall back to General (0).
@@ -438,8 +435,8 @@ impl NumFmt {
             return fmt.clone();
         }
         // Clamp unknown / negative IDs to 0 (General).
-        let resolved = if Self::is_builtin_id(id) { id } else { 0 };
-        // Gap IDs (49–163) not in custom_fmts silently fall back to General.
+        let resolved = if BuiltinFmts::contains_id(id) { id } else { 0 };
+        // Gap IDs (49–163) not in custom_fmts silently fall back to General (debug builds only).
         debug_assert!(
             id < 0 || resolved == id,
             "num_fmt_id {id} is unknown (not a built-in ECMA-376 ID and not in custom_fmts); \
@@ -447,14 +444,14 @@ impl NumFmt {
         );
         NumFmt {
             num_fmt_id: resolved,
-            format_code: Self::format_code_for_id(resolved, &[]).to_string(),
+            format_code: BuiltinFmts::by_id(resolved).unwrap_or("general").to_string(),
         }
     }
 
     /// Build a `NumFmt` from a format code; resolves to the built-in ID, or
     /// `-1` as a sentinel for custom codes (real ID assigned at persist time).
     pub fn from_format_code(code: &str) -> Self {
-        let num_fmt_id = Self::builtin_id(code).unwrap_or(-1);
+        let num_fmt_id = BuiltinFmts::by_code(code).unwrap_or(-1);
         NumFmt {
             num_fmt_id,
             format_code: code.to_string(),
@@ -482,7 +479,7 @@ impl NumFmt {
     /// Built-in codes resolve immediately with their ECMA-376 ID.
     /// Custom codes are assigned an ID ≥ 164 on first registration and re-used thereafter.
     pub fn get_or_register(code: &str, num_fmts: &mut Vec<NumFmt>) -> Self {
-        if let Some(id) = Self::builtin_id(code) {
+        if let Some(id) = BuiltinFmts::by_code(code) {
             return NumFmt {
                 num_fmt_id: id,
                 format_code: code.to_string(),

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -333,6 +333,16 @@ pub struct Style {
     pub quote_prefix: bool,
 }
 
+/// Number format to apply when storing a parsed cell value.
+/// No `LocaleDateTime` variant: numFmtId 22 is set only by formula evaluation, not user input.
+#[derive(Debug, PartialEq)]
+pub(crate) enum NumFmtSpec {
+    /// Locale short date (numFmtId 14).
+    LocaleDate,
+    /// A literal format string (ISO dates, currency, percent, …).
+    Literal(String),
+}
+
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub struct NumFmt {
@@ -463,18 +473,6 @@ impl NumFmt {
             num_fmt_id,
             format_code: code.to_string(),
         }
-    }
-
-    /// Resolve format code; unknown/negative IDs return `"General"`.
-    pub(crate) fn format_code_for_id(id: i32, custom_fmts: &[NumFmt]) -> &str {
-        if let Some(code) = DefaultFmts::by_id(id) {
-            return code;
-        }
-        custom_fmts
-            .iter()
-            .find(|f| f.num_fmt_id == id)
-            .map(|f| f.format_code.as_str())
-            .unwrap_or(DefaultFmts::by_id(0).unwrap_or("General"))
     }
 
     /// Returns the `NumFmt` for `code`, registering it in `num_fmts` if it is not yet present.

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -387,6 +387,7 @@ impl NumFmt {
     /// `format_code` at persist time, and `Styles::get_style_index` compares
     /// styles by `format_code`, so deduplication is correct regardless.
     pub fn from_format_code(code: &str) -> Self {
+        // Only 
         let num_fmt_id = Self::builtin_id(code).unwrap_or(-1);
         NumFmt {
             num_fmt_id,
@@ -394,9 +395,9 @@ impl NumFmt {
         }
     }
 
-    /// Returns a fully-resolved `NumFmt`, registering a new custom entry in
-    /// `num_fmts` if the code isn't already there.  Use this when you have
-    /// mutable access to the styles registry (e.g. inside `Styles` methods).
+
+    /// Covers functions `get_num_fmt()` and `get_new_num_fmt_index()` previously in file number_format.rs 
+    /// `Styles` methods .
     pub fn get_or_register(code: &str, num_fmts: &mut Vec<NumFmt>) -> Self {
         if let Some(id) = Self::builtin_id(code) {
             return NumFmt {

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -370,7 +370,7 @@ impl<'de> Deserialize<'de> for NumFmt {
 
             // Legacy path: `num_fmt` was serialized as a plain format-code string.
             fn visit_str<E: de::Error>(self, value: &str) -> Result<NumFmt, E> {
-                Ok(NumFmt::from_format_code(value))
+                Ok(NumFmt::from_format_code(value, None))
             }
 
             fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<NumFmt, M::Error> {
@@ -388,7 +388,7 @@ impl<'de> Deserialize<'de> for NumFmt {
                 let format_code =
                     format_code.ok_or_else(|| de::Error::missing_field("format_code"))?;
                 // format_code is the source of truth; re-derive id for consistency.
-                let derived = NumFmt::from_format_code(&format_code);
+                let derived = NumFmt::from_format_code(&format_code, None);
                 let stored_id = num_fmt_id.unwrap_or(derived.num_fmt_id);
                 // Accept stored_id only when it is provably consistent with format_code:
                 //  • exact match: both agree on the ID
@@ -472,33 +472,65 @@ impl NumFmt {
 
     /// format code resolves to the built-in ID, or
     /// `-1` as a sentinel for custom codes (real ID assigned at persist time).
-    pub fn from_format_code(code: &str) -> Self {
-        let num_fmt_id = DefaultFmts::by_code(code).unwrap_or(-1);
+    pub fn from_format_code(code: &str, num_fmts: Option<&mut Vec<NumFmt>>) -> Self {
+        // let num_fmt_id = DefaultFmts::by_code(code).unwrap_or(-1);
+
+        if let Some(num_fmt_id) = DefaultFmts::by_code(code) {
+            return NumFmt {
+                num_fmt_id,
+                format_code: code.to_string(),
+            };
+        }
+
+        if code.eq_ignore_ascii_case("general") {
+            return NumFmt {
+                num_fmt_id: 0,
+                format_code: DefaultFmts::id_fmt_or_general(0),
+            };
+        }
+
+        if let Some(fmts) = num_fmts {
+            if let Some(fmt) = fmts.iter().find(|f| f.format_code == code) {
+                return fmt.clone();
+            } else {
+                return NumFmt::get_or_register(code, fmts);
+            }
+        }
+
         NumFmt {
-            num_fmt_id,
+            num_fmt_id: -1,
             format_code: code.to_string(),
         }
     }
 
     /// Returns the `NumFmt` for `code`, registering it in `num_fmts` if it is not yet present.
-    ///
-    /// Built-in codes resolve immediately with their ID.
     /// Custom codes are assigned an ID ≥ 164 on first registration and re-used thereafter.
     pub fn get_or_register(code: &str, num_fmts: &mut Vec<NumFmt>) -> Self {
+        // Built-in codes resolve immediately with their ID.
         if let Some(id) = DefaultFmts::by_code(code) {
             return NumFmt {
                 num_fmt_id: id,
                 format_code: code.to_string(),
             };
         }
+
+        if code.eq_ignore_ascii_case("general") {
+            return NumFmt {
+                num_fmt_id: 0,
+                format_code: DefaultFmts::id_fmt_or_general(0),
+            };
+        }
+
         if let Some(existing) = num_fmts.iter().find(|f| f.format_code == code) {
             return existing.clone();
         }
+
         // ECMA-376 custom IDs must be ≥ 164; find the lowest unused one.
         let mut new_id = ECMA_CUSTOM_FMT_MIN_ID;
         while num_fmts.iter().any(|f| f.num_fmt_id == new_id) {
             new_id += 1;
         }
+
         let fmt = NumFmt {
             num_fmt_id: new_id,
             format_code: code.to_string(),

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -3,9 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
 
 use crate::expressions::token::Error;
-use crate::number_format::{
-    DEFAULT_NUM_FMTS,
-};
+use crate::number_format::BuiltinFmts;
 
 fn default_as_false() -> bool {
     false
@@ -419,30 +417,8 @@ impl NumFmt {
         }
     }
 
-    /// ECMA-376 numFmtId 14: locale short date.
-    pub(crate) const SHORT_DATE_ID: i32 = 14;
-    /// ECMA-376 numFmtId 22: locale short date+time.
-    pub(crate) const SHORT_DATETIME_ID: i32 = 22;
-    
-    fn builtins() -> &'static [&'static str] {
-        DEFAULT_NUM_FMTS
-    }
-
-    fn builtin_id(code: &str) -> Option<i32> {
-        Self::builtins()
-            .iter()
-            .position(|&s| s == code)
-            .map(|i| i as i32)
-    }
-
-    fn is_builtin_id(id: i32) -> bool {
-        usize::try_from(id).is_ok_and(|i| i < Self::builtins().len())
-    }
-    
-    /// True if `id` is a locale date format (14 or 22).
-    pub(crate) fn is_locale_date_id(id: i32) -> bool {
-        id == Self::SHORT_DATE_ID || id == Self::SHORT_DATETIME_ID
-    }
+    fn builtin_id(code: &str) -> Option<i32>  { BuiltinFmts::by_code(code) }
+    fn is_builtin_id(id: i32) -> bool         { BuiltinFmts::contains_id(id) }
 
     /// True if `id` is a built-in or registered custom format ID.
     pub(crate) fn is_known_id(id: i32, custom_fmts: &[NumFmt]) -> bool {
@@ -454,12 +430,8 @@ impl NumFmt {
         if let Some(fmt) = custom_fmts.iter().find(|f| f.num_fmt_id == id) {
             return fmt.clone();
         }
-        // Clamp out-of-range / negative IDs to 0 (General).
-        let resolved = usize::try_from(id)
-            .ok()
-            .filter(|&i| i < Self::builtins().len())
-            .map(|i| i as i32)
-            .unwrap_or(0);
+        // Clamp unknown / negative IDs to 0 (General).
+        let resolved = if Self::is_builtin_id(id) { id } else { 0 };
         // Gap IDs (49–163) not in custom_fmts silently fall back to General.
         debug_assert!(
             id < 0 || resolved == id,
@@ -484,18 +456,24 @@ impl NumFmt {
 
     /// Resolve a `num_fmt_id` to its format code; unknown/negative IDs return `"general"`.
     pub(crate) fn format_code_for_id(id: i32, custom_fmts: &[NumFmt]) -> &str {
-        if let Some(i) = usize::try_from(id).ok().filter(|&i| i < Self::builtins().len()) {
-            return Self::builtins()[i];
+        if let Some(code) = BuiltinFmts::by_id(id) {
+            return code;
         }
         custom_fmts
             .iter()
             .find(|f| f.num_fmt_id == id)
             .map(|f| f.format_code.as_str())
-            .unwrap_or(Self::builtins()[0])
+            .unwrap_or("general")
     }
 
-    /// Covers functions `get_num_fmt()` and `get_new_num_fmt_index()` previously in file number_format.rs
-    /// `Styles` methods .
+    /// ECMA-376 §18.8.30: custom numFmtIds must be ≥ 164.
+    /// IDs 0–163 are reserved for built-in formats; assigning lower IDs corrupts XLSX readers.
+    const ECMA_CUSTOM_FMT_MIN_ID: i32 = 164;
+
+    /// Returns the `NumFmt` for `code`, registering it in `num_fmts` if it is not yet present.
+    ///
+    /// Built-in codes resolve immediately with their ECMA-376 ID.
+    /// Custom codes are assigned an ID ≥ 164 on first registration and re-used thereafter.
     pub fn get_or_register(code: &str, num_fmts: &mut Vec<NumFmt>) -> Self {
         if let Some(id) = Self::builtin_id(code) {
             return NumFmt {
@@ -506,8 +484,8 @@ impl NumFmt {
         if let Some(existing) = num_fmts.iter().find(|f| f.format_code == code) {
             return existing.clone();
         }
-        // Find the lowest custom ID (≥ built-in table length) not already in use.
-        let mut new_id = Self::builtins().len() as i32;
+        // ECMA-376 custom IDs must be ≥ 164; find the lowest unused one.
+        let mut new_id = Self::ECMA_CUSTOM_FMT_MIN_ID;
         while num_fmts.iter().any(|f| f.num_fmt_id == new_id) {
             new_id += 1;
         }

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, fmt::Display};
 
 use crate::expressions::token::Error;
 use crate::number_format::{
-    DEFAULT_NUM_FMTS, SHORT_DATE_FMT_ID, SHORT_DATE_TIME_FMT_ID,
+    DEFAULT_NUM_FMTS,
 };
 
 fn default_as_false() -> bool {
@@ -341,9 +341,8 @@ pub struct NumFmt {
     pub format_code: String,
 }
 
-// Custom deserializer so that workbooks serialized before the `String` →
-// `NumFmt` migration can still be loaded.  Old JSON has `"num_fmt": "mm/dd/yy"`;
-// new JSON has `"num_fmt": {"num_fmt_id": 14, "format_code": "mm/dd/yy"}`.
+// Custom deserializer for backwards compat: old JSON had `"num_fmt": "mm/dd/yy"` (string);
+// new JSON has `"num_fmt": {"num_fmt_id": 14, "format_code": "mm/dd/yy"}` (object).
 impl<'de> Deserialize<'de> for NumFmt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -377,12 +376,9 @@ impl<'de> Deserialize<'de> for NumFmt {
                 }
                 let format_code = format_code
                     .ok_or_else(|| de::Error::missing_field("format_code"))?;
-                // Re-derive num_fmt_id from format_code so the two fields are always
-                // consistent.  If the incoming id disagrees (e.g. a hand-edited file),
-                // format_code is treated as the source of truth.
+                // format_code is the source of truth; re-derive id for consistency.
                 let derived = NumFmt::from_format_code(&format_code);
-                // Accept the stored id only if it matches what we'd derive — this lets
-                // custom IDs (≥ 164) round-trip correctly when both fields are present.
+                // Accept stored id only if consistent — lets custom IDs (≥ 164) round-trip.
                 let stored_id = num_fmt_id.unwrap_or(derived.num_fmt_id);
                 let fmt = if stored_id == derived.num_fmt_id || derived.num_fmt_id == -1 {
                     NumFmt { num_fmt_id: stored_id, format_code }
@@ -398,10 +394,7 @@ impl<'de> Deserialize<'de> for NumFmt {
     }
 }
 
-// Emit only the format_code string.  The Deserialize impl handles both this
-// string form and the legacy struct form, so round-trips are lossless for
-// built-in IDs (re-derived by from_format_code) and for custom IDs (sentinel
-// -1, re-resolved at persist time by get_or_register).
+// Serialize as format_code string; Deserialize handles both this and the legacy struct form.
 impl Serialize for NumFmt {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.format_code)
@@ -418,13 +411,7 @@ impl Default for NumFmt {
 }
 
 impl NumFmt {
-    /// Construct a `NumFmt` from a known `num_fmt_id` and `format_code`.
-    ///
-    /// Prefer [`NumFmt::from_id`], [`NumFmt::from_format_code`], or
-    /// [`NumFmt::get_or_register`] when working within the engine.  This
-    /// constructor exists for callers (e.g. XLSX import) that already hold a
-    /// validated id/code pair from an external source and need to build the
-    /// struct directly.
+    /// Construct a `NumFmt` directly from a known id/code pair (e.g. XLSX import).
     pub fn new(num_fmt_id: i32, format_code: String) -> Self {
         NumFmt {
             num_fmt_id,
@@ -432,22 +419,15 @@ impl NumFmt {
         }
     }
 
-    /// ECMA-376 numFmtId for the locale-derived short date (e.g. "m/d/yy" in en-US).
-    pub(crate) const SHORT_DATE_ID: i32 = SHORT_DATE_FMT_ID;
-    /// ECMA-376 numFmtId for the locale-derived short date+time (e.g. "m/d/yy h:mm").
-    pub(crate) const SHORT_DATETIME_ID: i32 = SHORT_DATE_TIME_FMT_ID;
+    /// ECMA-376 numFmtId 14: locale short date.
+    pub(crate) const SHORT_DATE_ID: i32 = 14;
+    /// ECMA-376 numFmtId 22: locale short date+time.
+    pub(crate) const SHORT_DATETIME_ID: i32 = 22;
     
-    /// The ECMA-376 built-in format strings, indexed by numFmtId.
-    ///
-    /// Prefer this accessor over importing `DEFAULT_NUM_FMTS` directly —
-    /// callers get `.iter()`, `.len()`, and `.get(i)` without depending on
-    /// the private constant.
     fn builtins() -> &'static [&'static str] {
         DEFAULT_NUM_FMTS
     }
 
-    /// Return the ECMA-376 built-in `numFmtId` for `code`, or `None` if the
-    /// code is not in the built-in table.
     fn builtin_id(code: &str) -> Option<i32> {
         Self::builtins()
             .iter()
@@ -455,28 +435,21 @@ impl NumFmt {
             .map(|i| i as i32)
     }
 
-    /// Return `true` if `id` is a valid ECMA-376 built-in numFmtId.
     fn is_builtin_id(id: i32) -> bool {
         usize::try_from(id).is_ok_and(|i| i < Self::builtins().len())
     }
     
-    /// Return `true` if `id` is one of the two locale-derived format IDs (14 or 22).
+    /// True if `id` is a locale date format (14 or 22).
     pub(crate) fn is_locale_date_id(id: i32) -> bool {
         id == Self::SHORT_DATE_ID || id == Self::SHORT_DATETIME_ID
     }
 
-    /// Return `true` if `id` is either a built-in ECMA-376 ID or registered
-    /// in `custom_fmts`.  Use this to validate an ID before storing it in a
-    /// `CellXfs` entry.
+    /// True if `id` is a built-in or registered custom format ID.
     pub(crate) fn is_known_id(id: i32, custom_fmts: &[NumFmt]) -> bool {
         Self::is_builtin_id(id) || custom_fmts.iter().any(|f| f.num_fmt_id == id)
     }
 
-    /// Build a `NumFmt` from a known `num_fmt_id`.
-    ///
-    /// Looks up the format code from the workbook's custom list first,
-    /// then falls back to the ECMA-376 built-in table. Unknown IDs resolve
-    /// to General (ID 0).
+    /// Build a `NumFmt` from a `num_fmt_id`; unknown IDs fall back to General (0).
     pub fn from_id(id: i32, custom_fmts: &[NumFmt]) -> Self {
         if let Some(fmt) = custom_fmts.iter().find(|f| f.num_fmt_id == id) {
             return fmt.clone();
@@ -487,9 +460,7 @@ impl NumFmt {
             .filter(|&i| i < Self::builtins().len())
             .map(|i| i as i32)
             .unwrap_or(0);
-        // IDs in the ECMA-376 gap (49–163) or any positive ID not registered in
-        // custom_fmts will silently fall back to General.  Flag this in debug
-        // builds — it most likely indicates a misconfigured xlsx import.
+        // Gap IDs (49–163) not in custom_fmts silently fall back to General.
         debug_assert!(
             id < 0 || resolved == id,
             "num_fmt_id {id} is unknown (not a built-in ECMA-376 ID and not in custom_fmts); \
@@ -501,14 +472,8 @@ impl NumFmt {
         }
     }
 
-    /// Build a `NumFmt` from a format code string.
-    ///
-    /// For ECMA-376 built-in codes the canonical ID is resolved immediately.
-    /// For custom codes (not in the built-in table) `num_fmt_id` is `-1` — an
-    /// unambiguous sentinel distinct from all valid IDs (which are ≥ 0).
-    /// `Styles::get_style_index_or_create` re-derives the real ID from
-    /// `format_code` at persist time, and `Styles::get_style_index` compares
-    /// styles by `format_code`, so deduplication is correct regardless.
+    /// Build a `NumFmt` from a format code; resolves to the built-in ID, or
+    /// `-1` as a sentinel for custom codes (real ID assigned at persist time).
     pub fn from_format_code(code: &str) -> Self {
         let num_fmt_id = Self::builtin_id(code).unwrap_or(-1);
         NumFmt {
@@ -517,15 +482,8 @@ impl NumFmt {
         }
     }
 
-    /// Resolve a `num_fmt_id` to its format code string.
-    ///
-    /// Checks the ECMA-376 built-in table first (O(1) bounds check), then
-    /// falls back to a linear scan of `custom_fmts` (workbook-specific entries).
-    /// Unknown or negative IDs — including the `-1` sentinel used by
-    /// `from_format_code` — return `"general"` (ID 0).
-    pub(crate) fn format_code_for_id<'a>(id: i32, custom_fmts: &'a [NumFmt]) -> &'a str {
-        // Fast path: most IDs are ECMA-376 builtins.  A single bounds check
-        // avoids the custom_fmts scan for the common case.
+    /// Resolve a `num_fmt_id` to its format code; unknown/negative IDs return `"general"`.
+    pub(crate) fn format_code_for_id(id: i32, custom_fmts: &[NumFmt]) -> &str {
         if let Some(i) = usize::try_from(id).ok().filter(|&i| i < Self::builtins().len()) {
             return Self::builtins()[i];
         }

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -376,15 +376,22 @@ impl<'de> Deserialize<'de> for NumFmt {
                     .ok_or_else(|| de::Error::missing_field("format_code"))?;
                 // format_code is the source of truth; re-derive id for consistency.
                 let derived = NumFmt::from_format_code(&format_code);
-                // Accept stored id only if consistent — lets custom IDs (≥ 164) round-trip.
                 let stored_id = num_fmt_id.unwrap_or(derived.num_fmt_id);
-                let fmt = if stored_id == derived.num_fmt_id || derived.num_fmt_id == -1 {
-                    NumFmt { num_fmt_id: stored_id, format_code }
+                // Accept stored_id only when it is provably consistent with format_code:
+                //  • exact match: both agree on the ID
+                //  • custom round-trip: code is not a built-in (derived == -1) and the
+                //    stored ID is in the ECMA-376 custom range (≥ 164); this lets a
+                //    registered custom ID survive a serialize→deserialize round-trip.
+                // Anything else (e.g. a built-in-range ID paired with a custom code)
+                // is suspect — discard the stored ID and keep the derived value.
+                let num_fmt_id = if stored_id == derived.num_fmt_id {
+                    stored_id
+                } else if derived.num_fmt_id == -1 && stored_id >= NumFmt::ECMA_CUSTOM_FMT_MIN_ID {
+                    stored_id
                 } else {
-                    // Mismatch — trust format_code, discard stale id.
-                    derived
+                    derived.num_fmt_id
                 };
-                Ok(fmt)
+                Ok(NumFmt { num_fmt_id, format_code })
             }
         }
 

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Display};
 
 use crate::expressions::token::Error;
-use crate::number_format::BuiltinFmts;
+use crate::number_format::DefaultFmts;
 
 fn default_as_false() -> bool {
     false
@@ -369,11 +369,13 @@ impl<'de> Deserialize<'de> for NumFmt {
                     match key.as_str() {
                         "num_fmt_id" => num_fmt_id = Some(map.next_value()?),
                         "format_code" => format_code = Some(map.next_value()?),
-                        _ => { let _: serde::de::IgnoredAny = map.next_value()?; }
+                        _ => {
+                            let _: serde::de::IgnoredAny = map.next_value()?;
+                        }
                     }
                 }
-                let format_code = format_code
-                    .ok_or_else(|| de::Error::missing_field("format_code"))?;
+                let format_code =
+                    format_code.ok_or_else(|| de::Error::missing_field("format_code"))?;
                 // format_code is the source of truth; re-derive id for consistency.
                 let derived = NumFmt::from_format_code(&format_code);
                 let stored_id = num_fmt_id.unwrap_or(derived.num_fmt_id);
@@ -384,14 +386,17 @@ impl<'de> Deserialize<'de> for NumFmt {
                 //    registered custom ID survive a serialize→deserialize round-trip.
                 // Anything else (e.g. a built-in-range ID paired with a custom code)
                 // is suspect — discard the stored ID and keep the derived value.
-                let num_fmt_id = if stored_id == derived.num_fmt_id {
-                    stored_id
-                } else if derived.num_fmt_id == -1 && stored_id >= NumFmt::ECMA_CUSTOM_FMT_MIN_ID {
+                let num_fmt_id = if stored_id == derived.num_fmt_id
+                    || (derived.num_fmt_id == -1 && stored_id >= NumFmt::ECMA_CUSTOM_FMT_MIN_ID)
+                {
                     stored_id
                 } else {
                     derived.num_fmt_id
                 };
-                Ok(NumFmt { num_fmt_id, format_code })
+                Ok(NumFmt {
+                    num_fmt_id,
+                    format_code,
+                })
             }
         }
 
@@ -408,10 +413,7 @@ impl Serialize for NumFmt {
 
 impl Default for NumFmt {
     fn default() -> Self {
-        NumFmt {
-            num_fmt_id: 0,
-            format_code: "general".to_string(),
-        }
+        Self::from_id(0, &[])
     }
 }
 
@@ -426,7 +428,7 @@ impl NumFmt {
 
     /// True if `id` is a built-in or registered custom format ID.
     pub(crate) fn is_known_id(id: i32, custom_fmts: &[NumFmt]) -> bool {
-        BuiltinFmts::contains_id(id) || custom_fmts.iter().any(|f| f.num_fmt_id == id)
+        DefaultFmts::contains_id(id) || custom_fmts.iter().any(|f| f.num_fmt_id == id)
     }
 
     /// Build a `NumFmt` from a `num_fmt_id`; unknown IDs fall back to General (0).
@@ -434,24 +436,29 @@ impl NumFmt {
         if let Some(fmt) = custom_fmts.iter().find(|f| f.num_fmt_id == id) {
             return fmt.clone();
         }
-        // Clamp unknown / negative IDs to 0 (General).
-        let resolved = if BuiltinFmts::contains_id(id) { id } else { 0 };
-        // Gap IDs (49–163) not in custom_fmts silently fall back to General (debug builds only).
-        debug_assert!(
-            id < 0 || resolved == id,
-            "num_fmt_id {id} is unknown (not a built-in ECMA-376 ID and not in custom_fmts); \
-             silently falling back to General (0)"
-        );
+        // Single lookup: built-in ID -> use it; unknown/negative -> fall back to General (0).
+        let (num_fmt_id, format_code) = match DefaultFmts::by_id(id) {
+            Some(code) => (id, code),
+            None => {
+                // Gap IDs (49–163) not in custom_fmts silently fall back (debug builds only).
+                debug_assert!(
+                    id < 0,
+                    "num_fmt_id {id} is unknown (not a built-in ECMA-376 ID and not in custom_fmts); \
+                     silently falling back to General (0)"
+                );
+                (0, "general")
+            }
+        };
         NumFmt {
-            num_fmt_id: resolved,
-            format_code: BuiltinFmts::by_id(resolved).unwrap_or("general").to_string(),
+            num_fmt_id,
+            format_code: format_code.to_string(),
         }
     }
 
     /// Build a `NumFmt` from a format code; resolves to the built-in ID, or
     /// `-1` as a sentinel for custom codes (real ID assigned at persist time).
     pub fn from_format_code(code: &str) -> Self {
-        let num_fmt_id = BuiltinFmts::by_code(code).unwrap_or(-1);
+        let num_fmt_id = DefaultFmts::by_code(code).unwrap_or(-1);
         NumFmt {
             num_fmt_id,
             format_code: code.to_string(),
@@ -460,7 +467,7 @@ impl NumFmt {
 
     /// Resolve a `num_fmt_id` to its format code; unknown/negative IDs return `"general"`.
     pub(crate) fn format_code_for_id(id: i32, custom_fmts: &[NumFmt]) -> &str {
-        if let Some(code) = BuiltinFmts::by_id(id) {
+        if let Some(code) = DefaultFmts::by_id(id) {
             return code;
         }
         custom_fmts
@@ -479,7 +486,7 @@ impl NumFmt {
     /// Built-in codes resolve immediately with their ECMA-376 ID.
     /// Custom codes are assigned an ID ≥ 164 on first registration and re-used thereafter.
     pub fn get_or_register(code: &str, num_fmts: &mut Vec<NumFmt>) -> Self {
-        if let Some(id) = BuiltinFmts::by_code(code) {
+        if let Some(id) = DefaultFmts::by_code(code) {
             return NumFmt {
                 num_fmt_id: id,
                 format_code: code.to_string(),

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -18,8 +18,7 @@ pub struct Metadata {
     pub application: String,
     pub app_version: String,
     pub creator: String,
-    pub last_modified_by: String, // Search custom formats first (by their stored ID, not position).
-
+    pub last_modified_by: String,
     pub created: String,       // "2020-08-06T21:20:53Z",
     pub last_modified: String, //"2020-11-20T16:24:35"
 }

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -334,7 +334,7 @@ pub struct Style {
     pub quote_prefix: bool,
 }
 
-#[derive(Serialize, Encode, Decode, Debug, PartialEq, Eq, Clone)]
+#[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub struct NumFmt {
     pub num_fmt_id: i32,
@@ -383,6 +383,16 @@ impl<'de> Deserialize<'de> for NumFmt {
         }
 
         deserializer.deserialize_any(NumFmtVisitor)
+    }
+}
+
+// Emit only the format_code string.  The Deserialize impl handles both this
+// string form and the legacy struct form, so round-trips are lossless for
+// built-in IDs (re-derived by from_format_code) and for custom IDs (sentinel
+// -1, re-resolved at persist time by get_or_register).
+impl Serialize for NumFmt {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.format_code)
     }
 }
 

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -1,4 +1,5 @@
 use crate::{
+    constants::{SHORT_DATETIME_ID, SHORT_DATE_ID},
     expressions::{parser::Node, token::OpProduct, types::CellReferenceIndex},
     formatter::parser::{ParsePart, Parser},
     functions::Function,
@@ -96,8 +97,8 @@ impl<'a> Model<'a> {
             .ok()?;
         // Check numFmtId directly: locale IDs 14/22 may not reverse-map reliably from their string.
         match style.num_fmt.num_fmt_id {
-            DefaultFmts::SHORT_DATE_ID => Some(Units::LocaleDate),
-            DefaultFmts::SHORT_DATETIME_ID => Some(Units::LocaleDateTime),
+            SHORT_DATE_ID => Some(Units::LocaleDate),
+            SHORT_DATETIME_ID => Some(Units::LocaleDateTime),
             _ => get_units_from_format_string(&style.num_fmt.format_code),
         }
     }

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -25,9 +25,8 @@ pub enum Units {
         precision: i32,
         num_fmt: String,
     },
-    /// Date-only functions (DATE, TODAY): store numFmtId 14 so the display
-    /// derives its pattern from the active locale at render time.
     LocaleDate,
+    LocaleDateTime,
     Date(String),
 }
 
@@ -37,7 +36,9 @@ impl Units {
             Units::Number { num_fmt, .. } => num_fmt.to_string(),
             Units::Currency { num_fmt, .. } => num_fmt.to_string(),
             Units::Percentage { num_fmt, .. } => num_fmt.to_string(),
-            Units::LocaleDate => String::new(), // never used; ID-14 path skips get_num_fmt
+            Units::LocaleDate | Units::LocaleDateTime => {
+                unreachable!("locale date IDs are handled before get_num_fmt() is ever called")
+            }
             Units::Date(num_fmt) => num_fmt.to_string(),
         }
     }
@@ -47,6 +48,7 @@ impl Units {
             Units::Currency { precision, .. } => *precision,
             Units::Percentage { precision, .. } => *precision,
             Units::LocaleDate => 0,
+            Units::LocaleDateTime => 0,
             Units::Date(_) => 0,
         }
     }
@@ -378,28 +380,13 @@ impl<'a> Model<'a> {
     }
 
     fn units_fn_dates(&self, _args: &[Node], _cell: &CellReferenceIndex) -> Option<Units> {
-        // Signal that the cell should use numFmtId 14 (LOCALE_SHORTself.compute_node_units(parsed_formula,_DATE_FMT_ID).
+        // Signal that the cell should use numFmtId 14 (LOCALE_SHORT_DATE_FMT_ID).
         // The display functions derive the actual pattern from the active locale
         // at render time, so locale switches take effect without a re-edit.
         Some(Units::LocaleDate)
     }
 
     fn units_fn_date_times(&self, _args: &[Node], _cell: &CellReferenceIndex) -> Option<Units> {
-        let mut date_short = self.locale.dates.date_formats.short.clone();
-        // We want always 4 digit year. So if it is not already the case, we replace yy by yyyy
-        if !date_short.contains("yyyy") {
-            date_short = date_short.replace("yy", "yyyy");
-        }
-        // NB: full and medium time formats might include timezone info (in the form of z or zzzz)
-        let time_short_template = &self.locale.dates.time_formats.short;
-        let time_short = time_short_template.replace('a', "AM/PM");
-        // This would be something like: "{1}, {0}"
-        let date_time_short_template = &self.locale.dates.date_time_formats.short;
-        let date_time_short = date_time_short_template
-            .replace("{0}", time_short.trim())
-            .replace("{1}", &date_short);
-
-        // FIXME: Remove weird spaces (we should do that in the locale loading phase)
-        Some(Units::Date(date_time_short.replace(' ', " ")))
+        Some(Units::LocaleDateTime)
     }
 }

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -94,10 +94,7 @@ impl<'a> Model<'a> {
                 cell_reference.column,
             )
             .ok()?;
-        // Check the raw numFmtId before parsing the format string.  For locale
-        // dates (ID 14/22), get_style() resolves the ID to an en-US literal like
-        // "mm-dd-yy" — relying on that string reverse-mapping back to ID 14 is a
-        // fragile coincidence.  Checking the ID explicitly is exact and cheap.
+        // Check numFmtId directly: locale IDs 14/22 may not reverse-map reliably from their string.
         match style.num_fmt.num_fmt_id {
             NumFmt::SHORT_DATE_ID => Some(Units::LocaleDate),
             NumFmt::SHORT_DATETIME_ID => Some(Units::LocaleDateTime),
@@ -382,13 +379,11 @@ impl<'a> Model<'a> {
     }
 
     fn units_fn_dates(&self, _args: &[Node], cell: &CellReferenceIndex) -> Option<Units> {
-        // Signal that the cell should use numFmtId 14 (locale short date).
-        // Exception: if the cell already has an explicit non-date format (e.g.
-        // "#,##0"), preserve it rather than overwriting with the locale date.
+        // Preserve explicit non-date formats; only apply locale date if appropriate.
         if let Ok(style) = self.get_style_for_cell(cell.sheet, cell.row, cell.column) {
             let id = style.num_fmt.num_fmt_id;
             if id != 0 && !NumFmt::is_locale_date_id(id) {
-                // Explicit format — only overwrite if it is already date-like.
+                // Only overwrite if already date-like.
                 if !matches!(
                     get_units_from_format_string(&style.num_fmt.format_code),
                     Some(Units::Date(_))
@@ -404,13 +399,14 @@ impl<'a> Model<'a> {
         // Same logic as units_fn_dates: preserve any explicit non-datetime format.
         if let Ok(style) = self.get_style_for_cell(cell.sheet, cell.row, cell.column) {
             let id = style.num_fmt.num_fmt_id;
-            if id != 0 && !NumFmt::is_locale_date_id(id) {
-                if !matches!(
+            if id != 0
+                && !NumFmt::is_locale_date_id(id)
+                && !matches!(
                     get_units_from_format_string(&style.num_fmt.format_code),
                     Some(Units::Date(_))
-                ) {
-                    return None;
-                }
+                )
+            {
+                return None;
             }
         }
         Some(Units::LocaleDateTime)

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -331,8 +331,13 @@ impl<'a> Model<'a> {
             Function::Tbilleq => self.units_fn_percentage_2(args, cell),
             Function::Tbillprice => self.units_fn_currency(args, cell),
             Function::Tbillyield => self.units_fn_percentage_2(args, cell),
-            Function::Date => self.units_fn_dates(args, cell),
-            Function::Today => self.units_fn_dates(args, cell),
+            Function::Date
+            | Function::Edate
+            | Function::Eomonth
+            | Function::Workday
+            | Function::WorkdayIntl
+            | Function::Datevalue
+            | Function::Today => self.units_fn_dates(args, cell),
             Function::Now => self.units_fn_date_times(args, cell),
             _ => None,
         }

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -99,8 +99,8 @@ impl<'a> Model<'a> {
         // "mm-dd-yy" — relying on that string reverse-mapping back to ID 14 is a
         // fragile coincidence.  Checking the ID explicitly is exact and cheap.
         match style.num_fmt.num_fmt_id {
-            NumFmt::LOCALE_DATE_ID => Some(Units::LocaleDate),
-            NumFmt::LOCALE_DATETIME_ID => Some(Units::LocaleDateTime),
+            NumFmt::SHORT_DATE_ID => Some(Units::LocaleDate),
+            NumFmt::SHORT_DATETIME_ID => Some(Units::LocaleDateTime),
             _ => get_units_from_format_string(&style.num_fmt.format_code),
         }
     }
@@ -381,14 +381,38 @@ impl<'a> Model<'a> {
         })
     }
 
-    fn units_fn_dates(&self, _args: &[Node], _cell: &CellReferenceIndex) -> Option<Units> {
-        // Signal that the cell should use numFmtId 14 (LOCALE_SHORT_DATE_FMT_ID).
-        // The display functions derive the actual pattern from the active locale
-        // at render time, so locale switches take effect without a re-edit.
+    fn units_fn_dates(&self, _args: &[Node], cell: &CellReferenceIndex) -> Option<Units> {
+        // Signal that the cell should use numFmtId 14 (locale short date).
+        // Exception: if the cell already has an explicit non-date format (e.g.
+        // "#,##0"), preserve it rather than overwriting with the locale date.
+        if let Ok(style) = self.get_style_for_cell(cell.sheet, cell.row, cell.column) {
+            let id = style.num_fmt.num_fmt_id;
+            if id != 0 && !NumFmt::is_locale_date_id(id) {
+                // Explicit format — only overwrite if it is already date-like.
+                if !matches!(
+                    get_units_from_format_string(&style.num_fmt.format_code),
+                    Some(Units::Date(_))
+                ) {
+                    return None;
+                }
+            }
+        }
         Some(Units::LocaleDate)
     }
 
-    fn units_fn_date_times(&self, _args: &[Node], _cell: &CellReferenceIndex) -> Option<Units> {
+    fn units_fn_date_times(&self, _args: &[Node], cell: &CellReferenceIndex) -> Option<Units> {
+        // Same logic as units_fn_dates: preserve any explicit non-datetime format.
+        if let Ok(style) = self.get_style_for_cell(cell.sheet, cell.row, cell.column) {
+            let id = style.num_fmt.num_fmt_id;
+            if id != 0 && !NumFmt::is_locale_date_id(id) {
+                if !matches!(
+                    get_units_from_format_string(&style.num_fmt.format_code),
+                    Some(Units::Date(_))
+                ) {
+                    return None;
+                }
+            }
+        }
         Some(Units::LocaleDateTime)
     }
 }

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -3,6 +3,7 @@ use crate::{
     formatter::parser::{ParsePart, Parser},
     functions::Function,
     model::Model,
+    number_format::{LOCALE_SHORT_DATE_FMT_ID, LOCALE_SHORT_DATE_TIME_FMT_ID},
 };
 
 pub enum Units {
@@ -31,17 +32,6 @@ pub enum Units {
 }
 
 impl Units {
-    pub fn get_num_fmt(&self) -> String {
-        match self {
-            Units::Number { num_fmt, .. } => num_fmt.to_string(),
-            Units::Currency { num_fmt, .. } => num_fmt.to_string(),
-            Units::Percentage { num_fmt, .. } => num_fmt.to_string(),
-            Units::LocaleDate | Units::LocaleDateTime => {
-                unreachable!("locale date IDs are handled before get_num_fmt() is ever called")
-            }
-            Units::Date(num_fmt) => num_fmt.to_string(),
-        }
-    }
     pub fn get_precision(&self) -> i32 {
         match self {
             Units::Number { precision, .. } => *precision,
@@ -97,14 +87,21 @@ fn get_units_from_format_string(num_fmt: &str) -> Option<Units> {
 
 impl<'a> Model<'a> {
     fn compute_cell_units(&self, cell_reference: &CellReferenceIndex) -> Option<Units> {
-        let cell_style_res = &self.get_style_for_cell(
-            cell_reference.sheet,
-            cell_reference.row,
-            cell_reference.column,
-        );
-        match cell_style_res {
-            Ok(style) => get_units_from_format_string(&style.num_fmt),
-            Err(_) => None,
+        let style = self
+            .get_style_for_cell(
+                cell_reference.sheet,
+                cell_reference.row,
+                cell_reference.column,
+            )
+            .ok()?;
+        // Check the raw numFmtId before parsing the format string.  For locale
+        // dates (ID 14/22), get_style() resolves the ID to an en-US literal like
+        // "mm-dd-yy" — relying on that string reverse-mapping back to ID 14 is a
+        // fragile coincidence.  Checking the ID explicitly is exact and cheap.
+        match style.num_fmt.num_fmt_id {
+            LOCALE_SHORT_DATE_FMT_ID => Some(Units::LocaleDate),
+            LOCALE_SHORT_DATE_TIME_FMT_ID => Some(Units::LocaleDateTime),
+            _ => get_units_from_format_string(&style.num_fmt.format_code),
         }
     }
 

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -25,6 +25,9 @@ pub enum Units {
         precision: i32,
         num_fmt: String,
     },
+    /// Date-only functions (DATE, TODAY): store numFmtId 14 so the display
+    /// derives its pattern from the active locale at render time.
+    LocaleDate,
     Date(String),
 }
 
@@ -34,6 +37,7 @@ impl Units {
             Units::Number { num_fmt, .. } => num_fmt.to_string(),
             Units::Currency { num_fmt, .. } => num_fmt.to_string(),
             Units::Percentage { num_fmt, .. } => num_fmt.to_string(),
+            Units::LocaleDate => String::new(), // never used; ID-14 path skips get_num_fmt
             Units::Date(num_fmt) => num_fmt.to_string(),
         }
     }
@@ -42,6 +46,7 @@ impl Units {
             Units::Number { precision, .. } => *precision,
             Units::Currency { precision, .. } => *precision,
             Units::Percentage { precision, .. } => *precision,
+            Units::LocaleDate => 0,
             Units::Date(_) => 0,
         }
     }
@@ -373,12 +378,10 @@ impl<'a> Model<'a> {
     }
 
     fn units_fn_dates(&self, _args: &[Node], _cell: &CellReferenceIndex) -> Option<Units> {
-        let mut date_short = self.locale.dates.date_formats.short.clone();
-        // FIXME: We want always 4 digit year. So if it is not already the case, we replace yy by yyyy
-        if !date_short.contains("yyyy") {
-            date_short = date_short.replace("yy", "yyyy");
-        }
-        Some(Units::Date(date_short.replace(' ', " ")))
+        // Signal that the cell should use numFmtId 14 (LOCALE_SHORTself.compute_node_units(parsed_formula,_DATE_FMT_ID).
+        // The display functions derive the actual pattern from the active locale
+        // at render time, so locale switches take effect without a re-edit.
+        Some(Units::LocaleDate)
     }
 
     fn units_fn_date_times(&self, _args: &[Node], _cell: &CellReferenceIndex) -> Option<Units> {

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -3,7 +3,7 @@ use crate::{
     formatter::parser::{ParsePart, Parser},
     functions::Function,
     model::Model,
-    types::NumFmt,
+    number_format::BuiltinFmts,
 };
 
 pub enum Units {
@@ -96,8 +96,8 @@ impl<'a> Model<'a> {
             .ok()?;
         // Check numFmtId directly: locale IDs 14/22 may not reverse-map reliably from their string.
         match style.num_fmt.num_fmt_id {
-            NumFmt::SHORT_DATE_ID => Some(Units::LocaleDate),
-            NumFmt::SHORT_DATETIME_ID => Some(Units::LocaleDateTime),
+            BuiltinFmts::SHORT_DATE_ID => Some(Units::LocaleDate),
+            BuiltinFmts::SHORT_DATETIME_ID => Some(Units::LocaleDateTime),
             _ => get_units_from_format_string(&style.num_fmt.format_code),
         }
     }
@@ -378,37 +378,27 @@ impl<'a> Model<'a> {
         })
     }
 
+    /// Returns `true` when a locale date/datetime format should be applied to the cell.
+    /// Returns `false` if the cell already has an explicit non-date, non-locale format
+    /// that should be preserved.
+    fn should_override_with_locale_date(&self, cell: &CellReferenceIndex) -> bool {
+        let Ok(style) = self.get_style_for_cell(cell.sheet, cell.row, cell.column) else {
+            return true;
+        };
+        let id = style.num_fmt.num_fmt_id;
+        id == 0
+            || BuiltinFmts::is_locale_date(id)
+            || matches!(
+                get_units_from_format_string(&style.num_fmt.format_code),
+                Some(Units::Date(_))
+            )
+    }
+
     fn units_fn_dates(&self, _args: &[Node], cell: &CellReferenceIndex) -> Option<Units> {
-        // Preserve explicit non-date formats; only apply locale date if appropriate.
-        if let Ok(style) = self.get_style_for_cell(cell.sheet, cell.row, cell.column) {
-            let id = style.num_fmt.num_fmt_id;
-            if id != 0 && !NumFmt::is_locale_date_id(id) {
-                // Only overwrite if already date-like.
-                if !matches!(
-                    get_units_from_format_string(&style.num_fmt.format_code),
-                    Some(Units::Date(_))
-                ) {
-                    return None;
-                }
-            }
-        }
-        Some(Units::LocaleDate)
+        self.should_override_with_locale_date(cell).then_some(Units::LocaleDate)
     }
 
     fn units_fn_date_times(&self, _args: &[Node], cell: &CellReferenceIndex) -> Option<Units> {
-        // Same logic as units_fn_dates: preserve any explicit non-datetime format.
-        if let Ok(style) = self.get_style_for_cell(cell.sheet, cell.row, cell.column) {
-            let id = style.num_fmt.num_fmt_id;
-            if id != 0
-                && !NumFmt::is_locale_date_id(id)
-                && !matches!(
-                    get_units_from_format_string(&style.num_fmt.format_code),
-                    Some(Units::Date(_))
-                )
-            {
-                return None;
-            }
-        }
-        Some(Units::LocaleDateTime)
+        self.should_override_with_locale_date(cell).then_some(Units::LocaleDateTime)
     }
 }

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -195,7 +195,7 @@ impl<'a> Model<'a> {
                             Some(Units::Percentage {
                                 group_separator: false,
                                 precision: 2,
-                                num_fmt: "0.00%".to_string(),
+                                num_fmt: DefaultFmts::percent_dec(), // "0.00%"
                             })
                         }
                     }
@@ -219,7 +219,7 @@ impl<'a> Model<'a> {
                                     currency: currency.to_string(),
                                     group_separator: true,
                                     precision: 2,
-                                    num_fmt: format!("{currency}#,##0.00"),
+                                    num_fmt: format!("{currency}{}", DefaultFmts::comma_dec()),
                                 })
                             }
                         }
@@ -244,7 +244,7 @@ impl<'a> Model<'a> {
                                     currency: currency.to_string(),
                                     group_separator: true,
                                     precision: 2,
-                                    num_fmt: format!("{currency}#,##0.00"),
+                                    num_fmt: format!("{currency}{}", DefaultFmts::comma_dec()),
                                 })
                             }
                         }
@@ -366,7 +366,7 @@ impl<'a> Model<'a> {
         Some(Units::Percentage {
             group_separator: false,
             precision: 0,
-            num_fmt: "0%".to_string(),
+            num_fmt: DefaultFmts::percent_int(), // "0%"
         })
     }
 
@@ -374,7 +374,7 @@ impl<'a> Model<'a> {
         Some(Units::Percentage {
             group_separator: false,
             precision: 2,
-            num_fmt: "0.00%".to_string(),
+            num_fmt: DefaultFmts::percent_dec(), // "0.00%"
         })
     }
 

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -3,7 +3,7 @@ use crate::{
     formatter::parser::{ParsePart, Parser},
     functions::Function,
     model::Model,
-    number_format::BuiltinFmts,
+    number_format::DefaultFmts,
 };
 
 pub enum Units {
@@ -96,8 +96,8 @@ impl<'a> Model<'a> {
             .ok()?;
         // Check numFmtId directly: locale IDs 14/22 may not reverse-map reliably from their string.
         match style.num_fmt.num_fmt_id {
-            BuiltinFmts::SHORT_DATE_ID => Some(Units::LocaleDate),
-            BuiltinFmts::SHORT_DATETIME_ID => Some(Units::LocaleDateTime),
+            DefaultFmts::SHORT_DATE_ID => Some(Units::LocaleDate),
+            DefaultFmts::SHORT_DATETIME_ID => Some(Units::LocaleDateTime),
             _ => get_units_from_format_string(&style.num_fmt.format_code),
         }
     }
@@ -387,7 +387,7 @@ impl<'a> Model<'a> {
         };
         let id = style.num_fmt.num_fmt_id;
         id == 0
-            || BuiltinFmts::is_locale_date(id)
+            || DefaultFmts::is_locale_date(id)
             || matches!(
                 get_units_from_format_string(&style.num_fmt.format_code),
                 Some(Units::Date(_))
@@ -395,10 +395,12 @@ impl<'a> Model<'a> {
     }
 
     fn units_fn_dates(&self, _args: &[Node], cell: &CellReferenceIndex) -> Option<Units> {
-        self.should_override_with_locale_date(cell).then_some(Units::LocaleDate)
+        self.should_override_with_locale_date(cell)
+            .then_some(Units::LocaleDate)
     }
 
     fn units_fn_date_times(&self, _args: &[Node], cell: &CellReferenceIndex) -> Option<Units> {
-        self.should_override_with_locale_date(cell).then_some(Units::LocaleDateTime)
+        self.should_override_with_locale_date(cell)
+            .then_some(Units::LocaleDateTime)
     }
 }

--- a/base/src/units.rs
+++ b/base/src/units.rs
@@ -3,7 +3,7 @@ use crate::{
     formatter::parser::{ParsePart, Parser},
     functions::Function,
     model::Model,
-    number_format::{LOCALE_SHORT_DATE_FMT_ID, LOCALE_SHORT_DATE_TIME_FMT_ID},
+    types::NumFmt,
 };
 
 pub enum Units {
@@ -99,8 +99,8 @@ impl<'a> Model<'a> {
         // "mm-dd-yy" — relying on that string reverse-mapping back to ID 14 is a
         // fragile coincidence.  Checking the ID explicitly is exact and cheap.
         match style.num_fmt.num_fmt_id {
-            LOCALE_SHORT_DATE_FMT_ID => Some(Units::LocaleDate),
-            LOCALE_SHORT_DATE_TIME_FMT_ID => Some(Units::LocaleDateTime),
+            NumFmt::LOCALE_DATE_ID => Some(Units::LocaleDate),
+            NumFmt::LOCALE_DATETIME_ID => Some(Units::LocaleDateTime),
             _ => get_units_from_format_string(&style.num_fmt.format_code),
         }
     }

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -152,7 +152,7 @@ fn update_style(old_value: &Style, style_path: &str, value: &str) -> Result<Styl
             style.fill.pattern_type = "solid".to_string();
         }
         "num_fmt" => {
-            style.num_fmt = NumFmt::from_format_code(value);
+            style.num_fmt = NumFmt::from_format_code(value, None);
         }
         "alignment" => {
             if !value.is_empty() {

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     model::{FmtSettings, Model},
     types::{
-        Alignment, BorderItem, Cell, CellType, Col, HorizontalAlignment, SheetProperties,
+        Alignment, BorderItem, Cell, CellType, Col, HorizontalAlignment, NumFmt, SheetProperties,
         SheetState, Style, VerticalAlignment,
     },
     utils::is_valid_hex_color,
@@ -152,7 +152,7 @@ fn update_style(old_value: &Style, style_path: &str, value: &str) -> Result<Styl
             style.fill.pattern_type = "solid".to_string();
         }
         "num_fmt" => {
-            value.clone_into(&mut style.num_fmt);
+            style.num_fmt = NumFmt::from_format_code(value);
         }
         "alignment" => {
             if !value.is_empty() {

--- a/bindings/python/src/types.rs
+++ b/bindings/python/src/types.rs
@@ -294,7 +294,7 @@ impl From<&PyStyle> for Style {
     fn from(py_style: &PyStyle) -> Self {
         Style {
             alignment: py_style.alignment.as_ref().map(|a| a.into()),
-            num_fmt: NumFmt::from_format_code(&py_style.num_fmt),
+            num_fmt: NumFmt::from_format_code(&py_style.num_fmt, None),
             fill: (&py_style.fill).into(),
             font: (&py_style.font).into(),
             border: (&py_style.border).into(),

--- a/bindings/python/src/types.rs
+++ b/bindings/python/src/types.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use xlsx::base::types::{
     Alignment, Border, BorderItem, BorderStyle, CellType, Fill, Font, FontScheme,
-    HorizontalAlignment, Style, VerticalAlignment,
+    HorizontalAlignment, NumFmt, Style, VerticalAlignment,
 };
 
 #[derive(Clone)]
@@ -294,7 +294,7 @@ impl From<&PyStyle> for Style {
     fn from(py_style: &PyStyle) -> Self {
         Style {
             alignment: py_style.alignment.as_ref().map(|a| a.into()),
-            num_fmt: py_style.num_fmt.clone(),
+            num_fmt: NumFmt::from_format_code(&py_style.num_fmt),
             fill: (&py_style.fill).into(),
             font: (&py_style.font).into(),
             border: (&py_style.border).into(),
@@ -429,7 +429,7 @@ impl From<Style> for PyStyle {
     fn from(style: Style) -> Self {
         PyStyle {
             alignment: style.alignment.map(|a| a.into()),
-            num_fmt: style.num_fmt,
+            num_fmt: style.num_fmt.format_code,
             fill: style.fill.into(),
             font: style.font.into(),
             border: style.border.into(),

--- a/xlsx/src/import/styles.rs
+++ b/xlsx/src/import/styles.rs
@@ -71,10 +71,7 @@ pub(super) fn load_styles<R: Read + std::io::Seek>(
         for num_fmt in num_fmts_nodes[0].children() {
             let num_fmt_id = get_number(num_fmt, "numFmtId");
             let format_code = num_fmt.attribute("formatCode").unwrap_or("").to_string();
-            num_fmts.push(NumFmt {
-                num_fmt_id,
-                format_code,
-            });
+            num_fmts.push(NumFmt::new(num_fmt_id, format_code));
         }
     }
 


### PR DESCRIPTION
### Root Cause Fixed

Previously, date cells stored a **literal format string** derived from the active locale at input time (e.g. `"mm/dd/yy"`). When the locale changed, the stored string did not update.

**Before**

```
User enters date
  | - parse_formatted_number() -> Option<String> (e.g. "m/d/yy")
    | - get_style_with_format(format_string)
      | - CellStyle { num_fmt: String } <- stored literally
        | - get_localized_cell_content() uses num_fmt as-is
        | - get_formatted_cell_value()  uses num_fmt as-is
```

**After**

```
User enters date
  | - parse_formatted_number() -> Option<NumFmtSpec>
       | - NumFmtSpec::LocaleDate -> get_style_with_num_fmt_id(14)
       | - NumFmtSpec::Literal(string) -> get_style_with_format(string)

CellStyle { num_fmt: NumFmt { num_fmt_id: i32, format_code: String } }
  | - ID 14 or 22 → re-derive from active locale at render time
  | - all other IDs → use stored format_code string
```

### New `DefaultFmts` interface to interact with `DEFAULT_NUM_FMTS`
Implemented in number_format.rs

Constant `DEFAULT_NUM_FMTS` stores id and string `[(i32, &str)]` .
This is needed as in the standard some format IDs are not specified in the listing, such as 5, 6, 7, and 8 etc.
[OpenXML NumberingFormat Class Remarks](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.numberingformat?view=openxml-3.0.1)
Built-in formats changed to ECMA-376 compliance.
ECMA-376 custom IDs must be ≥ 164; new constant ECMA_CUSTOM_FMT_MIN_ID added.

**NOTE**
Previously short date in default us locale was "mm-dd-yyyy" but short date is 14, "mm-dd-yy", see OpenXML Remarks above. This needed updating affected tests.

> NOTE 3: I did not implement the "short date" in base/src/formatter/format.rs:751
**This** implements short date by defining constants for `SHORT_DATE_ID` and `SHORT_DATETIME_ID`; this is done using `DefaultFmts`.


The new `struct NumFmt` uses this to:
```rust
DefaultFmts::by_id()  -> Option<&'static str>
DefaultFmts::by_code()  ->  Option<i32>
DefaultFmts::contains_id()  ->  bool
```


Helpers used in formatter `parse_formatted_number()` for consistency instead of writing `"#,##0.00".to_string()` etc.
```rust
DefaultFmts::comma_int() -> String
DefaultFmts::comma_dec() -> String
DefaultFmts::percent_int() -> String
DefaultFmts::percent_dec() -> String
DefaultFmts::scientific_format() -> String
// Helper used in `Model` and `Units`.
DefaultFmts::is_locale_date() ->  bool
```

Added test `test_full_numbering_format_class`, this test case is a copy/pase from [NumberingFormat Class](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.numberingformat?view=openxml-3.0.1)

**Removed**:
Functions removed from `number_format.rs`; logic migrated to NumFmt implementation.
- `get_default_num_fmt_id()`
- `get_new_num_fmt_index()`
- `get_num_fmt()`


### New Types for number format


```rust
pub struct Style {
    pub alignment: Option<Alignment>,
    pub num_fmt: NumFmt // Old: String,
//--------------------------------------
pub struct NumFmt {
    pub num_fmt_id: i32,
    pub format_code: String,
}
```


Previously stored as `String` - **THIS** was the main issue. As both `Model::get_localized_cell_content()` and `Model::get_formatted_cell_value()` 
looked up the cell's `num_fmt`. When the locale changed, edit-bar still showed the old locale's string, causing re-parse to interpret it incorrectly and corrupt the serial.

Styles uses `NumFmt` to create, get styles.
The `get_num_fmt_index()` helper — replaced by `NumFmt::get_or_register()`.
```rust
NumFmt::is_known_id(id: i32, custom_fmts: &[NumFmt]) -> bool
NumFmt::from_id(id: i32, custom_fmts: &[NumFmt]) -> Self
NumFmt::get_or_register(code: &str, num_fmts: &mut Vec<NumFmt>) -> Self
NumFmt::from_format_code(code: &str) -> Self
```

**Implemented Deserialization / Serialization** as suggestion of Claude code review.
> Explanation
> Deserialization:
> - Legacy JSON `"num_fmt": "mm/dd/yy"` (string) -> `from_format_code()`
>
> - New JSON `"num_fmt": {"num_fmt_id": 14, ...}` (object) -> validated fields
> - Validation rejects stored ID if it conflicts with the derived ID (prevents corrupt state 
> like built-in ID paired with custom format code)
>
>Serialization: `NumFmt` serializes as the `format_code` string (not a struct).
>This keeps the on-disk format stable and human-readable.




**`NumFmtSpec` only used in parsing**
```rust
// Number format to apply when storing a parsed cell value
pub(crate) enum NumFmtSpec {
    /// Locale short date (numFmtId 14).
    LocaleDate,
    /// A literal format string (ISO dates, currency, percent, …).
    Literal(String),
}
```



### Formatter functions return changed:

```rust
parse_formatted_number() -> Option<NumFmtSpec>
parse_date() -> Option<String>
```

- **Locale dates** -> `Some(NumFmtSpec::LocaleDate)` — no string
- **ISO dates** `yyyy-mm-dd` -> `Some(NumFmtSpec::Literal("yyyy-mm-dd"))` - stored as-is
- **Non-date** -> `Some(NumFmtSpec::Literal(format_code))`  DefaultFmts helpers above

Abstracted `self.dates.date_formats.short.starts_with('d')` to helper in Locale implementation `locale.day_first()`.



### Model update

Refactored `parse_formatted_number()` to use `NumFmtSpec` and `DefaultFmts`.

`set_user_input()` :
- parse as formula updated to use Units on for parsed as function.
- parse as number updated to use `NumFmtSpec`

**New helper `locale_short_datetime_fmt(locale)`**:
Builds a short datetime format from `locale.dates.*`, normalizing CLDR Unicode quirks

Function `get_localized_cell_content()` now matches on num_fmt_id.

```rust
match style.num_fmt.num_fmt_id {
    SHORT_DATE_ID (14)     => locale.dates.date_formats.short
    SHORT_DATETIME_ID (22) => locale_short_datetime_fmt(locale)
    _                      => style.num_fmt.format_code  // literal/custom
}
```



### Units - DateTime functions locale update
Added new variants to enum Units in `base/src/units.rs`.
**Removed**: `get_num_fmt() -> String` since there is no string to return. Callers now pattern-match explicitly on variants
```rust
Units::LocaleDate
Units::LocaleDateTime
```

Updated to use `DefaultFmts` helpers above when working with `Units::num_fmt` number format.
```rust
num_fmt: DefaultFmts::percent_int() // "0%".to_string()
```

**Style application pattern** now matches on variant:
```rust
Units::LocaleDate       => get_style_with_num_fmt_id(SHORT_DATE_ID)
Units::LocaleDateTime   => get_style_with_num_fmt_id(SHORT_DATETIME_ID)
Units::Date(fmt)        => get_style_with_format(&fmt)
Units::Number { num_fmt, .. } | ... => get_style_with_format(&num_fmt)
```

Updated `compute_function_units()` to trigger locale update for functions below.
Added helper `should_override_with_locale_date()` called by `units_fn_dates()` and `units_fn_date_times()` before assigning locale units. Guards against overwriting user-set formats.
 
**Functions now set / update locale formats**:
  - =DATE()
  - =TODAY()
  - =NOW()
  - =EDATE()
  - =EOMONTH()
  - =WORKDAY()
  - =WORKDAYINTL()
  - =DATEVALUE()



### Styles

`get_style_index()` per the Claude code review suggestion.
>Explanation
>**CellXfs de-duplication** (the subtle fix):
>```rust
>// Before: compared full style structs, which collapsed locale IDs with same-looking strings
>// After:
>if incoming_id >= 0 {
>    xf.num_fmt_id == incoming_id      // ID-based: no false matches
>} else {
>    format_code_for_id(...) == code   // string fallback only for -1 (unregistered)
>}
>```
>Without this, a locale-date cell (ID 14) could be reused for a custom format with the
>same visual string, causing them to share a CellXfs entry and silently overwrite the ID.


**`get_style_with_format()`**: Now calls `NumFmt::get_or_register(code, &mut self.num_fmts)`
internally.


**Removed**: `get_num_fmt_index()` helper — replaced by `NumFmt::get_or_register()`.


### Checklist for discussion / approval
- [ ] Naming of added code (naming is hard)
- [ ] Location of `NumFmt`, `NumFmtSpec` (it may be in number_format.rs)

Fixes #761 