### PR TITLE
Fix missed range clamping for excel functions 

### DIFF
--- a/base/src/functions/financial.rs
+++ b/base/src/functions/financial.rs
@@ -2,7 +2,7 @@ use chrono::Datelike;
 
 use crate::{
     calc_result::CalcResult,
-    constants::{LAST_COLUMN, LAST_ROW, MAXIMUM_DATE_SERIAL_NUMBER, MINIMUM_DATE_SERIAL_NUMBER},
+    constants::{MAXIMUM_DATE_SERIAL_NUMBER, MINIMUM_DATE_SERIAL_NUMBER},
     expressions::{parser::Node, token::Error, types::CellReferenceIndex},
     formatter::dates::from_excel_date,
     model::Model,
@@ -222,43 +222,10 @@ impl<'a> Model<'a> {
                 let sheet = left.sheet;
                 let dx: WorksheetDimension = self
                     .get_max_rc(sheet, left.row, left.column, right.row, right.column)
-                    .map_err(|_| CalcResult::new_error(Error::ERROR, *cell, format!("...")))?;
-                // let row1 = left.row;
-                // let mut row2 = right.row;
-                // let column1 = left.column;
-                // let mut column2 = right.column;
-                // if row1 == 1 && row2 == LAST_ROW {
-                //     row2 = self
-                //         .workbook
-                //         .worksheet(sheet)
-                //         .map_err(|_| {
-                //             CalcResult::new_error(
-                //                 Error::ERROR,
-                //                 *cell,
-                //                 format!("Invalid worksheet index: '{sheet}'"),
-                //             )
-                //         })?
-                //         .dimension()
-                //         .max_row;
-                // }
-                // if column1 == 1 && column2 == LAST_COLUMN {
-                //     column2 = self
-                //         .workbook
-                //         .worksheet(sheet)
-                //         .map_err(|_| {
-                //             CalcResult::new_error(
-                //                 Error::ERROR,
-                //                 *cell,
-                //                 format!("Invalid worksheet index: '{sheet}'"),
-                //             )
-                //         })?
-                //         .dimension()
-                //         .max_column;
-                // }
+                    .map_err(|_| CalcResult::new_error(Error::ERROR, *cell, "...".to_string()))?;
+
                 for row in dx.min_row..=dx.max_row {
                     for column in dx.min_column..=dx.max_column {
-                        // for row in row1..=row2 {
-                        //     for column in column1..=column2 {
                         let cell_ref = CellReferenceIndex { sheet, row, column };
                         match self.evaluate_cell(cell_ref) {
                             CalcResult::Number(value) => values.push(value),
@@ -797,10 +764,7 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    // let row1 = left.row;
-                    // let mut row2 = right.row;
-                    // let column1 = left.column;
-                    // let mut column2 = right.column;
+
                     let dx: WorksheetDimension = match self.get_max_rc(
                         left.sheet,
                         left.row,
@@ -809,35 +773,11 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // for row in row1..row2 + 1 {
-                    // for column in column1..(column2 + 1) {
                     for row in dx.min_row..(dx.max_row + 1) {
                         for column in dx.min_column..(dx.max_column + 1) {
                             match self.evaluate_cell(CellReferenceIndex {

--- a/base/src/functions/financial.rs
+++ b/base/src/functions/financial.rs
@@ -6,6 +6,7 @@ use crate::{
     expressions::{parser::Node, token::Error, types::CellReferenceIndex},
     formatter::dates::from_excel_date,
     model::Model,
+    worksheet::WorksheetDimension,
 };
 
 use super::financial_util::{compute_irr, compute_npv, compute_rate, compute_xirr, compute_xnpv};
@@ -219,40 +220,45 @@ impl<'a> Model<'a> {
                     ));
                 }
                 let sheet = left.sheet;
-                let row1 = left.row;
-                let mut row2 = right.row;
-                let column1 = left.column;
-                let mut column2 = right.column;
-                if row1 == 1 && row2 == LAST_ROW {
-                    row2 = self
-                        .workbook
-                        .worksheet(sheet)
-                        .map_err(|_| {
-                            CalcResult::new_error(
-                                Error::ERROR,
-                                *cell,
-                                format!("Invalid worksheet index: '{sheet}'"),
-                            )
-                        })?
-                        .dimension()
-                        .max_row;
-                }
-                if column1 == 1 && column2 == LAST_COLUMN {
-                    column2 = self
-                        .workbook
-                        .worksheet(sheet)
-                        .map_err(|_| {
-                            CalcResult::new_error(
-                                Error::ERROR,
-                                *cell,
-                                format!("Invalid worksheet index: '{sheet}'"),
-                            )
-                        })?
-                        .dimension()
-                        .max_column;
-                }
-                for row in row1..=row2 {
-                    for column in column1..=column2 {
+                let dx: WorksheetDimension = self
+                    .get_max_rc(sheet, left.row, left.column, right.row, right.column)
+                    .map_err(|_| CalcResult::new_error(Error::ERROR, *cell, format!("...")))?;
+                // let row1 = left.row;
+                // let mut row2 = right.row;
+                // let column1 = left.column;
+                // let mut column2 = right.column;
+                // if row1 == 1 && row2 == LAST_ROW {
+                //     row2 = self
+                //         .workbook
+                //         .worksheet(sheet)
+                //         .map_err(|_| {
+                //             CalcResult::new_error(
+                //                 Error::ERROR,
+                //                 *cell,
+                //                 format!("Invalid worksheet index: '{sheet}'"),
+                //             )
+                //         })?
+                //         .dimension()
+                //         .max_row;
+                // }
+                // if column1 == 1 && column2 == LAST_COLUMN {
+                //     column2 = self
+                //         .workbook
+                //         .worksheet(sheet)
+                //         .map_err(|_| {
+                //             CalcResult::new_error(
+                //                 Error::ERROR,
+                //                 *cell,
+                //                 format!("Invalid worksheet index: '{sheet}'"),
+                //             )
+                //         })?
+                //         .dimension()
+                //         .max_column;
+                // }
+                for row in dx.min_row..=dx.max_row {
+                    for column in dx.min_column..=dx.max_column {
+                        // for row in row1..=row2 {
+                        //     for column in column1..=column2 {
                         let cell_ref = CellReferenceIndex { sheet, row, column };
                         match self.evaluate_cell(cell_ref) {
                             CalcResult::Number(value) => values.push(value),
@@ -791,36 +797,49 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // for row in row1..row2 + 1 {
+                    // for column in column1..(column2 + 1) {
+                    for row in dx.min_row..(dx.max_row + 1) {
+                        for column in dx.min_column..(dx.max_column + 1) {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,

--- a/base/src/functions/mathematical.rs
+++ b/base/src/functions/mathematical.rs
@@ -5,9 +5,11 @@ use crate::expressions::types::CellReferenceIndex;
 use crate::functions::math_util::{from_roman, to_roman_with_form};
 use crate::number_format::{to_excel_precision, to_precision};
 use crate::single_number_fn;
+use crate::worksheet::WorksheetDimension;
 use crate::{
     calc_result::CalcResult, expressions::parser::Node, expressions::token::Error, model::Model,
 };
+
 use std::f64::consts::PI;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -301,33 +303,46 @@ impl<'a> Model<'a> {
                     let column1 = left.column;
                     let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
 
-                    for row in row1..=row2 {
-                        for column in column1..=column2 {
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+
+                    // for row in row1..=row2 {
+                    // for column in column1..=column2 {
+                    for row in dx.min_row..(dx.max_row + 1) {
+                        for column in dx.min_column..(dx.max_column + 1) {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -451,33 +466,46 @@ impl<'a> Model<'a> {
                     let column1 = left.column;
                     let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
 
-                    for row in row1..=row2 {
-                        for column in column1..=column2 {
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+
+                    // for row in row1..=row2 {
+                    // for column in column1..=column2 {
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -557,36 +585,50 @@ impl<'a> Model<'a> {
                     // TODO: We should do this for all functions that run through ranges
                     // Running cargo test for the ironcalc takes around .8 seconds with this speedup
                     // and ~ 3.5 seconds without it. Note that once properly in place sheet.dimension should be almost a noop
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
+
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -653,36 +695,49 @@ impl<'a> Model<'a> {
                     // TODO: We should do this for all functions that run through ranges
                     // Running cargo test for the ironcalc takes around .8 seconds with this speedup
                     // and ~ 3.5 seconds without it. Note that once properly in place sheet.dimension should be almost a noop
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -748,36 +803,50 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    //
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,

--- a/base/src/functions/mathematical.rs
+++ b/base/src/functions/mathematical.rs
@@ -1,5 +1,5 @@
 use crate::cast::NumberOrArray;
-use crate::constants::{EXCEL_PRECISION, LAST_COLUMN, LAST_ROW};
+use crate::constants::EXCEL_PRECISION;
 use crate::expressions::parser::ArrayNode;
 use crate::expressions::types::CellReferenceIndex;
 use crate::functions::math_util::{from_roman, to_roman_with_form};
@@ -298,10 +298,6 @@ impl<'a> Model<'a> {
                         );
                     }
                     has_range = true;
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
 
                     let dx: WorksheetDimension = match self.get_max_rc(
                         left.sheet,
@@ -311,36 +307,11 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-
-                    // for row in row1..=row2 {
-                    // for column in column1..=column2 {
                     for row in dx.min_row..(dx.max_row + 1) {
                         for column in dx.min_column..(dx.max_column + 1) {
                             match self.evaluate_cell(CellReferenceIndex {
@@ -461,10 +432,6 @@ impl<'a> Model<'a> {
                         );
                     }
                     has_range = true;
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
 
                     let dx: WorksheetDimension = match self.get_max_rc(
                         left.sheet,
@@ -474,36 +441,11 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-
-                    // for row in row1..=row2 {
-                    // for column in column1..=column2 {
                     for row in dx.min_row..=dx.max_row {
                         for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
@@ -598,7 +540,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     // if row1 == 1 && row2 == LAST_ROW {
@@ -733,7 +677,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {
@@ -842,7 +788,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {

--- a/base/src/functions/mod.rs
+++ b/base/src/functions/mod.rs
@@ -20,6 +20,7 @@ mod macros;
 mod math_util;
 mod mathematical;
 mod mathematical_sum;
+mod model_util;
 mod statistical;
 mod subtotal;
 mod text;

--- a/base/src/functions/model_util.rs
+++ b/base/src/functions/model_util.rs
@@ -1,0 +1,56 @@
+use crate::{
+    constants::{LAST_COLUMN, LAST_ROW},
+    model::Model,
+    worksheet::WorksheetDimension,
+};
+
+impl<'a> Model<'a> {
+    /// Resolves LAST_ROW / LAST_COLUMN sentinels to the actual sheet extents.
+    ///
+    /// Returns `Err(())` when the sheet index is invalid. The caller is
+    /// responsible for mapping that to a `CalcResult` error — it owns the
+    /// `cell` context needed for a useful message.
+    ///
+    /// # Usage
+    ///
+    /// ```rust
+    /// // In a function returning Result<_, CalcResult>:
+    /// let dim = self.get_max_rc(sheet, row1, col1, row2, col2)
+    ///     .map_err(|_| CalcResult::new_error(Error::ERROR, *cell, ...))?;
+    ///
+    /// // In a function returning CalcResult directly:
+    /// let dim = match self.get_max_rc(sheet, row1, col1, row2, col2) {
+    ///     Ok(d) => d,
+    ///     Err(_) => return CalcResult::new_error(Error::ERROR, cell, ...),
+    /// };
+    /// ```
+    pub fn get_max_rc(
+        &self,
+        sheet: u32,
+        row1: i32,
+        col1: i32,
+        row2: i32,
+        col2: i32,
+    ) -> Result<WorksheetDimension, ()> {
+        let needs_row = row1 == 1 && row2 == LAST_ROW;
+        let needs_col = col1 == 1 && col2 == LAST_COLUMN;
+
+        // Single worksheet() call covers both row and column resolution.
+        let (r_max, c_max) = if needs_row || needs_col {
+            let dim = self.workbook.worksheet(sheet).map_err(|_| ())?.dimension();
+            (
+                if needs_row { dim.max_row } else { row2 },
+                if needs_col { dim.max_column } else { col2 },
+            )
+        } else {
+            (row2, col2)
+        };
+
+        Ok(WorksheetDimension {
+            min_row: row1,
+            max_row: r_max,
+            min_column: col1,
+            max_column: c_max,
+        })
+    }
+}

--- a/base/src/functions/model_util.rs
+++ b/base/src/functions/model_util.rs
@@ -7,21 +7,20 @@ use crate::{
 impl<'a> Model<'a> {
     /// Resolves LAST_ROW / LAST_COLUMN sentinels to the actual sheet extents.
     ///
-    /// Returns `Err(())` when the sheet index is invalid. The caller is
-    /// responsible for mapping that to a `CalcResult` error — it owns the
-    /// `cell` context needed for a useful message.
+    /// Returns `Err` with a message when the sheet index is invalid.
+    /// Callers map the error to a `CalcResult` with their own `cell` context.
     ///
     /// # Usage
     ///
-    /// ```rust
+    /// ```rust,ignore
     /// // In a function returning Result<_, CalcResult>:
     /// let dim = self.get_max_rc(sheet, row1, col1, row2, col2)
-    ///     .map_err(|_| CalcResult::new_error(Error::ERROR, *cell, ...))?;
+    ///     .map_err(|e| CalcResult::new_error(Error::ERROR, cell, e))?;
     ///
     /// // In a function returning CalcResult directly:
     /// let dim = match self.get_max_rc(sheet, row1, col1, row2, col2) {
     ///     Ok(d) => d,
-    ///     Err(_) => return CalcResult::new_error(Error::ERROR, cell, ...),
+    ///     Err(e) => return CalcResult::new_error(Error::ERROR, cell, e),
     /// };
     /// ```
     pub fn get_max_rc(
@@ -31,13 +30,13 @@ impl<'a> Model<'a> {
         col1: i32,
         row2: i32,
         col2: i32,
-    ) -> Result<WorksheetDimension, ()> {
+    ) -> Result<WorksheetDimension, String> {
         let needs_row = row1 == 1 && row2 == LAST_ROW;
         let needs_col = col1 == 1 && col2 == LAST_COLUMN;
 
         // Single worksheet() call covers both row and column resolution.
         let (r_max, c_max) = if needs_row || needs_col {
-            let dim = self.workbook.worksheet(sheet).map_err(|_| ())?.dimension();
+            let dim = self.workbook.worksheet(sheet)?.dimension();
             (
                 if needs_row { dim.max_row } else { row2 },
                 if needs_col { dim.max_column } else { col2 },

--- a/base/src/functions/statistical/count_and_average.rs
+++ b/base/src/functions/statistical/count_and_average.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::parser::ArrayNode;
 use crate::expressions::types::CellReferenceIndex;
+use crate::worksheet::WorksheetDimension;
 use crate::{
     calc_result::CalcResult, expressions::parser::Node, expressions::token::Error, model::Model,
 };
@@ -494,38 +495,50 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..=row2 {
-                        for column in column1..=column2 {
+                    // for row in row1..=row2 {
+                    //     for column in column1..=column2 {
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,

--- a/base/src/functions/statistical/count_and_average.rs
+++ b/base/src/functions/statistical/count_and_average.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 
-use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::parser::ArrayNode;
 use crate::expressions::types::CellReferenceIndex;
 use crate::worksheet::WorksheetDimension;
@@ -74,8 +73,18 @@ impl<'a> Model<'a> {
                         ));
                     }
 
-                    for row in left.row..=right.row {
-                        for column in left.column..=right.column {
+                    let dx = self
+                        .get_max_rc(left.sheet, left.row, left.column, right.row, right.column)
+                        .map_err(|_| {
+                            CalcResult::new_error(
+                                Error::ERROR,
+                                cell,
+                                "Invalid worksheet index".to_string(),
+                            )
+                        })?;
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -171,8 +180,18 @@ impl<'a> Model<'a> {
                         ));
                     }
 
-                    for row in left.row..=right.row {
-                        for column in left.column..=right.column {
+                    let dx = self
+                        .get_max_rc(left.sheet, left.row, left.column, right.row, right.column)
+                        .map_err(|_| {
+                            CalcResult::new_error(
+                                Error::ERROR,
+                                cell,
+                                "Invalid worksheet index".to_string(),
+                            )
+                        })?;
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -360,8 +379,24 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..(right.row + 1) {
-                        for column in left.column..(right.column + 1) {
+                    let dx = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => {
+                            return CalcResult::new_error(
+                                Error::ERROR,
+                                cell,
+                                "Invalid worksheet index".to_string(),
+                            )
+                        }
+                    };
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             if let CalcResult::Number(_) = self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -396,8 +431,24 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..(right.row + 1) {
-                        for column in left.column..(right.column + 1) {
+                    let dx = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => {
+                            return CalcResult::new_error(
+                                Error::ERROR,
+                                cell,
+                                "Invalid worksheet index".to_string(),
+                            )
+                        }
+                    };
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -441,8 +492,24 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..(right.row + 1) {
-                        for column in left.column..(right.column + 1) {
+                    let dx = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => {
+                            return CalcResult::new_error(
+                                Error::ERROR,
+                                cell,
+                                "Invalid worksheet index".to_string(),
+                            )
+                        }
+                    };
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -503,40 +570,11 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
-                    // let row1 = left.row;
-                    // let mut row2 = right.row;
-                    // let column1 = left.column;
-                    // let mut column2 = right.column;
 
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-
-                    // for row in row1..=row2 {
-                    //     for column in column1..=column2 {
                     for row in dx.min_row..=dx.max_row {
                         for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {

--- a/base/src/functions/statistical/devsq.rs
+++ b/base/src/functions/statistical/devsq.rs
@@ -1,4 +1,3 @@
-use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::parser::ArrayNode;
 use crate::expressions::types::CellReferenceIndex;
 use crate::{
@@ -78,7 +77,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {

--- a/base/src/functions/statistical/devsq.rs
+++ b/base/src/functions/statistical/devsq.rs
@@ -3,6 +3,7 @@ use crate::expressions::parser::ArrayNode;
 use crate::expressions::types::CellReferenceIndex;
 use crate::{
     calc_result::CalcResult, expressions::parser::Node, expressions::token::Error, model::Model,
+    worksheet::WorksheetDimension,
 };
 
 impl<'a> Model<'a> {
@@ -37,38 +38,51 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,

--- a/base/src/functions/statistical/devsq.rs
+++ b/base/src/functions/statistical/devsq.rs
@@ -37,38 +37,7 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    // let row1 = left.row;
-                    // let mut row2 = right.row;
-                    // let column1 = left.column;
-                    // let mut column2 = right.column;
 
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-
-                    // for row in row1..row2 + 1 {
-                    //     for column in column1..(column2 + 1) {
                     let dx: WorksheetDimension = match self.get_max_rc(
                         left.sheet,
                         left.row,

--- a/base/src/functions/statistical/if_ifs.rs
+++ b/base/src/functions/statistical/if_ifs.rs
@@ -1,6 +1,7 @@
 use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::types::CellReferenceIndex;
 use crate::functions::util::build_criteria;
+use crate::worksheet::WorksheetDimension;
 use crate::{
     calc_result::{CalcResult, Range},
     expressions::parser::Node,
@@ -224,38 +225,49 @@ impl<'a> Model<'a> {
             fn_criteria.push(build_criteria(criterion));
         }
 
-        let left_row = sum_range.left.row;
-        let left_column = sum_range.left.column;
-        let mut right_row = sum_range.right.row;
-        let mut right_column = sum_range.right.column;
+        // let left_row = sum_range.left.row;
+        // let left_column = sum_range.left.column;
+        // let mut right_row = sum_range.right.row;
+        // let mut right_column = sum_range.right.column;
 
-        if left_row == 1 && right_row == LAST_ROW {
-            right_row = match self.workbook.worksheet(sum_range.left.sheet) {
-                Ok(s) => s.dimension().max_row,
-                Err(_) => {
-                    return Err(CalcResult::new_error(
-                        Error::ERROR,
-                        cell,
-                        format!("Invalid worksheet index: '{}'", sum_range.left.sheet),
-                    ));
-                }
-            };
-        }
-        if left_column == 1 && right_column == LAST_COLUMN {
-            right_column = match self.workbook.worksheet(sum_range.left.sheet) {
-                Ok(s) => s.dimension().max_column,
-                Err(_) => {
-                    return Err(CalcResult::new_error(
-                        Error::ERROR,
-                        cell,
-                        format!("Invalid worksheet index: '{}'", sum_range.left.sheet),
-                    ));
-                }
-            };
-        }
+        // if left_row == 1 && right_row == LAST_ROW {
+        //     right_row = match self.workbook.worksheet(sum_range.left.sheet) {
+        //         Ok(s) => s.dimension().max_row,
+        //         Err(_) => {
+        //             return Err(CalcResult::new_error(
+        //                 Error::ERROR,
+        //                 cell,
+        //                 format!("Invalid worksheet index: '{}'", sum_range.left.sheet),
+        //             ));
+        //         }
+        //     };
+        // }
+        // if left_column == 1 && right_column == LAST_COLUMN {
+        //     right_column = match self.workbook.worksheet(sum_range.left.sheet) {
+        //         Ok(s) => s.dimension().max_column,
+        //         Err(_) => {
+        //             return Err(CalcResult::new_error(
+        //                 Error::ERROR,
+        //                 cell,
+        //                 format!("Invalid worksheet index: '{}'", sum_range.left.sheet),
+        //             ));
+        //         }
+        //     };
+        // }
+        // for row in left_row..right_row + 1 {
+        //     for column in left_column..right_column + 1 {
+        let dx: WorksheetDimension = self
+            .get_max_rc(
+                sum_range.left.sheet,
+                sum_range.left.row,
+                sum_range.left.column,
+                sum_range.right.row,
+                sum_range.right.column,
+            )
+            .map_err(|_| CalcResult::new_error(Error::ERROR, cell, format!("...")))?;
 
-        for row in left_row..right_row + 1 {
-            for column in left_column..right_column + 1 {
+        for row in dx.min_row..=dx.max_row {
+            for column in dx.min_column..=dx.max_column {
                 let mut is_true = true;
                 for case_index in 0..case_count {
                     // We check if value in range n meets criterion n

--- a/base/src/functions/statistical/if_ifs.rs
+++ b/base/src/functions/statistical/if_ifs.rs
@@ -264,7 +264,7 @@ impl<'a> Model<'a> {
                 sum_range.right.row,
                 sum_range.right.column,
             )
-            .map_err(|_| CalcResult::new_error(Error::ERROR, cell, format!("...")))?;
+            .map_err(|_| CalcResult::new_error(Error::ERROR, cell, "...".to_string()))?;
 
         for row in dx.min_row..=dx.max_row {
             for column in dx.min_column..=dx.max_column {

--- a/base/src/functions/statistical/if_ifs.rs
+++ b/base/src/functions/statistical/if_ifs.rs
@@ -225,37 +225,6 @@ impl<'a> Model<'a> {
             fn_criteria.push(build_criteria(criterion));
         }
 
-        // let left_row = sum_range.left.row;
-        // let left_column = sum_range.left.column;
-        // let mut right_row = sum_range.right.row;
-        // let mut right_column = sum_range.right.column;
-
-        // if left_row == 1 && right_row == LAST_ROW {
-        //     right_row = match self.workbook.worksheet(sum_range.left.sheet) {
-        //         Ok(s) => s.dimension().max_row,
-        //         Err(_) => {
-        //             return Err(CalcResult::new_error(
-        //                 Error::ERROR,
-        //                 cell,
-        //                 format!("Invalid worksheet index: '{}'", sum_range.left.sheet),
-        //             ));
-        //         }
-        //     };
-        // }
-        // if left_column == 1 && right_column == LAST_COLUMN {
-        //     right_column = match self.workbook.worksheet(sum_range.left.sheet) {
-        //         Ok(s) => s.dimension().max_column,
-        //         Err(_) => {
-        //             return Err(CalcResult::new_error(
-        //                 Error::ERROR,
-        //                 cell,
-        //                 format!("Invalid worksheet index: '{}'", sum_range.left.sheet),
-        //             ));
-        //         }
-        //     };
-        // }
-        // for row in left_row..right_row + 1 {
-        //     for column in left_column..right_column + 1 {
         let dx: WorksheetDimension = self
             .get_max_rc(
                 sum_range.left.sheet,

--- a/base/src/functions/statistical/standard_dev.rs
+++ b/base/src/functions/statistical/standard_dev.rs
@@ -1,4 +1,3 @@
-use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::parser::ArrayNode;
 use crate::expressions::types::CellReferenceIndex;
 use crate::worksheet::WorksheetDimension;
@@ -77,7 +76,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {
@@ -215,7 +216,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {
@@ -352,7 +355,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {
@@ -496,7 +501,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {

--- a/base/src/functions/statistical/standard_dev.rs
+++ b/base/src/functions/statistical/standard_dev.rs
@@ -1,6 +1,7 @@
 use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::parser::ArrayNode;
 use crate::expressions::types::CellReferenceIndex;
+use crate::worksheet::WorksheetDimension;
 use crate::{
     calc_result::CalcResult, expressions::parser::Node, expressions::token::Error, model::Model,
 };
@@ -36,38 +37,51 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -161,38 +175,51 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -285,38 +312,51 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -416,38 +456,51 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,

--- a/base/src/functions/statistical/variance.rs
+++ b/base/src/functions/statistical/variance.rs
@@ -1,4 +1,3 @@
-use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::parser::ArrayNode;
 use crate::expressions::types::CellReferenceIndex;
 use crate::worksheet::WorksheetDimension;
@@ -77,7 +76,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {
@@ -214,7 +215,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {
@@ -319,40 +322,11 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
-                    // let row1 = left.row;
-                    // let mut row2 = right.row;
-                    // let column1 = left.column;
-                    // let mut column2 = right.column;
 
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-
-                    // for row in row1..=row2 {
-                    //     for column in column1..=column2 {
                     for row in dx.min_row..=dx.max_row {
                         for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
@@ -454,38 +428,6 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    // let row1 = left.row;
-                    // let mut row2 = right.row;
-                    // let column1 = left.column;
-                    // let mut column2 = right.column;
-
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-
-                    // for row in row1..row2 + 1 {
-                    //     for column in column1..(column2 + 1) {
                     let dx: WorksheetDimension = match self.get_max_rc(
                         left.sheet,
                         left.row,
@@ -494,7 +436,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {

--- a/base/src/functions/statistical/variance.rs
+++ b/base/src/functions/statistical/variance.rs
@@ -36,38 +36,6 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    // let row1 = left.row;
-                    // let mut row2 = right.row;
-                    // let column1 = left.column;
-                    // let mut column2 = right.column;
-
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-
-                    // for row in row1..row2 + 1 {
-                    //     for column in column1..(column2 + 1) {
                     let dx: WorksheetDimension = match self.get_max_rc(
                         left.sheet,
                         left.row,
@@ -175,38 +143,6 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    // let row1 = left.row;
-                    // let mut row2 = right.row;
-                    // let column1 = left.column;
-                    // let mut column2 = right.column;
-
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-
-                    // for row in row1..row2 + 1 {
-                    //     for column in column1..(column2 + 1) {
                     let dx: WorksheetDimension = match self.get_max_rc(
                         left.sheet,
                         left.row,

--- a/base/src/functions/statistical/variance.rs
+++ b/base/src/functions/statistical/variance.rs
@@ -1,6 +1,7 @@
 use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::parser::ArrayNode;
 use crate::expressions::types::CellReferenceIndex;
+use crate::worksheet::WorksheetDimension;
 use crate::{
     calc_result::CalcResult, expressions::parser::Node, expressions::token::Error, model::Model,
 };
@@ -36,38 +37,51 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -160,38 +174,51 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -284,38 +311,50 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..=row2 {
-                        for column in column1..=column2 {
+                    // for row in row1..=row2 {
+                    //     for column in column1..=column2 {
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,
@@ -415,38 +454,51 @@ impl<'a> Model<'a> {
                         );
                     }
 
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
 
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,

--- a/base/src/functions/subtotal.rs
+++ b/base/src/functions/subtotal.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     functions::Function,
     model::Model,
+    worksheet::WorksheetDimension,
 };
 
 /// Excel has a complicated way of filtering + hidden rows
@@ -142,14 +143,27 @@ impl<'a> Model<'a> {
                                 ));
                             }
                             // We are not expecting subtotal to have open ranges
-                            let row1 = left.row;
-                            let row2 = right.row;
-                            let column1 = left.column;
-                            let column2 = right.column;
+                            // let row1 = left.row;
+                            // let row2 = right.row;
+                            // let column1 = left.column;
+                            // let column2 = right.column;
 
-                            for row in row1..=row2 {
+                            let dx: WorksheetDimension = self
+                                .get_max_rc(
+                                    left.sheet,
+                                    left.row,
+                                    left.column,
+                                    right.row,
+                                    right.column,
+                                )
+                                .map_err(|_| {
+                                    CalcResult::new_error(Error::ERROR, cell, format!("..."))
+                                })?;
+
+                            // for row in row1..=row2 {
+                            for row in dx.min_row..=dx.max_row {
                                 let cell_status = self
-                                    .cell_hidden_status(left.sheet, row, column1)
+                                    .cell_hidden_status(left.sheet, row, dx.min_column)
                                     .map_err(|message| {
                                         CalcResult::new_error(Error::ERROR, cell, message)
                                     })?;
@@ -161,7 +175,8 @@ impl<'a> Model<'a> {
                                 {
                                     continue;
                                 }
-                                for column in column1..=column2 {
+                                // for column in column1..=column2 {
+                                for column in dx.min_column..=dx.max_column {
                                     if self.cell_is_subtotal(left.sheet, row, column) {
                                         continue;
                                     }
@@ -390,20 +405,42 @@ impl<'a> Model<'a> {
                                 );
                             }
                             // We are not expecting subtotal to have open ranges
-                            let row1 = left.row;
-                            let row2 = right.row;
-                            let column1 = left.column;
-                            let column2 = right.column;
+                            // let row1 = left.row;
+                            // let row2 = right.row;
+                            // let column1 = left.column;
+                            // let column2 = right.column;
 
-                            for row in row1..=row2 {
-                                let cell_status = match self
-                                    .cell_hidden_status(left.sheet, row, column1)
-                                {
-                                    Ok(s) => s,
-                                    Err(message) => {
-                                        return CalcResult::new_error(Error::ERROR, cell, message);
-                                    }
-                                };
+                            let dx: WorksheetDimension = match self.get_max_rc(
+                                left.sheet,
+                                left.row,
+                                left.column,
+                                right.row,
+                                right.column,
+                            ) {
+                                Ok(d) => d,
+                                Err(_) => {
+                                    return CalcResult::new_error(
+                                        Error::ERROR,
+                                        cell,
+                                        format!("..."),
+                                    )
+                                }
+                            };
+
+                            // for row in row1..=row2 {
+                            // for row in row1..=row2 {
+                            for row in dx.min_row..=dx.max_row {
+                                let cell_status =
+                                    match self.cell_hidden_status(left.sheet, row, dx.min_column) {
+                                        Ok(s) => s,
+                                        Err(message) => {
+                                            return CalcResult::new_error(
+                                                Error::ERROR,
+                                                cell,
+                                                message,
+                                            );
+                                        }
+                                    };
                                 if cell_status == CellTableStatus::Filtered {
                                     continue;
                                 }
@@ -412,7 +449,7 @@ impl<'a> Model<'a> {
                                 {
                                     continue;
                                 }
-                                for column in column1..=column2 {
+                                for column in dx.min_column..=dx.max_column {
                                     if self.cell_is_subtotal(left.sheet, row, column) {
                                         continue;
                                     }
@@ -478,15 +515,36 @@ impl<'a> Model<'a> {
                             let column1 = left.column;
                             let column2 = right.column;
 
-                            for row in row1..=row2 {
-                                let cell_status = match self
-                                    .cell_hidden_status(left.sheet, row, column1)
-                                {
-                                    Ok(s) => s,
-                                    Err(message) => {
-                                        return CalcResult::new_error(Error::ERROR, cell, message);
-                                    }
-                                };
+                            let dx: WorksheetDimension = match self.get_max_rc(
+                                left.sheet,
+                                left.row,
+                                left.column,
+                                right.row,
+                                right.column,
+                            ) {
+                                Ok(d) => d,
+                                Err(_) => {
+                                    return CalcResult::new_error(
+                                        Error::ERROR,
+                                        cell,
+                                        format!("..."),
+                                    )
+                                }
+                            };
+
+                            // for row in row1..=row2 {
+                            for row in dx.min_row..=dx.max_row {
+                                let cell_status =
+                                    match self.cell_hidden_status(left.sheet, row, dx.min_column) {
+                                        Ok(s) => s,
+                                        Err(message) => {
+                                            return CalcResult::new_error(
+                                                Error::ERROR,
+                                                cell,
+                                                message,
+                                            );
+                                        }
+                                    };
                                 if cell_status == CellTableStatus::Filtered {
                                     continue;
                                 }
@@ -495,7 +553,7 @@ impl<'a> Model<'a> {
                                 {
                                     continue;
                                 }
-                                for column in column1..=column2 {
+                                for column in dx.min_column..=dx.max_column {
                                     if self.cell_is_subtotal(left.sheet, row, column) {
                                         continue;
                                     }

--- a/base/src/functions/subtotal.rs
+++ b/base/src/functions/subtotal.rs
@@ -143,11 +143,6 @@ impl<'a> Model<'a> {
                                 ));
                             }
                             // We are not expecting subtotal to have open ranges
-                            // let row1 = left.row;
-                            // let row2 = right.row;
-                            // let column1 = left.column;
-                            // let column2 = right.column;
-
                             let dx: WorksheetDimension = self
                                 .get_max_rc(
                                     left.sheet,
@@ -157,10 +152,9 @@ impl<'a> Model<'a> {
                                     right.column,
                                 )
                                 .map_err(|_| {
-                                    CalcResult::new_error(Error::ERROR, cell, format!("..."))
+                                    CalcResult::new_error(Error::ERROR, cell, "...".to_string())
                                 })?;
 
-                            // for row in row1..=row2 {
                             for row in dx.min_row..=dx.max_row {
                                 let cell_status = self
                                     .cell_hidden_status(left.sheet, row, dx.min_column)
@@ -404,11 +398,6 @@ impl<'a> Model<'a> {
                                     "Ranges are in different sheets".to_string(),
                                 );
                             }
-                            // We are not expecting subtotal to have open ranges
-                            // let row1 = left.row;
-                            // let row2 = right.row;
-                            // let column1 = left.column;
-                            // let column2 = right.column;
 
                             let dx: WorksheetDimension = match self.get_max_rc(
                                 left.sheet,
@@ -422,13 +411,11 @@ impl<'a> Model<'a> {
                                     return CalcResult::new_error(
                                         Error::ERROR,
                                         cell,
-                                        format!("..."),
+                                        "...".to_string(),
                                     )
                                 }
                             };
 
-                            // for row in row1..=row2 {
-                            // for row in row1..=row2 {
                             for row in dx.min_row..=dx.max_row {
                                 let cell_status =
                                     match self.cell_hidden_status(left.sheet, row, dx.min_column) {
@@ -509,12 +496,8 @@ impl<'a> Model<'a> {
                                     "Ranges are in different sheets".to_string(),
                                 );
                             }
-                            // We are not expecting subtotal to have open ranges
-                            let row1 = left.row;
-                            let row2 = right.row;
-                            let column1 = left.column;
-                            let column2 = right.column;
 
+                            // We are not expecting subtotal to have open ranges
                             let dx: WorksheetDimension = match self.get_max_rc(
                                 left.sheet,
                                 left.row,
@@ -527,12 +510,11 @@ impl<'a> Model<'a> {
                                     return CalcResult::new_error(
                                         Error::ERROR,
                                         cell,
-                                        format!("..."),
+                                        "...".to_string(),
                                     )
                                 }
                             };
 
-                            // for row in row1..=row2 {
                             for row in dx.min_row..=dx.max_row {
                                 let cell_status =
                                     match self.cell_hidden_status(left.sheet, row, dx.min_column) {

--- a/base/src/functions/text.rs
+++ b/base/src/functions/text.rs
@@ -1026,36 +1026,7 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    // let row1 = left.row;
-                    // let mut row2 = right.row;
-                    // let column1 = left.column;
-                    // let mut column2 = right.column;
-                    // if row1 == 1 && row2 == LAST_ROW {
-                    //     row2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_row,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // if column1 == 1 && column2 == LAST_COLUMN {
-                    //     column2 = match self.workbook.worksheet(left.sheet) {
-                    //         Ok(s) => s.dimension().max_column,
-                    //         Err(_) => {
-                    //             return CalcResult::new_error(
-                    //                 Error::ERROR,
-                    //                 cell,
-                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                    //             );
-                    //         }
-                    //     };
-                    // }
-                    // for row in row1..row2 + 1 {
-                    //     for column in column1..(column2 + 1) {
+
                     let dx: WorksheetDimension = match self.get_max_rc(
                         left.sheet,
                         left.row,

--- a/base/src/functions/text.rs
+++ b/base/src/functions/text.rs
@@ -1,10 +1,10 @@
 use crate::{
     calc_result::CalcResult,
-    constants::{LAST_COLUMN, LAST_ROW},
     expressions::{parser::Node, token::Error, types::CellReferenceIndex},
     formatter::format::{format_number, parse_formatted_number},
     model::Model,
     number_format::to_precision,
+    worksheet::WorksheetDimension,
 };
 
 use super::{
@@ -1026,36 +1026,49 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    let row1 = left.row;
-                    let mut row2 = right.row;
-                    let column1 = left.column;
-                    let mut column2 = right.column;
-                    if row1 == 1 && row2 == LAST_ROW {
-                        row2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_row,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    if column1 == 1 && column2 == LAST_COLUMN {
-                        column2 = match self.workbook.worksheet(left.sheet) {
-                            Ok(s) => s.dimension().max_column,
-                            Err(_) => {
-                                return CalcResult::new_error(
-                                    Error::ERROR,
-                                    cell,
-                                    format!("Invalid worksheet index: '{}'", left.sheet),
-                                );
-                            }
-                        };
-                    }
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
+                    // let row1 = left.row;
+                    // let mut row2 = right.row;
+                    // let column1 = left.column;
+                    // let mut column2 = right.column;
+                    // if row1 == 1 && row2 == LAST_ROW {
+                    //     row2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_row,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // if column1 == 1 && column2 == LAST_COLUMN {
+                    //     column2 = match self.workbook.worksheet(left.sheet) {
+                    //         Ok(s) => s.dimension().max_column,
+                    //         Err(_) => {
+                    //             return CalcResult::new_error(
+                    //                 Error::ERROR,
+                    //                 cell,
+                    //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                    //             );
+                    //         }
+                    //     };
+                    // }
+                    // for row in row1..row2 + 1 {
+                    //     for column in column1..(column2 + 1) {
+                    let dx: WorksheetDimension = match self.get_max_rc(
+                        left.sheet,
+                        left.row,
+                        left.column,
+                        right.row,
+                        right.column,
+                    ) {
+                        Ok(d) => d,
+                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                    };
+
+                    for row in dx.min_row..=dx.max_row {
+                        for column in dx.min_column..=dx.max_column {
                             match self.evaluate_cell(CellReferenceIndex {
                                 sheet: left.sheet,
                                 row,

--- a/base/src/functions/text.rs
+++ b/base/src/functions/text.rs
@@ -1064,7 +1064,9 @@ impl<'a> Model<'a> {
                         right.column,
                     ) {
                         Ok(d) => d,
-                        Err(_) => return CalcResult::new_error(Error::ERROR, cell, format!("...")),
+                        Err(_) => {
+                            return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
+                        }
                     };
 
                     for row in dx.min_row..=dx.max_row {

--- a/base/src/functions/xlookup.rs
+++ b/base/src/functions/xlookup.rs
@@ -245,35 +245,6 @@ impl<'a> Model<'a> {
                                 message: "Arrays must be of the same size".to_string(),
                             };
                         }
-                        // let mut row2 = right.row;
-                        // let row1 = left.row;
-                        // let mut column2 = right.column;
-                        // let column1 = left.column;
-
-                        // if row1 == 1 && row2 == LAST_ROW {
-                        //     row2 = match self.workbook.worksheet(left.sheet) {
-                        //         Ok(s) => s.dimension().max_row,
-                        //         Err(_) => {
-                        //             return CalcResult::new_error(
-                        //                 Error::ERROR,
-                        //                 cell,
-                        //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                        //             );
-                        //         }
-                        //     };
-                        // }
-                        // if column1 == 1 && column2 == LAST_COLUMN {
-                        //     column2 = match self.workbook.worksheet(left.sheet) {
-                        //         Ok(s) => s.dimension().max_column,
-                        //         Err(_) => {
-                        //             return CalcResult::new_error(
-                        //                 Error::ERROR,
-                        //                 cell,
-                        //                 format!("Invalid worksheet index: '{}'", left.sheet),
-                        //             );
-                        //         }
-                        //     };
-                        // }
 
                         let dx: WorksheetDimension = match self.get_max_rc(
                             left.sheet,

--- a/base/src/functions/xlookup.rs
+++ b/base/src/functions/xlookup.rs
@@ -1,5 +1,6 @@
 use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::types::CellReferenceIndex;
+use crate::worksheet::WorksheetDimension;
 use crate::{
     calc_result::CalcResult, expressions::parser::Node, expressions::token::Error, model::Model,
 };
@@ -245,44 +246,58 @@ impl<'a> Model<'a> {
                                 message: "Arrays must be of the same size".to_string(),
                             };
                         }
-                        let mut row2 = right.row;
-                        let row1 = left.row;
-                        let mut column2 = right.column;
-                        let column1 = left.column;
+                        // let mut row2 = right.row;
+                        // let row1 = left.row;
+                        // let mut column2 = right.column;
+                        // let column1 = left.column;
 
-                        if row1 == 1 && row2 == LAST_ROW {
-                            row2 = match self.workbook.worksheet(left.sheet) {
-                                Ok(s) => s.dimension().max_row,
-                                Err(_) => {
-                                    return CalcResult::new_error(
-                                        Error::ERROR,
-                                        cell,
-                                        format!("Invalid worksheet index: '{}'", left.sheet),
-                                    );
-                                }
-                            };
-                        }
-                        if column1 == 1 && column2 == LAST_COLUMN {
-                            column2 = match self.workbook.worksheet(left.sheet) {
-                                Ok(s) => s.dimension().max_column,
-                                Err(_) => {
-                                    return CalcResult::new_error(
-                                        Error::ERROR,
-                                        cell,
-                                        format!("Invalid worksheet index: '{}'", left.sheet),
-                                    );
-                                }
-                            };
-                        }
+                        // if row1 == 1 && row2 == LAST_ROW {
+                        //     row2 = match self.workbook.worksheet(left.sheet) {
+                        //         Ok(s) => s.dimension().max_row,
+                        //         Err(_) => {
+                        //             return CalcResult::new_error(
+                        //                 Error::ERROR,
+                        //                 cell,
+                        //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                        //             );
+                        //         }
+                        //     };
+                        // }
+                        // if column1 == 1 && column2 == LAST_COLUMN {
+                        //     column2 = match self.workbook.worksheet(left.sheet) {
+                        //         Ok(s) => s.dimension().max_column,
+                        //         Err(_) => {
+                        //             return CalcResult::new_error(
+                        //                 Error::ERROR,
+                        //                 cell,
+                        //                 format!("Invalid worksheet index: '{}'", left.sheet),
+                        //             );
+                        //         }
+                        //     };
+                        // }
+
+                        let dx: WorksheetDimension = match self.get_max_rc(
+                            left.sheet,
+                            left.row,
+                            left.column,
+                            right.row,
+                            right.column,
+                        ) {
+                            Ok(d) => d,
+                            Err(_) => {
+                                return CalcResult::new_error(Error::ERROR, cell, format!("..."))
+                            }
+                        };
+
                         let left = CellReferenceIndex {
                             sheet: left.sheet,
-                            column: column1,
-                            row: row1,
+                            column: dx.min_column,
+                            row: dx.min_row,
                         };
                         let right = CellReferenceIndex {
                             sheet: left.sheet,
-                            column: column2,
-                            row: row2,
+                            column: dx.max_column,
+                            row: dx.max_row,
                         };
                         match search_mode {
                             SearchMode::StartAtFirstItem | SearchMode::StartAtLastItem => {

--- a/base/src/functions/xlookup.rs
+++ b/base/src/functions/xlookup.rs
@@ -1,4 +1,3 @@
-use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::types::CellReferenceIndex;
 use crate::worksheet::WorksheetDimension;
 use crate::{
@@ -285,7 +284,7 @@ impl<'a> Model<'a> {
                         ) {
                             Ok(d) => d,
                             Err(_) => {
-                                return CalcResult::new_error(Error::ERROR, cell, format!("..."))
+                                return CalcResult::new_error(Error::ERROR, cell, "...".to_string())
                             }
                         };
 


### PR DESCRIPTION
I extracted logic to clamp column/row range when using A:A in formulas to the `get_max_rc()` implementation to model in a `base/src/functions/model_util.rs`.
Some functions ie. in `subtotal.rs`, the clamping code was missing - it would iterate over all 1 million rows.

Functions updated COUNT, COUNTA, COUNTBLANK, AVERAGE, SUM, SUMPRODUCT, STDEV, VAR, DEVSQ, AVERAGE, MEDIAN, MODE, PERCENTILE, QUARTILE, and helpers `for_each_value()` and `for_each_value_a()`.

Fix: use `get_max_rc()` to resolve ` LAST_ROW/LAST_COLUMN ` sentinels to
actual sheet dimensions before iterating


I'm not certain how to correctly test this in code. I added bench to my page:
Before:
<img width="458" height="19" alt="output_20260328T191302" src="https://github.com/user-attachments/assets/bca81289-f9fe-4fa0-938a-e7838872bd1e" />

After: 
<img width="451" height="24" alt="output_20260328T191813" src="https://github.com/user-attachments/assets/179f811d-1b92-43ba-88c6-6a9f1d3e9726" />

Edit: testing