### PR TITLE
app: add workbook search to left drawer

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/DeleteWorkbookDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/DeleteWorkbookDialog.tsx
@@ -7,11 +7,15 @@ interface DeleteWorkbookDialogProperties {
   onClose: () => void;
   onConfirm: () => void;
   workbookName: string;
+  titleId?: string;
+  descriptionId?: string;
 }
 
 function DeleteWorkbookDialog(properties: DeleteWorkbookDialogProperties) {
   const { t } = useTranslation();
   const deleteButtonRef = useRef<HTMLButtonElement>(null);
+  const titleId = properties.titleId ?? "delete-dialog-title";
+  const descriptionId = properties.descriptionId ?? "delete-dialog-description";
 
   useEffect(() => {
     if (deleteButtonRef.current) {
@@ -27,15 +31,17 @@ function DeleteWorkbookDialog(properties: DeleteWorkbookDialogProperties) {
           properties.onClose();
         }
       }}
-      aria-labelledby="delete-dialog-title"
-      aria-describedby="delete-dialog-description"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
     >
       <IconWrapper>
         <Trash2 />
       </IconWrapper>
       <ContentWrapper>
-        <Title>{t("file_bar.file_menu.delete_workbook.title")}</Title>
-        <Body>
+        <Title id={titleId}>
+          {t("file_bar.file_menu.delete_workbook.title")}
+        </Title>
+        <Body id={descriptionId}>
           <Trans
             i18nKey="file_bar.file_menu.delete_workbook.subtitle"
             components={{ bold: <strong /> }}

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerContent.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerContent.tsx
@@ -5,15 +5,20 @@ import WorkbookList from "./WorkbookList";
 interface DrawerContentProps {
   setModel: (key: string) => void;
   onDelete: (uuid: string) => void;
+  searchQuery: string;
 }
 
 function DrawerContent(props: DrawerContentProps) {
-  const { setModel, onDelete } = props;
+  const { setModel, onDelete, searchQuery } = props;
 
   return (
     <>
       <ContentContainer>
-        <WorkbookList setModel={setModel} onDelete={onDelete} />
+        <WorkbookList
+          setModel={setModel}
+          onDelete={onDelete}
+          searchQuery={searchQuery}
+        />
       </ContentContainer>
       <LocalStorageAlertWrapper>
         <LocalStorageAlert />

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerHeader.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerHeader.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
 import { IronCalcIconWhite as IronCalcIcon } from "@ironcalc/workbook";
-import { IconButton, Tooltip } from "@mui/material";
-import { Plus } from "lucide-react";
+import { IconButton, TextField, Tooltip } from "@mui/material";
+import { Plus, Search, X } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DialogHeaderLogoWrapper } from "../WelcomeDialog/WelcomeDialog";
 
@@ -11,47 +12,51 @@ interface DrawerHeaderProps {
 
 function DrawerHeader({ onNewModel }: DrawerHeaderProps) {
   const { t } = useTranslation();
+  const [isSearching, setIsSearching] = useState(false);
+
   return (
     <HeaderContainer>
-      <LogoWrapper>
+      <LogoWrapper className={isSearching ? "hidden" : ""}>
         <Logo>
           <IronCalcIcon />
         </Logo>
         <Title>IronCalc</Title>
       </LogoWrapper>
-      <Tooltip
-        title={t("left_drawer.new_workbook")}
-        slotProps={{
-          popper: {
-            modifiers: [
-              {
-                name: "offset",
-                options: {
-                  offset: [0, -8],
-                },
-              },
-            ],
-          },
-        }}
-      >
-        <AddButton onClick={onNewModel}>
-          <PlusIcon />
-        </AddButton>
-      </Tooltip>
+
+      <ActionsWrapper className={isSearching ? "hidden" : ""}>
+        <Tooltip title="Search workbooks">
+          <AddButton onClick={() => setIsSearching(true)}>
+            <Search />
+          </AddButton>
+        </Tooltip>
+
+        <Tooltip title={t("left_drawer.new_workbook")}>
+          <AddButton onClick={onNewModel}>
+            <Plus />
+          </AddButton>
+        </Tooltip>
+      </ActionsWrapper>
+
+      <SearchOverlay className={isSearching ? "active" : ""}>
+        <SearchIconWrapper>
+          <Search />
+        </SearchIconWrapper>
+
+        <SearchInput
+          size="small"
+          placeholder="Search workbook..."
+          autoFocus
+          variant="standard"
+          fullWidth
+          InputProps={{ disableUnderline: true }}
+        />
+        <ClearIcon onClick={() => setIsSearching(false)}>
+          <X />
+        </ClearIcon>
+      </SearchOverlay>
     </HeaderContainer>
   );
 }
-
-const HeaderContainer = styled("div")`
-  display: flex;
-  align-items: center;
-  padding: 12px 8px 12px 16px;
-  justify-content: space-between;
-  max-height: 60px;
-  min-height: 60px;
-  box-sizing: border-box;
-  box-shadow: 0 1px 0 0 #e0e0e0;
-`;
 
 const LogoWrapper = styled("div")`
   display: flex;
@@ -70,8 +75,13 @@ const Logo = styled(DialogHeaderLogoWrapper)`
   padding: 6px;
 `;
 
+const ActionsWrapper = styled("div")`
+  display: flex;
+  flex-direction: row;
+  gap: 2px;
+`;
+
 const AddButton = styled(IconButton)`
-  margin-left: 8px;
   height: 32px;
   width: 32px;
   padding: 8px;
@@ -91,9 +101,88 @@ const AddButton = styled(IconButton)`
   }
 `;
 
-const PlusIcon = styled(Plus)`
+const HeaderContainer = styled("div")`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 8px 12px 16px;
+  height: 60px;
+  box-sizing: border-box;
+  box-shadow: 0 1px 0 0 #e0e0e0;
+
+  .hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+`;
+
+const SearchOverlay = styled("div")`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 20px;
+
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+
+  &.active {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+`;
+
+const SearchIconWrapper = styled("div")`
+  display: flex;
+  align-items: center;
+
+  svg {
+    stroke: #757575;
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+const SearchInput = styled(TextField)`
+  flex: 1;
+  
+  .MuiInputBase-root {
+    width: 100%;
+    height: 32px;
+    font-size: 12px;
+  }
+
+  .MuiInputBase-input {
+    padding: 0; 
+    height: 100%;
+    box-sizing: border-box;
+  }
+
+  .MuiInputBase-input::placeholder {
+    transition: opacity 0.15s ease;
+  }
+
+  .MuiInputBase-input:focus::placeholder {
+    opacity: 0;
+  }
+`;
+
+const ClearIcon = styled("div")`
+  display: flex;
+  
   width: 16px;
-  height: 16px;
+  cursor: pointer;
+
+  svg {
+    stroke: #757575;
+    width: 16px;
+    height: 16px;
+    }
+  }
 `;
 
 export default DrawerHeader;

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerHeader.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerHeader.tsx
@@ -8,9 +8,15 @@ import { DialogHeaderLogoWrapper } from "../WelcomeDialog/WelcomeDialog";
 
 interface DrawerHeaderProps {
   onNewModel: () => void;
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
 }
 
-function DrawerHeader({ onNewModel }: DrawerHeaderProps) {
+function DrawerHeader({
+  onNewModel,
+  searchQuery,
+  setSearchQuery,
+}: DrawerHeaderProps) {
   const { t } = useTranslation();
   const [isSearching, setIsSearching] = useState(false);
 
@@ -43,6 +49,8 @@ function DrawerHeader({ onNewModel }: DrawerHeaderProps) {
         </SearchIconWrapper>
 
         <SearchInput
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
           size="small"
           placeholder="Search workbook..."
           autoFocus
@@ -50,7 +58,12 @@ function DrawerHeader({ onNewModel }: DrawerHeaderProps) {
           fullWidth
           InputProps={{ disableUnderline: true }}
         />
-        <ClearIcon onClick={() => setIsSearching(false)}>
+        <ClearIcon
+          onClick={() => {
+            setSearchQuery("");
+            setIsSearching(false);
+          }}
+        >
           <X />
         </ClearIcon>
       </SearchOverlay>

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerHeader.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerHeader.tsx
@@ -38,15 +38,21 @@ function DrawerHeader({
 
       <ActionsWrapper className={isSearching ? "hidden" : ""}>
         <Tooltip title={t("left_drawer.search_workbook")}>
-          <AddButton onClick={() => setIsSearching(true)}>
+          <HeaderButton
+            onClick={() => setIsSearching(true)}
+            aria-label={t("left_drawer.search_workbook")}
+          >
             <Search />
-          </AddButton>
+          </HeaderButton>
         </Tooltip>
 
         <Tooltip title={t("left_drawer.new_workbook")}>
-          <AddButton onClick={onNewModel}>
+          <HeaderButton
+            onClick={onNewModel}
+            aria-label={t("left_drawer.new_workbook")}
+          >
             <Plus />
-          </AddButton>
+          </HeaderButton>
         </Tooltip>
       </ActionsWrapper>
 
@@ -73,14 +79,16 @@ function DrawerHeader({
             inputRef: searchInputRef,
           }}
         />
-        <ClearIcon
+        <ClearButton
           onClick={() => {
             setSearchQuery("");
             setIsSearching(false);
           }}
+          disableRipple
+          aria-label={t("left_drawer.clear_search")}
         >
           <X />
-        </ClearIcon>
+        </ClearButton>
       </SearchOverlay>
     </HeaderContainer>
   );
@@ -109,7 +117,7 @@ const ActionsWrapper = styled("div")`
   gap: 2px;
 `;
 
-const AddButton = styled(IconButton)`
+const HeaderButton = styled(IconButton)`
   height: 32px;
   width: 32px;
   padding: 8px;
@@ -191,22 +199,27 @@ const SearchInput = styled(TextField)`
   }
 `;
 
-const ClearIcon = styled("div")`
-  display: flex;
-  
+const ClearButton = styled(IconButton)`  
+height: 20px;
+width: 20px;
+padding: 0px;
+border-radius: 6px;
+
+svg {
+  stroke-width: 2px;
+  stroke: #757575;
   width: 16px;
-  cursor: pointer;
-
-  svg {
-    stroke: #757575;
-    width: 16px;
-    height: 16px;
-    }
-
-    &:hover svg {
-      stroke: #272525;
-    }
+  height: 16px;
+}
+&:hover {
+  background-color: transparent;
+    svg {
+    stroke: #000;
   }
+}
+&:active {
+  background-color: transparent;
+}
 `;
 
 export default DrawerHeader;

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerHeader.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerHeader.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { IronCalcIconWhite as IronCalcIcon } from "@ironcalc/workbook";
 import { IconButton, TextField, Tooltip } from "@mui/material";
 import { Plus, Search, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DialogHeaderLogoWrapper } from "../WelcomeDialog/WelcomeDialog";
 
@@ -19,6 +19,13 @@ function DrawerHeader({
 }: DrawerHeaderProps) {
   const { t } = useTranslation();
   const [isSearching, setIsSearching] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isSearching && searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [isSearching]);
 
   return (
     <HeaderContainer>
@@ -30,7 +37,7 @@ function DrawerHeader({
       </LogoWrapper>
 
       <ActionsWrapper className={isSearching ? "hidden" : ""}>
-        <Tooltip title="Search workbooks">
+        <Tooltip title={t("left_drawer.search_workbook")}>
           <AddButton onClick={() => setIsSearching(true)}>
             <Search />
           </AddButton>
@@ -51,12 +58,20 @@ function DrawerHeader({
         <SearchInput
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              setSearchQuery("");
+              setIsSearching(false);
+            }
+          }}
           size="small"
-          placeholder="Search workbook..."
-          autoFocus
+          placeholder={t("left_drawer.search_placeholder")}
           variant="standard"
           fullWidth
-          InputProps={{ disableUnderline: true }}
+          InputProps={{
+            disableUnderline: true,
+            inputRef: searchInputRef,
+          }}
         />
         <ClearIcon
           onClick={() => {
@@ -119,7 +134,7 @@ const HeaderContainer = styled("div")`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 8px 12px 16px;
+  padding: 12px 10px 12px 16px;
   height: 60px;
   box-sizing: border-box;
   box-shadow: 0 1px 0 0 #e0e0e0;
@@ -174,14 +189,6 @@ const SearchInput = styled(TextField)`
     height: 100%;
     box-sizing: border-box;
   }
-
-  .MuiInputBase-input::placeholder {
-    transition: opacity 0.15s ease;
-  }
-
-  .MuiInputBase-input:focus::placeholder {
-    opacity: 0;
-  }
 `;
 
 const ClearIcon = styled("div")`
@@ -194,6 +201,10 @@ const ClearIcon = styled("div")`
     stroke: #757575;
     width: 16px;
     height: 16px;
+    }
+
+    &:hover svg {
+      stroke: #272525;
     }
   }
 `;

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/LeftDrawer.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { Drawer } from "@mui/material";
+import { useState } from "react";
 import DrawerContent from "./DrawerContent";
 import DrawerFooter from "./DrawerFooter";
 import DrawerHeader from "./DrawerHeader";
@@ -20,6 +21,8 @@ function LeftDrawer({
   setModel,
   onDelete,
 }: LeftDrawerProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+
   return (
     <DrawerWrapper
       variant="persistent"
@@ -28,8 +31,16 @@ function LeftDrawer({
       onClose={onClose}
       transitionDuration={0}
     >
-      <DrawerHeader onNewModel={newModel} />
-      <DrawerContent setModel={setModel} onDelete={onDelete} />
+      <DrawerHeader
+        onNewModel={newModel}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+      />
+      <DrawerContent
+        setModel={setModel}
+        onDelete={onDelete}
+        searchQuery={searchQuery}
+      />
 
       <DrawerFooter />
     </DrawerWrapper>

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
@@ -224,16 +224,19 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
     (a, b) => models[b].createdAt - models[a].createdAt,
   );
 
-  const filteredModels =
-    normalizedQuery.length > 0
-      ? allModelsSorted.filter((uuid) =>
-          models[uuid].name.toLowerCase().includes(normalizedQuery),
-        )
-      : null;
+  const isSearchMode = normalizedQuery.length > 0;
+
+  const filteredModels = isSearchMode
+    ? allModelsSorted.filter((uuid) =>
+        models[uuid].name.toLowerCase().includes(normalizedQuery),
+      )
+    : [];
+
+  const isNoResults = isSearchMode && filteredModels.length === 0;
 
   return (
     <>
-      {filteredModels ? (
+      {isSearchMode ? (
         // Search mode (flat list, no grouping)
         filteredModels.map(renderWorkbookItem)
       ) : (
@@ -244,6 +247,11 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
           {renderSection(t("left_drawer.last_30_days"), modelsCreatedThisMonth)}
           {renderSection(t("left_drawer.older"), olderModels)}
         </>
+      )}
+      {isNoResults && (
+        <NoResultsContainer>
+          {t("left_drawer.search_no_results")}
+        </NoResultsContainer>
       )}
 
       <StyledMenu
@@ -323,7 +331,7 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
         </DeleteButton>
       </StyledMenu>
 
-      <Modal open={isDeleteDialogOpen} onClose={handleDeleteCancel} >
+      <Modal open={isDeleteDialogOpen} onClose={handleDeleteCancel}>
         <DeleteWorkbookDialog
           onClose={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}
@@ -433,6 +441,14 @@ const SectionTitle = styled("div")`
     width: 12px;
     height: 12px;
   }
+`;
+
+const NoResultsContainer = styled("div")`
+  padding: 12px 8px;
+  color: #9e9e9e;
+  font-size: 12px;
+  line-height: 18px;
+  padding: 0 8px;
 `;
 
 export default WorkbookList;

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
@@ -163,12 +163,13 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
 
   const modelsMetadata = getModelsMetadata();
 
-  const {
-    pinnedModels,
-    modelsCreatedToday,
-    modelsCreatedThisMonth,
-    olderModels,
-  } = groupWorkbooks(modelsMetadata);
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const isSearchMode = normalizedQuery.length > 0;
+
+  let pinnedModels: string[] = [];
+  let modelsCreatedToday: string[] = [];
+  let modelsCreatedThisMonth: string[] = [];
+  let olderModels: string[] = [];
 
   const renderWorkbookItem = (uuid: string) => {
     const isMenuOpen = menuAnchorEl !== null && selectedWorkbookUuid === uuid;
@@ -218,19 +219,18 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
     );
   };
 
-  const normalizedQuery = searchQuery.trim().toLowerCase();
+  let filteredModels: string[] = [];
 
-  const allModelsSorted = Object.keys(modelsMetadata).sort(
-    (a, b) => modelsMetadata[b].createdAt - modelsMetadata[a].createdAt,
-  );
-
-  const isSearchMode = normalizedQuery.length > 0;
-
-  const filteredModels = isSearchMode
-    ? allModelsSorted.filter((uuid) =>
+  if (isSearchMode) {
+    filteredModels = Object.keys(modelsMetadata)
+      .sort((a, b) => modelsMetadata[b].createdAt - modelsMetadata[a].createdAt)
+      .filter((uuid) =>
         modelsMetadata[uuid].name.toLowerCase().includes(normalizedQuery),
-      )
-    : [];
+      );
+  } else {
+    ({ pinnedModels, modelsCreatedToday, modelsCreatedThisMonth, olderModels } =
+      groupWorkbooks(modelsMetadata));
+  }
 
   const isNoResults = isSearchMode && filteredModels.length === 0;
 
@@ -331,7 +331,12 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
         </DeleteButton>
       </StyledMenu>
 
-      <Modal open={isDeleteDialogOpen} onClose={handleDeleteCancel}>
+      <Modal
+        open={isDeleteDialogOpen}
+        onClose={handleDeleteCancel}
+        aria-labelledby="delete-dialog-title"
+        aria-describedby="delete-dialog-description"
+      >
         <DeleteWorkbookDialog
           onClose={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
@@ -27,9 +27,10 @@ import {
 interface WorkbookListProps {
   setModel: (key: string) => void;
   onDelete: (uuid: string) => void;
+  searchQuery: string;
 }
 
-function WorkbookList({ setModel, onDelete }: WorkbookListProps) {
+function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
   const { t } = useTranslation();
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedWorkbookUuid, setSelectedWorkbookUuid] = useState<
@@ -170,6 +171,7 @@ function WorkbookList({ setModel, onDelete }: WorkbookListProps) {
     const isMenuOpen = menuAnchorEl !== null && selectedWorkbookUuid === uuid;
     const isAnyMenuOpen = menuAnchorEl !== null;
     const models = getModelsMetadata();
+
     return (
       <WorkbookListItem
         key={uuid}
@@ -216,12 +218,33 @@ function WorkbookList({ setModel, onDelete }: WorkbookListProps) {
 
   const models = getModelsMetadata();
 
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+
+  const allModelsSorted = Object.keys(models).sort(
+    (a, b) => models[b].createdAt - models[a].createdAt,
+  );
+
+  const filteredModels =
+    normalizedQuery.length > 0
+      ? allModelsSorted.filter((uuid) =>
+          models[uuid].name.toLowerCase().includes(normalizedQuery),
+        )
+      : null;
+
   return (
     <>
-      {renderSection(t("left_drawer.pinned"), pinnedModels)}
-      {renderSection(t("left_drawer.today"), modelsCreatedToday)}
-      {renderSection(t("left_drawer.last_30_days"), modelsCreatedThisMonth)}
-      {renderSection(t("left_drawer.older"), olderModels)}
+      {filteredModels ? (
+        // Search mode (flat list, no grouping)
+        filteredModels.map(renderWorkbookItem)
+      ) : (
+        // Default mode (grouped)
+        <>
+          {renderSection(t("left_drawer.pinned"), pinnedModels)}
+          {renderSection(t("left_drawer.today"), modelsCreatedToday)}
+          {renderSection(t("left_drawer.last_30_days"), modelsCreatedThisMonth)}
+          {renderSection(t("left_drawer.older"), olderModels)}
+        </>
+      )}
 
       <StyledMenu
         anchorEl={menuAnchorEl}
@@ -230,9 +253,7 @@ function WorkbookList({ setModel, onDelete }: WorkbookListProps) {
         autoFocus={false}
         disableRestoreFocus={true}
         transitionDuration={0}
-        MenuListProps={{
-          dense: true,
-        }}
+        MenuListProps={{ dense: true }}
         anchorOrigin={{
           vertical: "bottom",
           horizontal: "right",
@@ -255,6 +276,7 @@ function WorkbookList({ setModel, onDelete }: WorkbookListProps) {
           <FileDown />
           {t("left_drawer.workbook_menu.download")}
         </MenuItemWrapper>
+
         <MenuItemWrapper
           onClick={() => {
             if (selectedWorkbookUuid) {
@@ -272,6 +294,7 @@ function WorkbookList({ setModel, onDelete }: WorkbookListProps) {
             ? t("left_drawer.workbook_menu.unpin")
             : t("left_drawer.workbook_menu.pin")}
         </MenuItemWrapper>
+
         <MenuItemWrapper
           onClick={() => {
             if (selectedWorkbookUuid) {
@@ -283,7 +306,9 @@ function WorkbookList({ setModel, onDelete }: WorkbookListProps) {
           <Copy />
           {t("left_drawer.workbook_menu.duplicate")}
         </MenuItemWrapper>
+
         <MenuDivider />
+
         <DeleteButton
           selected={false}
           onClick={() => {
@@ -298,12 +323,7 @@ function WorkbookList({ setModel, onDelete }: WorkbookListProps) {
         </DeleteButton>
       </StyledMenu>
 
-      <Modal
-        open={isDeleteDialogOpen}
-        onClose={handleDeleteCancel}
-        aria-labelledby="delete-dialog-title"
-        aria-describedby="delete-dialog-description"
-      >
+      <Modal open={isDeleteDialogOpen} onClose={handleDeleteCancel} >
         <DeleteWorkbookDialog
           onClose={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
@@ -120,7 +120,9 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
   };
 
   // Group workbooks by pinned status and creation date
-  const groupWorkbooks = () => {
+  const groupWorkbooks = (
+    modelsMetadata: ReturnType<typeof getModelsMetadata>,
+  ) => {
     const now = Date.now();
     const millisecondsInDay = 24 * 60 * 60 * 1000;
     const millisecondsIn30Days = 30 * millisecondsInDay;
@@ -129,7 +131,6 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
     const modelsCreatedToday = [];
     const modelsCreatedThisMonth = [];
     const olderModels = [];
-    const modelsMetadata = getModelsMetadata();
 
     for (const uuid in modelsMetadata) {
       const createdAt = modelsMetadata[uuid].createdAt;
@@ -160,17 +161,18 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
     };
   };
 
+  const modelsMetadata = getModelsMetadata();
+
   const {
     pinnedModels,
     modelsCreatedToday,
     modelsCreatedThisMonth,
     olderModels,
-  } = groupWorkbooks();
+  } = groupWorkbooks(modelsMetadata);
 
   const renderWorkbookItem = (uuid: string) => {
     const isMenuOpen = menuAnchorEl !== null && selectedWorkbookUuid === uuid;
     const isAnyMenuOpen = menuAnchorEl !== null;
-    const models = getModelsMetadata();
 
     return (
       <WorkbookListItem
@@ -189,7 +191,7 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
         <StorageIndicator>
           <Table2 />
         </StorageIndicator>
-        <WorkbookListText>{models[uuid].name}</WorkbookListText>
+        <WorkbookListText>{modelsMetadata[uuid].name}</WorkbookListText>
         <EllipsisButton
           onClick={(e) => handleMenuOpen(e, uuid)}
           isOpen={isMenuOpen}
@@ -216,19 +218,17 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
     );
   };
 
-  const models = getModelsMetadata();
-
   const normalizedQuery = searchQuery.trim().toLowerCase();
 
-  const allModelsSorted = Object.keys(models).sort(
-    (a, b) => models[b].createdAt - models[a].createdAt,
+  const allModelsSorted = Object.keys(modelsMetadata).sort(
+    (a, b) => modelsMetadata[b].createdAt - modelsMetadata[a].createdAt,
   );
 
   const isSearchMode = normalizedQuery.length > 0;
 
   const filteredModels = isSearchMode
     ? allModelsSorted.filter((uuid) =>
-        models[uuid].name.toLowerCase().includes(normalizedQuery),
+        modelsMetadata[uuid].name.toLowerCase().includes(normalizedQuery),
       )
     : [];
 
@@ -335,7 +335,9 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
         <DeleteWorkbookDialog
           onClose={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}
-          workbookName={workbookToDelete ? models[workbookToDelete].name : ""}
+          workbookName={
+            workbookToDelete ? modelsMetadata[workbookToDelete].name : ""
+          }
         />
       </Modal>
     </>
@@ -444,11 +446,10 @@ const SectionTitle = styled("div")`
 `;
 
 const NoResultsContainer = styled("div")`
-  padding: 12px 8px;
+  padding: 0 8px;
   color: #9e9e9e;
   font-size: 12px;
   line-height: 18px;
-  padding: 0 8px;
 `;
 
 export default WorkbookList;

--- a/webapp/app.ironcalc.com/frontend/src/components/MobileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/MobileMenu.tsx
@@ -272,6 +272,8 @@ export function MobileMenu(props: MobileMenuProps) {
           onClose={() => setMobileDeleteDialogOpen(false)}
           onConfirm={props.onDelete}
           workbookName={(selectedUuid && models[selectedUuid]?.name) || ""}
+          titleId="mobile-delete-dialog-title"
+          descriptionId="mobile-delete-dialog-description"
         />
       </Modal>
     </>

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -28,6 +28,7 @@
     "new_workbook": "Neue Arbeitsmappe",
     "search_workbook": "Arbeitsmappen durchsuchen",
     "search_placeholder": "Arbeitsmappe suchen...",
+    "clear_search": "Suche löschen",
     "search_no_results": "Deine Suche entspricht keinem Arbeitsmappe.",
     "pinned": "Angeheftet",
     "today": "Heute",

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -28,7 +28,7 @@
     "new_workbook": "Neue Arbeitsmappe",
     "search_workbook": "Arbeitsmappen durchsuchen",
     "search_placeholder": "Arbeitsmappe suchen...",
-    "search_no_results": "Deine Suche entspricht keinem Arbeitsbuch.",
+    "search_no_results": "Deine Suche entspricht keinem Arbeitsmappe.",
     "pinned": "Angeheftet",
     "today": "Heute",
     "last_30_days": "Letzte 30 Tage",

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -26,6 +26,9 @@
   },
   "left_drawer": {
     "new_workbook": "Neue Arbeitsmappe",
+    "search_workbook": "Arbeitsmappen durchsuchen",
+    "search_placeholder": "Arbeitsmappe suchen...",
+    "search_no_results": "Deine Suche entspricht keinem Arbeitsbuch.",
     "pinned": "Angeheftet",
     "today": "Heute",
     "last_30_days": "Letzte 30 Tage",

--- a/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
@@ -28,6 +28,7 @@
     "new_workbook": "New workbook",
     "search_workbook": "Search workbooks",
     "search_placeholder": "Search workbook...",
+    "clear_search": "Clear search",
     "search_no_results": "Your search does not match any workbooks.",
     "pinned": "Pinned",
     "today": "Today",

--- a/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
@@ -26,6 +26,9 @@
   },
   "left_drawer": {
     "new_workbook": "New workbook",
+    "search_workbook": "Search workbooks",
+    "search_placeholder": "Search workbook...",
+    "search_no_results": "Your search does not match any workbooks.",
     "pinned": "Pinned",
     "today": "Today",
     "last_30_days": "Last 30 Days",

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -28,6 +28,7 @@
     "new_workbook": "Nuevo libro",
     "search_workbook": "Buscar libros",
     "search_placeholder": "Buscar libro...",
+    "clear_search": "Borrar búsqueda",
     "search_no_results": "Tu búsqueda no coincide con ningún libro.",
     "pinned": "Fijados",
     "today": "Hoy",

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -26,6 +26,9 @@
   },
   "left_drawer": {
     "new_workbook": "Nuevo libro",
+    "search_workbook": "Buscar libros",
+    "search_placeholder": "Buscar libro...",
+    "search_no_results": "Tu búsqueda no coincide con ningún libro.",
     "pinned": "Fijados",
     "today": "Hoy",
     "last_30_days": "Últimos 30 días",

--- a/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
@@ -26,6 +26,9 @@
   },
   "left_drawer": {
     "new_workbook": "Nouveau classeur",
+    "search_workbook": "Rechercher des classeurs",
+    "search_placeholder": "Rechercher un classeur...",
+    "search_no_results": "Votre recherche ne correspond à aucun classeur.",
     "pinned": "Épinglés",
     "today": "Aujourd'hui",
     "last_30_days": "30 derniers jours",

--- a/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
@@ -28,6 +28,7 @@
     "new_workbook": "Nouveau classeur",
     "search_workbook": "Rechercher des classeurs",
     "search_placeholder": "Rechercher un classeur...",
+    "clear_search": "Effacer la recherche",
     "search_no_results": "Votre recherche ne correspond à aucun classeur.",
     "pinned": "Épinglés",
     "today": "Aujourd'hui",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -28,6 +28,7 @@
     "new_workbook": "Nuova cartella di lavoro",
     "search_workbook": "Cerca cartelle di lavoro",
     "search_placeholder": "Cerca cartella di lavoro...",
+    "clear_search": "Cancella ricerca",
     "search_no_results": "La tua ricerca non corrisponde a nessuna cartella di lavoro.",
     "pinned": "Fissati",
     "today": "Oggi",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -28,7 +28,7 @@
     "new_workbook": "Nuova cartella di lavoro",
     "search_workbook": "Cerca cartelle di lavoro",
     "search_placeholder": "Cerca cartella di lavoro...",
-    "search_no_results": "La tua ricerca non corrisponde a nessun libro di lavoro.",
+    "search_no_results": "La tua ricerca non corrisponde a nessuna cartella di lavoro.",
     "pinned": "Fissati",
     "today": "Oggi",
     "last_30_days": "Ultimi 30 giorni",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -26,6 +26,9 @@
   },
   "left_drawer": {
     "new_workbook": "Nuova cartella di lavoro",
+    "search_workbook": "Cerca cartelle di lavoro",
+    "search_placeholder": "Cerca cartella di lavoro...",
+    "search_no_results": "La tua ricerca non corrisponde a nessun libro di lavoro.",
     "pinned": "Fissati",
     "today": "Oggi",
     "last_30_days": "Ultimi 30 giorni",


### PR DESCRIPTION
This PR adds the ability of searching workbooks, as described on #851 

### Changes

1. Add search logic to `DrawerHeader.tsx`: the current header includes IronCalc's logo and a button to add new workbooks. Now, we'll be having a new action: workbook search. Clicking on it will replace the logo with the search field. The video below showcases how this works:

https://github.com/user-attachments/assets/fa1fc12b-abcf-4b37-a444-eb69fac8855d

2. Toggle the content in `WorkbookList.tsx` depending on if we're searching or not: when search is not active, we'll just show the usual date grouping. When it's active, no grouping will apply. We're also adding an empty state message for when there are no results.

3. Update all translation files: we've added 3 new terms to each of them