### PR TITLE
UPDATE: Refactor color pickers to improve accessibility and focus handling

### DIFF
--- a/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/AdvancedColorPicker.tsx
+++ b/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/AdvancedColorPicker.tsx
@@ -1,11 +1,13 @@
 import { Check } from "lucide-react";
 import type { RefObject } from "react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import { HexColorInput, HexColorPicker } from "react-colorful";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "../Button/Button";
 import "./advanced-color-picker.css";
+import { getFocusableElements } from "../util";
+import { useKeyDown } from "./useKeyDown";
 
 type AdvancedColorPickerProps = {
   color: string;
@@ -33,11 +35,20 @@ const AdvancedColorPicker = ({
   const [position, setPosition] = useState<Position>({ top: 0, left: 0 });
   const recentColors = useRef<string[]>([]);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const hexInputId = useId();
   const { t } = useTranslation();
 
   useEffect(() => {
     setSelectedColor(color);
   }, [color]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    panelRef.current?.querySelector<HTMLElement>("input, button")?.focus();
+  }, [open]);
 
   // poor person's popover positioning logic
   useLayoutEffect(() => {
@@ -102,24 +113,10 @@ const AdvancedColorPicker = ({
     };
   }, [open, anchorEl]);
 
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onCancel();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown, true);
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown, true);
-    };
-  }, [open, onCancel]);
+  const { onKeyDown } = useKeyDown({
+    onEscape: onCancel,
+    getFocusableElements: () => getFocusableElements(panelRef.current),
+  });
 
   const handleColorSelect = (newColor: string) => {
     if (!recentColors.current.includes(newColor)) {
@@ -140,12 +137,8 @@ const AdvancedColorPicker = ({
   }
 
   return createPortal(
-    <div className="ic-advanced-color-picker-layer">
-      <div
-        className="ic-advanced-color-picker-backdrop"
-        onClick={onCancel}
-        aria-hidden="true"
-      />
+    <div className="ic-menu-layer">
+      <div className="ic-menu-backdrop" onClick={onCancel} aria-hidden="true" />
 
       <div
         ref={panelRef}
@@ -157,8 +150,17 @@ const AdvancedColorPicker = ({
         role="dialog"
         aria-modal="true"
         aria-label={t("color_picker.title")}
+        onKeyDown={onKeyDown}
       >
-        <div className="ic-advanced-color-picker">
+        {/** biome-ignore lint/a11y/noStaticElementInteractions: FIXME */}
+        {/** biome-ignore lint/a11y/useKeyWithClickEvents: FIXME */}
+        <div
+          className="ic-advanced-color-picker"
+          onClick={(event) => {
+            // Otherwise the sheet would grab the keyboard focus
+            event.stopPropagation();
+          }}
+        >
           <HexColorPicker
             color={selectedColor}
             onChange={(newColor): void => {
@@ -170,18 +172,23 @@ const AdvancedColorPicker = ({
 
           <div className="ic-advanced-color-picker-input-row">
             <div className="ic-advanced-color-picker-hex-wrapper">
-              <div className="ic-advanced-color-picker-hex-label">Hex</div>
+              <label
+                className="ic-advanced-color-picker-hex-label"
+                htmlFor={hexInputId}
+              >
+                Hex
+              </label>
 
               <div className="ic-advanced-color-picker-hex-input-box">
                 <div className="ic-advanced-color-picker-hash-label">#</div>
 
                 <HexColorInput
+                  id={hexInputId}
                   className="ic-advanced-color-picker-hex-input"
                   color={selectedColor}
                   onChange={(newColor): void => {
                     setSelectedColor(newColor);
                   }}
-                  tabIndex={0}
                 />
               </div>
             </div>
@@ -199,6 +206,7 @@ const AdvancedColorPicker = ({
                   ? "var(--palette-grey-300)"
                   : selectedColor,
               }}
+              aria-hidden="true"
             />
           </div>
 

--- a/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/advanced-color-picker.css
+++ b/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/advanced-color-picker.css
@@ -77,7 +77,7 @@
 }
 
 .ic-advanced-color-picker-hex-input-box:focus-within {
-  outline: 2px solid var(--palette-secondary-main);
+  outline: 2px solid var(--palette-primary-main);
   outline-offset: 1px;
 }
 
@@ -119,17 +119,6 @@
   justify-content: space-between;
   margin: 8px;
   gap: 8px;
-}
-
-.ic-advanced-color-picker-layer {
-  position: fixed;
-  inset: 0;
-  z-index: 1300;
-}
-
-.ic-advanced-color-picker-backdrop {
-  position: fixed;
-  inset: 0;
 }
 
 .ic-advanced-color-picker-panel {

--- a/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/useKeyDown.ts
+++ b/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/useKeyDown.ts
@@ -1,0 +1,54 @@
+import { type KeyboardEvent, useCallback } from "react";
+
+interface Options {
+  onEscape: () => void;
+  getFocusableElements: () => HTMLElement[];
+}
+
+// Simple navigation:
+// * Tab/Shift+Tab: cycle through focusable elements
+// * Escape: close the picker
+export const useKeyDown = (
+  options: Options,
+): { onKeyDown: (event: KeyboardEvent) => void } => {
+  const { onEscape, getFocusableElements } = options;
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onEscape();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const focusable = getFocusableElements();
+
+      if (focusable.length === 0) {
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    },
+    [getFocusableElements, onEscape],
+  );
+
+  return { onKeyDown };
+};
+
+export default useKeyDown;

--- a/webapp/IronCalc/src/components/BorderPicker/BorderPicker.tsx
+++ b/webapp/IronCalc/src/components/BorderPicker/BorderPicker.tsx
@@ -289,10 +289,10 @@ export default function BorderPicker({
 
       <div className="ic-border-picker__menu">
         {/** biome-ignore lint/a11y/noStaticElementInteractions: FIXME */}
+        {/** biome-ignore lint/a11y/useKeyWithClickEvents: FIXME */}
         <div
           className="ic-border-picker__submenu-anchor"
-          onMouseEnter={() => setColorPickerOpen(true)}
-          onMouseLeave={() => setColorPickerOpen(false)}
+          onClick={() => setColorPickerOpen((prev) => !prev)}
         >
           <button
             ref={borderColorButtonRef}

--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
@@ -1,14 +1,19 @@
 import { Check, Plus } from "lucide-react";
 import React, {
   type CSSProperties,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import AdvancedColorPicker from "./AdvancedColorPicker";
+import AdvancedColorPicker from "../AdvancedColorPicker.tsx/AdvancedColorPicker";
+import { getFocusableElements } from "../util";
 import "./color-picker.css";
+import { createPortal } from "react-dom";
+import useKeyDown from "./useKeyDown";
+import { getCheckColor, isWhiteColor, mainColors, toneArrays } from "./util";
 
 type ColorPickerProps = {
   color: string;
@@ -22,88 +27,6 @@ type ColorPickerProps = {
 };
 
 const FALLBACK_COLOR = "#272525"; // --palette-common-black
-
-const mainColors = [
-  "#FFFFFF",
-  "#272525",
-  "#1B717E",
-  "#3BB68A",
-  "#8CB354",
-  "#F8CD3C",
-  "#F2994A",
-  "#EC5753",
-  "#523E93",
-  "#3358B7",
-];
-
-const lightTones = [
-  "#F5F5F5", // --palette-grey-50
-  "#F2F2F2", // --palette-grey-100
-  "#EEEEEE", // --palette-grey-200
-  "#E0E0E0", // --palette-grey-300
-  "#BDBDBD", // --palette-grey-400
-];
-
-const darkTones = [
-  "#9E9E9E", // --palette-grey-500
-  "#757575", // --palette-grey-600
-  "#616161", // --palette-grey-700
-  "#424242", // --palette-grey-800
-  "#333333", // --palette-grey-900
-];
-
-const tealTones = ["#BBD4D8", "#82B1B8", "#498D98", "#1E5A63", "#224348"];
-const greenTones = ["#C4E9DC", "#93D7BF", "#62C5A1", "#358A6C", "#2F5F4D"];
-const limeTones = ["#DDE8CC", "#C0D5A1", "#A3C276", "#6E8846", "#4F5E38"];
-const yellowTones = ["#FDF0C5", "#FBE394", "#F9D764", "#B99A36", "#7A682E"];
-const orangeTones = ["#FBE0C9", "#F8C79B", "#F5AD6E", "#B5763F", "#785334"];
-const redTones = ["#F9CDCB", "#F5A3A0", "#F07975", "#B14845", "#763937"];
-const purpleTones = ["#CBC5DF", "#A095C4", "#7565A9", "#453672", "#382F51"];
-const blueTones = ["#C2CDE9", "#8FA3D7", "#5D79C5", "#30498B", "#2C395F"];
-
-const toneArrays = [
-  lightTones,
-  darkTones,
-  tealTones,
-  greenTones,
-  limeTones,
-  yellowTones,
-  orangeTones,
-  redTones,
-  purpleTones,
-  blueTones,
-];
-
-// This function checks if a color is light or dark.
-// This is needed to determine the icon color, as it's not visible on light colors.
-const isLightColor = (hex: string): boolean => {
-  if (!hex.startsWith("#")) {
-    return false;
-  }
-
-  const normalized =
-    hex.length === 4
-      ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
-      : hex;
-
-  const n = parseInt(normalized.slice(1), 16);
-  const r = (n >> 16) & 255;
-  const g = (n >> 8) & 255;
-  const b = n & 255;
-
-  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-  return luminance > 160;
-};
-
-function isWhiteColor(color: string): boolean {
-  const upper = color.toUpperCase();
-  return upper === "#FFF" || upper === "#FFFFFF";
-}
-
-function getCheckColor(color: string): string {
-  // --palette-common-black: #272525;
-  return isLightColor(color) ? "#272525" : "#FFFFFF";
-}
 
 type Placement = "bottom" | "top" | "right" | "left";
 
@@ -180,6 +103,21 @@ const ColorPicker = ({
     setSelectedColor(color);
   }, [color]);
 
+  const { onKeyDown } = useKeyDown({
+    onEscape: () => {
+      setPickerOpen(false);
+      onClose();
+    },
+    getFocusableElements: () => getFocusableElements(panelRef.current),
+  });
+
+  // focus the first button when the menu opens or when the advanced picker closes
+  useEffect(() => {
+    if (open && !isPickerOpen) {
+      panelRef.current?.querySelector<HTMLButtonElement>("button")?.focus();
+    }
+  }, [open, isPickerOpen]);
+
   useLayoutEffect(() => {
     if (!open || isPickerOpen) {
       return;
@@ -206,12 +144,8 @@ const ColorPicker = ({
     };
   }, [anchorEl, open, isPickerOpen, placement]);
 
-  useEffect(() => {
-    if (!open || isPickerOpen) {
-      return;
-    }
-
-    const handlePointerDown = (event: MouseEvent) => {
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent) => {
       const target = event.target as Node | null;
       const panel = panelRef.current;
       const anchor = anchorEl.current;
@@ -229,23 +163,9 @@ const ColorPicker = ({
       }
 
       onClose();
-    };
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setPickerOpen(false);
-        onClose();
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown, true);
-    document.addEventListener("keydown", handleKeyDown, true);
-
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown, true);
-      document.removeEventListener("keydown", handleKeyDown, true);
-    };
-  }, [anchorEl, isPickerOpen, onClose, open]);
+    },
+    [onClose, anchorEl.current],
+  );
 
   const handleColorSelect = (nextColor: string) => {
     if (!recentColors.current.includes(nextColor)) {
@@ -257,7 +177,7 @@ const ColorPicker = ({
     setPickerOpen(false);
   };
 
-  const renderColorSwatch = (presetColor: string) => {
+  const renderColorSwatch = (presetColor: string, row: number, col: number) => {
     const isSelected =
       selectedColor.toUpperCase() === presetColor.toUpperCase();
 
@@ -277,6 +197,8 @@ const ColorPicker = ({
         style={{ backgroundColor: presetColor }}
         onClick={() => handleColorSelect(presetColor)}
         aria-label={presetColor}
+        data-nav-row={row}
+        data-nav-col={col}
       >
         {isSelected ? (
           <Check
@@ -304,94 +226,118 @@ const ColorPicker = ({
     );
   }
 
-  return (
-    <div
-      ref={panelRef}
-      className="ic-color-picker"
-      style={
-        {
-          top: `${position.top}px`,
-          left: `${position.left}px`,
-        } as CSSProperties
-      }
-      role="dialog"
-      aria-label={t("color_picker.add")}
-    >
-      <button
-        type="button"
-        className="ic-color-picker__menu-item"
-        onClick={() => handleColorSelect(defaultColor)}
+  return createPortal(
+    <div className="ic-menu-layer">
+      <div
+        className="ic-menu-backdrop"
+        onPointerDown={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={panelRef}
+        className="ic-color-picker"
+        style={
+          {
+            top: `${position.top}px`,
+            left: `${position.left}px`,
+          } as CSSProperties
+        }
+        role="dialog"
+        aria-label={t("color_picker.add")}
+        onKeyDown={onKeyDown}
+        onPointerDown={onPointerDown}
+        onClick={(event) => {
+          // Otherwise the sheet would grab the keyboard focus
+          event.stopPropagation();
+        }}
       >
-        <span
-          className="ic-color-picker__menu-item-square"
-          style={{ backgroundColor: defaultColor }}
-          aria-hidden="true"
-        />
-        <span className="ic-color-picker__menu-item-text">{title}</span>
-      </button>
-
-      <div className="ic-color-picker__divider" />
-
-      <div className="ic-color-picker__colors-wrapper">
-        <div className="ic-color-picker__color-list">
-          {mainColors.map(renderColorSwatch)}
-        </div>
-
-        <div className="ic-color-picker__color-grid">
-          {toneArrays.map((tones) => (
-            <div
-              className="ic-color-picker__color-grid-col"
-              key={tones.join("-")}
-            >
-              {tones.map(renderColorSwatch)}
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="ic-color-picker__divider" />
-
-      <div className="ic-color-picker__recent-label">
-        {t("color_picker.recent")}
-      </div>
-
-      <div className="ic-color-picker__recent-colors-list">
-        {recentColors.current.length > 0 ? (
-          recentColors.current.map((recentColor) => (
-            <button
-              key={recentColor}
-              type="button"
-              className={[
-                "ic-color-picker__swatch",
-                isWhiteColor(recentColor)
-                  ? "ic-color-picker__swatch--white"
-                  : "",
-              ]
-                .filter(Boolean)
-                .join(" ")}
-              style={{ backgroundColor: recentColor }}
-              onClick={() => {
-                setSelectedColor(recentColor);
-                handleColorSelect(recentColor);
-              }}
-              aria-label={recentColor}
-            />
-          ))
-        ) : (
-          <div className="ic-color-picker__empty" />
-        )}
-
         <button
           type="button"
-          className="ic-color-picker__plus-button"
-          onClick={() => setPickerOpen(true)}
-          title={t("color_picker.add")}
-          aria-label={t("color_picker.add")}
+          className="ic-color-picker__menu-item"
+          onClick={() => handleColorSelect(defaultColor)}
+          data-nav-row={0}
+          data-nav-col={0}
         >
-          <Plus />
+          <span
+            className="ic-color-picker__menu-item-square"
+            style={{ backgroundColor: defaultColor }}
+            aria-hidden="true"
+          />
+          <span className="ic-color-picker__menu-item-text">{title}</span>
         </button>
+
+        <div className="ic-color-picker__divider" />
+
+        <div className="ic-color-picker__colors-wrapper">
+          <div className="ic-color-picker__color-list">
+            {mainColors.map((presetColor, col) =>
+              renderColorSwatch(presetColor, 1, col),
+            )}
+          </div>
+
+          <div className="ic-color-picker__color-grid">
+            {toneArrays.map((tones, col) => (
+              <div
+                className="ic-color-picker__color-grid-col"
+                key={tones.join("-")}
+              >
+                {tones.map((presetColor, toneIndex) =>
+                  renderColorSwatch(presetColor, 2 + toneIndex, col),
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="ic-color-picker__divider" />
+
+        <div className="ic-color-picker__recent-label">
+          {t("color_picker.recent")}
+        </div>
+
+        <div className="ic-color-picker__recent-colors-list">
+          {recentColors.current.length > 0 ? (
+            recentColors.current.map((recentColor, col) => (
+              <button
+                key={recentColor}
+                type="button"
+                className={[
+                  "ic-color-picker__swatch",
+                  isWhiteColor(recentColor)
+                    ? "ic-color-picker__swatch--white"
+                    : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+                style={{ backgroundColor: recentColor }}
+                onClick={() => {
+                  setSelectedColor(recentColor);
+                  handleColorSelect(recentColor);
+                }}
+                aria-label={recentColor}
+                data-nav-row={7}
+                data-nav-col={col}
+              />
+            ))
+          ) : (
+            <div className="ic-color-picker__empty" />
+          )}
+
+          <button
+            type="button"
+            className="ic-color-picker__plus-button"
+            onClick={() => setPickerOpen(true)}
+            title={t("color_picker.add")}
+            aria-label={t("color_picker.add")}
+            data-nav-row={7}
+            data-nav-col={recentColors.current.length}
+          >
+            <Plus />
+          </button>
+        </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };
 

--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
@@ -164,7 +164,7 @@ const ColorPicker = ({
 
       onClose();
     },
-    [onClose, anchorEl.current],
+    [onClose, anchorEl],
   );
 
   const handleColorSelect = (nextColor: string) => {
@@ -243,6 +243,7 @@ const ColorPicker = ({
           } as CSSProperties
         }
         role="dialog"
+        aria-modal="true"
         aria-label={t("color_picker.add")}
         onKeyDown={onKeyDown}
         onPointerDown={onPointerDown}

--- a/webapp/IronCalc/src/components/ColorPicker/color-picker.css
+++ b/webapp/IronCalc/src/components/ColorPicker/color-picker.css
@@ -21,6 +21,15 @@
   box-sizing: border-box;
 }
 
+.ic-color-picker *:focus {
+  outline: none;
+}
+
+.ic-color-picker *:focus-visible {
+  outline: 2px solid var(--palette-primary-main);
+  outline-offset: 2px;
+}
+
 .ic-color-picker__menu-item {
   display: flex;
   flex-direction: row;

--- a/webapp/IronCalc/src/components/ColorPicker/useKeyDown.ts
+++ b/webapp/IronCalc/src/components/ColorPicker/useKeyDown.ts
@@ -1,0 +1,159 @@
+import { type KeyboardEvent, useCallback } from "react";
+
+interface Options {
+  onEscape: () => void;
+  getFocusableElements: () => HTMLElement[];
+}
+
+function getNavPosition(element: HTMLElement) {
+  const row = Number(element.dataset.navRow);
+  const col = Number(element.dataset.navCol);
+
+  if (Number.isNaN(row) || Number.isNaN(col)) {
+    return null;
+  }
+
+  return { row, col };
+}
+
+function getElementsInRow(
+  focusable: HTMLElement[],
+  row: number,
+): HTMLElement[] {
+  return focusable.filter((element) => getNavPosition(element)?.row === row);
+}
+
+function getLastColInRow(focusable: HTMLElement[], row: number): number | null {
+  const elements = getElementsInRow(focusable, row);
+  if (elements.length === 0) {
+    return null;
+  }
+
+  return Math.max(
+    ...elements
+      .map((element) => getNavPosition(element)?.col)
+      .filter((col): col is number => col !== undefined),
+  );
+}
+
+// Navigation for the color picker:
+// * Tab/Shift+Tab: cycle through focusable elements in DOM order
+// * Escape: close the picker
+// * Arrow keys: navigate between elements with data-nav-row and data-nav-col
+export const useKeyDown = (
+  options: Options,
+): { onKeyDown: (event: KeyboardEvent) => void } => {
+  const { onEscape, getFocusableElements } = options;
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      const { key, shiftKey } = event;
+      const focusable = getFocusableElements();
+
+      if (focusable.length === 0) {
+        return;
+      }
+
+      const active = document.activeElement as HTMLElement | null;
+      const currentIndex = active ? focusable.indexOf(active) : -1;
+
+      if (key === "Escape") {
+        event.preventDefault();
+        onEscape();
+        return;
+      }
+
+      if (key === "Tab") {
+        event.preventDefault();
+
+        if (currentIndex === -1) {
+          focusable[0]?.focus();
+          return;
+        }
+
+        const nextIndex = shiftKey
+          ? (currentIndex - 1 + focusable.length) % focusable.length
+          : (currentIndex + 1) % focusable.length;
+
+        focusable[nextIndex]?.focus();
+        return;
+      }
+
+      if (
+        key !== "ArrowLeft" &&
+        key !== "ArrowRight" &&
+        key !== "ArrowUp" &&
+        key !== "ArrowDown"
+      ) {
+        return;
+      }
+
+      if (!active) {
+        return;
+      }
+
+      const currentPosition = getNavPosition(active);
+      if (!currentPosition) {
+        return;
+      }
+
+      let targetRow = currentPosition.row;
+      let targetCol = currentPosition.col;
+
+      if (key === "ArrowLeft") {
+        targetCol -= 1;
+      } else if (key === "ArrowRight") {
+        targetCol += 1;
+      } else if (key === "ArrowUp") {
+        targetRow -= 1;
+      } else if (key === "ArrowDown") {
+        targetRow += 1;
+      }
+
+      let target = focusable.find((element) => {
+        const position = getNavPosition(element);
+        return position?.row === targetRow && position?.col === targetCol;
+      });
+
+      if (!target && key === "ArrowLeft") {
+        const previousRow = currentPosition.row - 1;
+        const lastCol = getLastColInRow(focusable, previousRow);
+
+        if (lastCol !== null) {
+          target = focusable.find((element) => {
+            const position = getNavPosition(element);
+            return position?.row === previousRow && position?.col === lastCol;
+          });
+        }
+      }
+
+      if (!target && key === "ArrowRight") {
+        const nextRow = currentPosition.row + 1;
+
+        target = focusable.find((element) => {
+          const position = getNavPosition(element);
+          return position?.row === nextRow && position?.col === 0;
+        });
+      }
+
+      if (!target && (key === "ArrowUp" || key === "ArrowDown")) {
+        target = focusable.find((element) => {
+          const position = getNavPosition(element);
+          return (
+            position?.row === targetRow && position?.col === currentPosition.col
+          );
+        });
+      }
+
+      if (target) {
+        event.preventDefault();
+        target.focus();
+      }
+    },
+    [getFocusableElements, onEscape],
+  );
+
+  return { onKeyDown };
+};
+
+export default useKeyDown;

--- a/webapp/IronCalc/src/components/ColorPicker/util.ts
+++ b/webapp/IronCalc/src/components/ColorPicker/util.ts
@@ -1,0 +1,81 @@
+export const mainColors = [
+  "#FFFFFF",
+  "#272525",
+  "#1B717E",
+  "#3BB68A",
+  "#8CB354",
+  "#F8CD3C",
+  "#F2994A",
+  "#EC5753",
+  "#523E93",
+  "#3358B7",
+];
+
+const lightTones = [
+  "#F5F5F5", // --palette-grey-50
+  "#F2F2F2", // --palette-grey-100
+  "#EEEEEE", // --palette-grey-200
+  "#E0E0E0", // --palette-grey-300
+  "#BDBDBD", // --palette-grey-400
+];
+
+const darkTones = [
+  "#9E9E9E", // --palette-grey-500
+  "#757575", // --palette-grey-600
+  "#616161", // --palette-grey-700
+  "#424242", // --palette-grey-800
+  "#333333", // --palette-grey-900
+];
+
+const tealTones = ["#BBD4D8", "#82B1B8", "#498D98", "#1E5A63", "#224348"];
+const greenTones = ["#C4E9DC", "#93D7BF", "#62C5A1", "#358A6C", "#2F5F4D"];
+const limeTones = ["#DDE8CC", "#C0D5A1", "#A3C276", "#6E8846", "#4F5E38"];
+const yellowTones = ["#FDF0C5", "#FBE394", "#F9D764", "#B99A36", "#7A682E"];
+const orangeTones = ["#FBE0C9", "#F8C79B", "#F5AD6E", "#B5763F", "#785334"];
+const redTones = ["#F9CDCB", "#F5A3A0", "#F07975", "#B14845", "#763937"];
+const purpleTones = ["#CBC5DF", "#A095C4", "#7565A9", "#453672", "#382F51"];
+const blueTones = ["#C2CDE9", "#8FA3D7", "#5D79C5", "#30498B", "#2C395F"];
+
+export const toneArrays = [
+  lightTones,
+  darkTones,
+  tealTones,
+  greenTones,
+  limeTones,
+  yellowTones,
+  orangeTones,
+  redTones,
+  purpleTones,
+  blueTones,
+];
+
+// This function checks if a color is light or dark.
+// This is needed to determine the icon color, as it's not visible on light colors.
+export const isLightColor = (hex: string): boolean => {
+  if (!hex.startsWith("#")) {
+    return false;
+  }
+
+  const normalized =
+    hex.length === 4
+      ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
+      : hex;
+
+  const n = parseInt(normalized.slice(1), 16);
+  const r = (n >> 16) & 255;
+  const g = (n >> 8) & 255;
+  const b = n & 255;
+
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return luminance > 160;
+};
+
+export const isWhiteColor = (color: string): boolean => {
+  const upper = color.toUpperCase();
+  return upper === "#FFF" || upper === "#FFFFFF";
+};
+
+export const getCheckColor = (color: string): string => {
+  // --palette-common-black: #272525;
+  return isLightColor(color) ? "#272525" : "#FFFFFF";
+};

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -61,6 +61,17 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
     },
   );
   const focusWorkbook = useCallback(() => {
+    const active = document.activeElement as HTMLElement | null;
+    // FIXME: Horrible HACK for now
+    // Basically prevents the workbook from stealing focus when the user is interacting with the color picker, border picker or advanced color picker
+    if (
+      active?.closest(
+        ".ic-color-picker, .ic-advanced-color-picker-panel, .ic-border-picker",
+      )
+    ) {
+      return;
+    }
+
     if (rootRef.current) {
       rootRef.current.focus({ preventScroll: true });
       // HACK: We need to select something inside the root for onCopy to work

--- a/webapp/IronCalc/src/components/util.ts
+++ b/webapp/IronCalc/src/components/util.ts
@@ -95,3 +95,22 @@ export function getFullRangeToString(
     columnStart,
   )}$${rowStart}:$${columnNameFromNumber(columnEnd)}$${rowEnd}`;
 }
+
+/**
+ * Returns all focusable elements inside a container in DOM order.
+ * Used for keyboard navigation (Tab/arrow keys) and focus management.
+ */
+export function getFocusableElements(root: HTMLElement | null): HTMLElement[] {
+  if (!root) return [];
+
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button, input, [href], [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter(
+    (el) =>
+      !el.hasAttribute("disabled") &&
+      !el.getAttribute("aria-hidden") &&
+      el.tabIndex !== -1,
+  );
+}

--- a/webapp/IronCalc/src/components/util.ts
+++ b/webapp/IronCalc/src/components/util.ts
@@ -110,7 +110,7 @@ export function getFocusableElements(root: HTMLElement | null): HTMLElement[] {
   ).filter(
     (el) =>
       !el.hasAttribute("disabled") &&
-      !el.getAttribute("aria-hidden") &&
+      el.getAttribute("aria-hidden") !== "true" &&
       el.tabIndex !== -1,
   );
 }

--- a/webapp/IronCalc/src/index.css
+++ b/webapp/IronCalc/src/index.css
@@ -5,3 +5,14 @@
   width: 100%;
   height: 100%;
 }
+
+.ic-menu-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+}
+
+.ic-menu-backdrop {
+  position: fixed;
+  inset: 0;
+}


### PR DESCRIPTION
In this PR I have tried to set the stage for future menus/popups/dialog.

The elephant in the room. I have done a terrible job at managin keyboard and pointer events all across the project.
The wrost offentder is the aggressive `focusWorkbook` function in Workbook.tsx

In this PR I have tried to add decent keyboard accessibility to the Color Picker and Advanced Color Picker. 

Notice they are both portals (as of now of document body) and they block pointer events (that is we can't see throgh Popper style). They are modal dialogs.

I have tried to remove `document.addEventListener` form these for pointer and keyboard events. There were also some bugs fixed. Visusal cues when some elements have the kb focus. The color picker input was broken