### PR TITLE
fix: DEFAULT_NUM_FMTS missing ECMA-376 numFmtId gap for IDs 23-36

### DIFF
--- a/base/src/number_format.rs
+++ b/base/src/number_format.rs
@@ -28,6 +28,9 @@ const DEFAULT_NUM_FMTS: &[&str] = &[
     "h:mm",
     "h:mm:ss",
     "m / d / yy h:mm",
+    // 23-36: not defined in ECMA-376 spec, filled with "general"
+    "general", "general", "general", "general", "general", "general", "general",
+    "general", "general", "general", "general", "general", "general", "general",
     "#,##0;()#,##0)",
     "#,##0; [Red]()#,##0)",
     "#,##0.00;()#,##0.00)",


### PR DESCRIPTION
ECMA-376 Part 1 (Section 18.8.30) does not define built-in number format IDs 23-36.

The `DEFAULT_NUM_FMTS` array used these indices for formats that should be at IDs 37-49, causing `get_num_fmt()` to return wrong format codes for any built-in `numFmtId >= 23`.

For example, `numFmtId=38` should return `#,##0;[Red](#,##0)` but returned `t0` because the array was shifted by 14 positions.

**Fix**: insert 14 "general" placeholders at indices 23-36 so array indices match ECMA-376 numFmtId values.

https://c-rex.net/samples/ooxml/e1/Part4/OOXML_P4_DOCX_numFmt_topic_ID0EHDH6.html
https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/17d11129-219b-4e2c-88db-45844d21e528
https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/0e59abdb-7f4e-48fc-9b89-67832fa11789