### PR TITLE
update: add reusable dialog component to Storybook

### DIFF
--- a/webapp/IronCalc/src/components/Dialog/Dialog.stories.tsx
+++ b/webapp/IronCalc/src/components/Dialog/Dialog.stories.tsx
@@ -1,0 +1,197 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Check, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../Button/Button";
+import { Dialog, type DialogProperties } from "./Dialog";
+
+type DialogStoryArgs = DialogProperties & {
+  showFooter: boolean;
+};
+
+const meta = {
+  title: "Components/Dialog",
+  component: Dialog,
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    title: "Dialog title",
+    showCloseButton: true,
+    showFooter: true,
+    width: 300,
+  },
+  argTypes: {
+    title: {
+      control: "text",
+    },
+    showCloseButton: {
+      control: "boolean",
+    },
+    showFooter: {
+      control: "boolean",
+    },
+    width: {
+      control: "number",
+    },
+  },
+} satisfies Meta<DialogStoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<DialogStoryArgs>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    const { showFooter, ...dialogArgs } = args;
+
+    return (
+      <>
+        <Dialog
+          {...dialogArgs}
+          open={open}
+          onClose={() => setOpen(false)}
+          footer={
+            showFooter ? (
+              <>
+                <Button variant="secondary" onClick={() => setOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  startIcon={<Check />}
+                  onClick={() => setOpen(false)}
+                >
+                  Confirm
+                </Button>
+              </>
+            ) : undefined
+          }
+        >
+          <div>Dialog content</div>
+        </Dialog>
+
+        <div
+          style={{
+            minHeight: "100vh",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Button variant="outline" onClick={() => setOpen(true)}>
+            Open dialog
+          </Button>
+        </div>
+      </>
+    );
+  },
+};
+
+export const Confirmation: Story = {
+  args: {
+    title: "Delete sheet",
+    showCloseButton: false,
+    showFooter: true,
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    const { showFooter, ...dialogArgs } = args;
+
+    return (
+      <>
+        <Dialog
+          {...dialogArgs}
+          open={open}
+          onClose={() => setOpen(false)}
+          footer={
+            showFooter ? (
+              <>
+                <Button variant="secondary" onClick={() => setOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  startIcon={<Trash2 />}
+                  onClick={() => setOpen(false)}
+                >
+                  Delete
+                </Button>
+              </>
+            ) : undefined
+          }
+        >
+          <div>
+            Are you sure you want to delete the sheet <b>"Sheet1"</b>? This
+            action cannot be undone.
+          </div>
+        </Dialog>
+
+        <div
+          style={{
+            minHeight: "100vh",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Button variant="outline" onClick={() => setOpen(true)}>
+            Open dialog
+          </Button>
+        </div>
+      </>
+    );
+  },
+};
+
+export const LongText: Story = {
+  args: {
+    title: "The Metamorphosis",
+    showFooter: true,
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    const { showFooter, ...dialogArgs } = args;
+
+    const longText = `One morning, when Gregor Samsa woke from troubled dreams, he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about helplessly as he looked. "What's happened to me?" he thought. It wasn't a dream. His room, a proper human room although a little too small, lay peacefully between its four familiar walls. A collection of textile samples lay spread out on the table - Samsa was a travelling salesman - and above it there hung a picture that he had recently cut out of an illustrated magazine and housed in a nice, gilded frame. It showed a lady fitted out with a fur hat and fur boa who sat upright, raising a heavy fur muff that covered the whole of her lower arm towards the viewer. Gregor then turned to look out the window at the dull weather."`;
+
+    return (
+      <>
+        <Dialog
+          {...dialogArgs}
+          open={open}
+          onClose={() => setOpen(false)}
+          footer={
+            showFooter ? (
+              <>
+                <Button variant="secondary" onClick={() => setOpen(false)}>
+                  Cancel
+                </Button>
+                <Button variant="primary" onClick={() => setOpen(false)}>
+                  Understood
+                </Button>
+              </>
+            ) : undefined
+          }
+        >
+          <p style={{ margin: 0, whiteSpace: "pre-wrap", lineHeight: 1.5 }}>
+            {longText}
+          </p>
+        </Dialog>
+
+        <div
+          style={{
+            minHeight: "100vh",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Button variant="outline" onClick={() => setOpen(true)}>
+            Open dialog
+          </Button>
+        </div>
+      </>
+    );
+  },
+};

--- a/webapp/IronCalc/src/components/Dialog/Dialog.stories.tsx
+++ b/webapp/IronCalc/src/components/Dialog/Dialog.stories.tsx
@@ -71,14 +71,7 @@ export const Default: Story = {
           <div>Dialog content</div>
         </Dialog>
 
-        <div
-          style={{
-            minHeight: "100vh",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
+        <div>
           <Button variant="outline" onClick={() => setOpen(true)}>
             Open dialog
           </Button>
@@ -127,14 +120,7 @@ export const Confirmation: Story = {
           </div>
         </Dialog>
 
-        <div
-          style={{
-            minHeight: "100vh",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
+        <div>
           <Button variant="outline" onClick={() => setOpen(true)}>
             Open dialog
           </Button>
@@ -174,19 +160,19 @@ export const LongText: Story = {
             ) : undefined
           }
         >
-          <p style={{ margin: 0, whiteSpace: "pre-wrap", lineHeight: 1.5 }}>
+          <p
+            style={{
+              margin: 0,
+              whiteSpace: "pre-wrap",
+              overflowWrap: "anywhere",
+              lineHeight: 1.5,
+            }}
+          >
             {longText}
           </p>
         </Dialog>
 
-        <div
-          style={{
-            minHeight: "100vh",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
+        <div>
           <Button variant="outline" onClick={() => setOpen(true)}>
             Open dialog
           </Button>

--- a/webapp/IronCalc/src/components/Dialog/Dialog.tsx
+++ b/webapp/IronCalc/src/components/Dialog/Dialog.tsx
@@ -83,7 +83,10 @@ const DialogContent = styled("div")(({ theme }) => ({
 const DialogFooter = styled("div")(({ theme }) => ({
   padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
   display: "flex",
-  flexDirection: "row",
+  flexDirection: "column-reverse",
+  [theme.breakpoints.up("sm")]: {
+    flexDirection: "row",
+  },
   gap: theme.spacing(1),
   justifyContent: "flex-end",
 }));
@@ -101,7 +104,6 @@ export const Dialog = ({
 
   useEffect(() => {
     if (!open) return;
-
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();

--- a/webapp/IronCalc/src/components/Dialog/Dialog.tsx
+++ b/webapp/IronCalc/src/components/Dialog/Dialog.tsx
@@ -1,9 +1,11 @@
 import { styled } from "@mui/material";
 import { alpha } from "@mui/material/styles";
+import TrapFocus from "@mui/material/Unstable_TrapFocus";
 import { X } from "lucide-react";
 import type React from "react";
 import { useEffect, useId } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { IconButton } from "../Button/IconButton";
 
 /**
@@ -34,10 +36,10 @@ const DialogOverlay = styled("div")(({ theme }) => ({
 }));
 
 const DialogContainer = styled("div", {
-  shouldForwardProp: (prop) => prop !== "dialogWidth",
-})<{ dialogWidth: number | string }>(({ theme, dialogWidth }) => ({
-  width: dialogWidth,
-  minWidth: "min(280px, calc(100vw - 32px))",
+  shouldForwardProp: (prop) => prop !== "dialogMinWidth",
+})<{ dialogMinWidth: string }>(({ theme, dialogMinWidth }) => ({
+  width: "max-content",
+  minWidth: `max(${dialogMinWidth}, min(280px, calc(100vw - 32px)))`,
   maxWidth: "calc(100vw - 32px)",
   maxHeight: "calc(100vh - 32px)",
   overflow: "hidden",
@@ -49,6 +51,11 @@ const DialogContainer = styled("div", {
   display: "flex",
   flexDirection: "column",
   fontFamily: theme.typography.fontFamily,
+  transition: "box-shadow 120ms ease-out",
+  "&:focus": {
+    outline: "none",
+    boxShadow: `0px 30px 70px ${alpha(theme.palette.common.black, 0.24)}, 0 0 0 4px ${alpha(theme.palette.common.black, 0.08)}`,
+  },
 }));
 
 const DialogHeader = styled("div")(({ theme }) => ({
@@ -100,7 +107,9 @@ export const Dialog = ({
   showCloseButton = true,
   width = 300,
 }: DialogProperties) => {
+  const { t } = useTranslation();
   const titleId = useId();
+  const dialogMinWidth = typeof width === "number" ? `${width}px` : width;
 
   useEffect(() => {
     if (!open) return;
@@ -110,9 +119,9 @@ export const Dialog = ({
         onClose();
       }
     };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
   }, [open, onClose]);
 
   if (!open) return null;
@@ -125,32 +134,34 @@ export const Dialog = ({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <DialogContainer
-        dialogWidth={width}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        onMouseDown={(e) => e.stopPropagation()}
-      >
-        {/* 1) header */}
-        <DialogHeader>
-          <DialogTitle id={titleId}>{title}</DialogTitle>
+      <TrapFocus open={open}>
+        <DialogContainer
+          dialogMinWidth={dialogMinWidth}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          {/* 1) header */}
+          <DialogHeader>
+            <DialogTitle id={titleId}>{title}</DialogTitle>
 
-          {showCloseButton && (
-            <IconButton
-              icon={<X />}
-              aria-label="Close dialog"
-              onClick={onClose}
-            />
-          )}
-        </DialogHeader>
+            {showCloseButton && (
+              <IconButton
+                icon={<X />}
+                aria-label={t("dialog.close")}
+                onClick={onClose}
+              />
+            )}
+          </DialogHeader>
 
-        {/* 2) content */}
-        <DialogContent>{children}</DialogContent>
+          {/* 2) content */}
+          <DialogContent>{children}</DialogContent>
 
-        {/* 3) footer */}
-        {footer != null && <DialogFooter>{footer}</DialogFooter>}
-      </DialogContainer>
+          {/* 3) footer */}
+          {footer != null && <DialogFooter>{footer}</DialogFooter>}
+        </DialogContainer>
+      </TrapFocus>
     </DialogOverlay>,
     document.body,
   );

--- a/webapp/IronCalc/src/components/Dialog/Dialog.tsx
+++ b/webapp/IronCalc/src/components/Dialog/Dialog.tsx
@@ -1,0 +1,157 @@
+import { styled } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import { X } from "lucide-react";
+import type React from "react";
+import { useEffect, useId } from "react";
+import { createPortal } from "react-dom";
+import { IconButton } from "../Button/IconButton";
+
+/**
+ * This is a reusable Dialog component with optional footer and close button.
+ * Width is editable but never less than 280px.
+ */
+
+export interface DialogProperties {
+  open: boolean;
+  onClose: () => void;
+  title: React.ReactNode;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  showCloseButton?: boolean;
+  width?: number | string;
+}
+
+const DialogOverlay = styled("div")(({ theme }) => ({
+  position: "fixed",
+  inset: 0,
+  zIndex: theme.zIndex.modal,
+  backgroundColor: alpha(theme.palette.common.black, 0.4),
+  backdropFilter: "blur(0.5px)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: theme.spacing(2),
+}));
+
+const DialogContainer = styled("div", {
+  shouldForwardProp: (prop) => prop !== "dialogWidth",
+})<{ dialogWidth: number | string }>(({ theme, dialogWidth }) => ({
+  width: dialogWidth,
+  minWidth: "min(280px, calc(100vw - 32px))",
+  maxWidth: "calc(100vw - 32px)",
+  maxHeight: "calc(100vh - 32px)",
+  overflow: "hidden",
+  backgroundColor: theme.palette.common.white,
+  color: theme.palette.common.black,
+  borderRadius: 10,
+  boxShadow: `0px 30px 70px ${alpha(theme.palette.common.black, 0.24)}`,
+  border: `1px solid ${alpha(theme.palette.common.black, 0.12)}`,
+  display: "flex",
+  flexDirection: "column",
+  fontFamily: theme.typography.fontFamily,
+}));
+
+const DialogHeader = styled("div")(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  minHeight: 28,
+  padding: theme.spacing(1),
+  paddingLeft: theme.spacing(2),
+  gap: theme.spacing(1),
+}));
+
+const DialogTitle = styled("h2")(({ theme }) => ({
+  margin: 0,
+  fontSize: theme.typography.fontSize * 1.14,
+  fontWeight: 700,
+  minWidth: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  flex: 1,
+}));
+
+const DialogContent = styled("div")(({ theme }) => ({
+  padding: theme.spacing(2),
+  fontSize: theme.typography.fontSize,
+  flex: 1,
+  minHeight: 0,
+  overflow: "auto",
+}));
+
+const DialogFooter = styled("div")(({ theme }) => ({
+  padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+  display: "flex",
+  flexDirection: "row",
+  gap: theme.spacing(1),
+  justifyContent: "flex-end",
+}));
+
+export const Dialog = ({
+  open,
+  onClose,
+  title,
+  children,
+  footer,
+  showCloseButton = true,
+  width = 300,
+}: DialogProperties) => {
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <DialogOverlay
+      role="presentation"
+      onMouseDown={(e) => {
+        // Close only when clicking the backdrop itself.
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <DialogContainer
+        dialogWidth={width}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {/* 1) header */}
+        <DialogHeader>
+          <DialogTitle id={titleId}>{title}</DialogTitle>
+
+          {showCloseButton && (
+            <IconButton
+              icon={<X />}
+              aria-label="Close dialog"
+              onClick={onClose}
+            />
+          )}
+        </DialogHeader>
+
+        {/* 2) content */}
+        <DialogContent>{children}</DialogContent>
+
+        {/* 3) footer */}
+        {footer != null && <DialogFooter>{footer}</DialogFooter>}
+      </DialogContainer>
+    </DialogOverlay>,
+    document.body,
+  );
+};
+
+Dialog.displayName = "Dialog";

--- a/webapp/IronCalc/src/components/FormatMenu/FormatMenu.tsx
+++ b/webapp/IronCalc/src/components/FormatMenu/FormatMenu.tsx
@@ -10,7 +10,6 @@ type FormatMenuProps = {
   children: React.ReactNode;
   numFmt: string;
   onChange: (numberFmt: string) => void;
-  onExited: () => void;
   anchorOrigin: ComponentProps<typeof Menu>["anchorOrigin"];
   formatOptions: FmtSettings;
 };

--- a/webapp/IronCalc/src/components/FormatMenu/FormatMenu.tsx
+++ b/webapp/IronCalc/src/components/FormatMenu/FormatMenu.tsx
@@ -157,7 +157,12 @@ const FormatMenu = (properties: FormatMenuProps) => {
         </MenuItemWrapper>
 
         <MenuDivider />
-        <MenuItemWrapper onClick={(): void => setPickerOpen(true)}>
+        <MenuItemWrapper
+          onClick={(): void => {
+            setMenuOpen(false);
+            setPickerOpen(true);
+          }}
+        >
           <MenuItemText>
             <CheckIcon $active={isCustomFormat} />
             {t("toolbar.format_menu.custom")}
@@ -169,7 +174,6 @@ const FormatMenu = (properties: FormatMenuProps) => {
         onChange={onSelect}
         open={isPickerOpen}
         onClose={(): void => setPickerOpen(false)}
-        onExited={properties.onExited}
       />
     </>
   );

--- a/webapp/IronCalc/src/components/FormatMenu/FormatPicker.tsx
+++ b/webapp/IronCalc/src/components/FormatMenu/FormatPicker.tsx
@@ -1,15 +1,13 @@
-import { Dialog, styled, TextField } from "@mui/material";
-import { Check, X } from "lucide-react";
-import { useState } from "react";
+import { styled, TextField } from "@mui/material";
+import { Check } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../Button/Button";
-import { IconButton } from "../Button/IconButton";
+import { Dialog } from "../Dialog/Dialog";
 
 type FormatPickerProps = {
-  className?: string;
   open: boolean;
   onClose: () => void;
-  onExited: () => void;
   numFmt: string;
   onChange: (numberFmt: string) => void;
 };
@@ -18,9 +16,10 @@ const FormatPicker = (properties: FormatPickerProps) => {
   const { t } = useTranslation();
   const [formatCode, setFormatCode] = useState(properties.numFmt);
 
-  const handleClose = () => {
-    properties.onClose();
-  };
+  useEffect(() => {
+    if (!properties.open) return;
+    setFormatCode(properties.numFmt);
+  }, [properties.open, properties.numFmt]);
 
   const onSubmit = (format_code: string): void => {
     properties.onChange(format_code);
@@ -30,70 +29,38 @@ const FormatPicker = (properties: FormatPickerProps) => {
     <Dialog
       open={properties.open}
       onClose={properties.onClose}
-      PaperProps={{
-        style: { minWidth: "280px" },
-      }}
-    >
-      <StyledDialogTitle>
-        {t("num_fmt.title")}
-        <IconButton
-          icon={<X />}
-          onClick={handleClose}
-          title={t("num_fmt.close")}
-          aria-label={t("num_fmt.close")}
-        />
-      </StyledDialogTitle>
-
-      <StyledDialogContent>
-        <StyledTextField
-          autoFocus
-          defaultValue={properties.numFmt}
-          name="format_code"
-          onChange={(event) => setFormatCode(event.target.value)}
-          onKeyDown={(event) => {
-            event.stopPropagation();
-            if (event.key === "Enter") {
-              onSubmit(formatCode);
-              properties.onClose();
-            }
-          }}
-          spellCheck="false"
-          onClick={(event) => event.stopPropagation()}
-          onFocus={(event) => event.target.select()}
-          onPaste={(event) => event.stopPropagation()}
-          onCopy={(event) => event.stopPropagation()}
-          onCut={(event) => event.stopPropagation()}
-        />
-      </StyledDialogContent>
-      <DialogFooter>
+      title={t("num_fmt.title")}
+      footer={
         <Button
-          size="md"
+          variant="primary"
           startIcon={<Check />}
           onClick={() => onSubmit(formatCode)}
         >
           {t("num_fmt.save")}
         </Button>
-      </DialogFooter>
+      }
+    >
+      <StyledTextField
+        autoFocus
+        value={formatCode}
+        name="format_code"
+        onChange={(event) => setFormatCode(event.target.value)}
+        onKeyDown={(event) => {
+          event.stopPropagation();
+          if (event.key === "Enter") {
+            onSubmit(formatCode);
+          }
+        }}
+        spellCheck="false"
+        onClick={(event) => event.stopPropagation()}
+        onFocus={(event) => event.target.select()}
+        onPaste={(event) => event.stopPropagation()}
+        onCopy={(event) => event.stopPropagation()}
+        onCut={(event) => event.stopPropagation()}
+      />
     </Dialog>
   );
 };
-
-const StyledDialogTitle = styled("div")(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  height: 44,
-  fontSize: 14,
-  fontWeight: 500,
-  fontFamily: "Inter",
-  padding: "0px 12px",
-  justifyContent: "space-between",
-  borderBottom: `1px solid ${theme.palette.grey[300]}`,
-}));
-
-const StyledDialogContent = styled("div")({
-  fontSize: 12,
-  margin: 12,
-});
 
 const StyledTextField = styled(TextField)(({ theme }) => ({
   width: "100%",
@@ -112,16 +79,6 @@ const StyledTextField = styled(TextField)(({ theme }) => ({
   "&:hover .MuiInputBase-input": {
     border: `1px solid ${theme.palette.grey[500]}`,
   },
-}));
-
-const DialogFooter = styled("div")(({ theme }) => ({
-  color: "#757575",
-  display: "flex",
-  alignItems: "center",
-  borderTop: `1px solid ${theme.palette.grey[300]}`,
-  fontFamily: "Inter",
-  justifyContent: "flex-end",
-  padding: 12,
 }));
 
 export default FormatPicker;

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetDeleteDialog.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetDeleteDialog.tsx
@@ -1,6 +1,7 @@
-import { Button, Dialog, styled } from "@mui/material";
 import { Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Button } from "../Button/Button";
+import { Dialog } from "../Dialog/Dialog";
 
 interface SheetDeleteDialogProps {
   open: boolean;
@@ -18,103 +19,32 @@ function SheetDeleteDialog({
   const { t } = useTranslation();
 
   return (
-    <Dialog open={open} onClose={onClose}>
-      <DialogWrapper>
-        <IconWrapper>
-          <Trash2 />
-        </IconWrapper>
-        <Title>{t("sheet_delete.title")}</Title>
-        <Body>
-          {t("sheet_delete.message", {
-            sheetName,
-          })}
-        </Body>
-        <ButtonGroup>
-          <DeleteButton onClick={onDelete} autoFocus>
-            {t("sheet_delete.confirm")}
-          </DeleteButton>
-          <CancelButton onClick={onClose}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={t("sheet_delete.title")}
+      showCloseButton={false}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
             {t("sheet_delete.cancel")}
-          </CancelButton>
-        </ButtonGroup>
-      </DialogWrapper>
+          </Button>
+          <Button
+            variant="destructive"
+            startIcon={<Trash2 />}
+            onClick={onDelete}
+            autoFocus
+          >
+            {t("sheet_delete.confirm")}
+          </Button>
+        </>
+      }
+    >
+      {t("sheet_delete.message", {
+        sheetName,
+      })}
     </Dialog>
   );
 }
-
-const DialogWrapper = styled("div")(({ theme }) => ({
-  position: "fixed",
-  top: "50%",
-  left: "50%",
-  transform: "translate(-50%, -50%)",
-  background: theme.palette.common.white,
-  display: "flex",
-  flexDirection: "column",
-  gap: 8,
-  padding: 12,
-  borderRadius: 8,
-  boxShadow: `0px 1px 3px 0px ${theme.palette.common.black}1A`,
-  width: 280,
-  maxWidth: "calc(100% - 40px)",
-  zIndex: 50,
-  fontFamily: '"Inter", sans-serif',
-}));
-
-const IconWrapper = styled("div")(({ theme }) => ({
-  display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
-  width: 36,
-  height: 36,
-  borderRadius: 4,
-  backgroundColor: `${theme.palette.error.main}1A`,
-  margin: "12px auto 8px auto",
-  color: theme.palette.error.main,
-  "& svg": {
-    width: 16,
-    height: 16,
-  },
-}));
-
-const Title = styled("h2")(({ theme }) => ({
-  margin: 0,
-  fontSize: 14,
-  fontWeight: 600,
-  color: theme.palette.grey[900],
-  textAlign: "center",
-}));
-
-const Body = styled("p")(({ theme }) => ({
-  margin: 0,
-  textAlign: "center",
-  color: theme.palette.grey[900],
-  fontSize: 12,
-}));
-
-const ButtonGroup = styled("div")({
-  display: "flex",
-  flexDirection: "column",
-  gap: 8,
-  marginTop: 8,
-  width: "100%",
-});
-
-const DeleteButton = styled(Button)(({ theme }) => ({
-  backgroundColor: theme.palette.error.main,
-  color: theme.palette.common.white,
-  textTransform: "none",
-  "&:hover": {
-    backgroundColor: theme.palette.error.dark,
-  },
-}));
-
-const CancelButton = styled(Button)(({ theme }) => ({
-  backgroundColor: theme.palette.grey[200],
-  color: theme.palette.grey[700],
-  textTransform: "none",
-  "&:hover": {
-    backgroundColor: theme.palette.grey[300],
-  },
-}));
 
 export default SheetDeleteDialog;

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -61,6 +61,9 @@
       "style": "Rahmenstil"
     }
   },
+  "dialog": {
+    "close": "Dialog schließen"
+  },
   "num_fmt": {
     "title": "Benutzerdefiniertes Zahlenformat",
     "label": "Zahlenformat",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -61,6 +61,9 @@
       "style": "Border style"
     }
   },
+  "dialog": {
+    "close": "Close dialog"
+  },
   "num_fmt": {
     "title": "Custom number format",
     "label": "Number format",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -61,6 +61,9 @@
       "style": "Estilo del borde"
     }
   },
+  "dialog": {
+    "close": "Cerrar diálogo"
+  },
   "num_fmt": {
     "title": "Formato de número personalizado",
     "label": "Formato de número",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -61,6 +61,9 @@
       "style": "Style de bordure"
     }
   },
+  "dialog": {
+    "close": "Fermer la boîte de dialogue"
+  },
   "num_fmt": {
     "title": "Format de nombre personnalisé",
     "label": "Format de nombre",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -61,6 +61,9 @@
       "style": "Stile bordo"
     }
   },
+  "dialog": {
+    "close": "Chiudi finestra"
+  },
   "num_fmt": {
     "title": "Formato numero personalizzato",
     "label": "Formato numero",


### PR DESCRIPTION
This PR is related to the issue #785 

This new component avoids using Mui's Dialog and aims to simplify both implementation and design. The PR includes changes in the following files:

- `Dialog.tsx`: main component
- `Dialog.stories.tsx`: Storybook stories with different variants

Additionally we've replaced the old dialog in the following places:

- `SheetDeleteDialog.tsx`: ditched MUI's dialog to use the new component. The design has also been adapted a bit so all dialogs are consistent
- `FormatPicker.tsx`: ditched MUI's dialog to use the new component
- `FormatMenu.tsx`: minor edit to avoid issues when focusing on the input in FormatPicker

Edit: after the first review round I've also changed all translation files (`de_de.json`, `es_es.json`, etc) 