### PR TITLE
UPDATE: Add Ukrainian (uk-UA) language support

### DIFF
--- a/webapp/IronCalc/src/i18n.ts
+++ b/webapp/IronCalc/src/i18n.ts
@@ -4,6 +4,7 @@ import translationEN from "./locale/en_us.json";
 import translationES from "./locale/es_es.json";
 import translationFR from "./locale/fr_fr.json";
 import translationIT from "./locale/it_it.json";
+import translationUK from "./locale/uk_ua.json";
 
 const resources = {
   "en-US": { translation: translationEN },
@@ -12,6 +13,7 @@ const resources = {
   "fr-FR": { translation: translationFR },
   "de-DE": { translation: translationDE },
   "it-IT": { translation: translationIT },
+  "uk-UA": { translation: translationUK },
 };
 
 const instance: typeof i18n = i18n.createInstance({

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -197,14 +197,16 @@
         "es": "Español",
         "fr": "Français",
         "de": "Deutsch",
-        "it": "Italiano"
+        "it": "Italiano",
+        "uk": "Українська"
       },
       "display_language_current_lang": {
         "en": "Englisch",
         "es": "Spanisch",
         "fr": "Französisch",
         "de": "Deutsch",
-        "it": "Italienisch"
+        "it": "Italienisch",
+        "uk": "Ukrainisch"
       }
     },
     "timezone": {

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -197,14 +197,16 @@
         "es": "Español",
         "fr": "Français",
         "de": "Deutsch",
-        "it": "Italiano"
+        "it": "Italiano",
+        "uk": "Українська"
       },
       "display_language_current_lang": {
         "en": "English",
         "es": "Spanish",
         "fr": "French",
         "de": "German",
-        "it": "Italian"
+        "it": "Italian",
+        "uk": "Ukrainian"
       }
     },
     "timezone": {

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -197,14 +197,16 @@
         "es": "Español",
         "fr": "Français",
         "de": "Deutsch",
-        "it": "Italiano"
+        "it": "Italiano",
+        "uk": "Українська"
       },
       "display_language_current_lang": {
         "en": "Inglés",
         "es": "Español",
         "fr": "Francés",
         "de": "Alemán",
-        "it": "Italiano"
+        "it": "Italiano",
+        "uk": "Ucraniano"
       }
     },
     "timezone": {

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -197,14 +197,16 @@
         "es": "Español",
         "fr": "Français",
         "de": "Deutsch",
-        "it": "Italiano"
+        "it": "Italiano",
+        "uk": "Українська"
       },
       "display_language_current_lang": {
         "en": "Anglais",
         "es": "Espagnol",
         "fr": "Français",
         "de": "Allemand",
-        "it": "Italien"
+        "it": "Italien",
+        "uk": "Ukrainien"
       }
     },
     "timezone": {

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -197,14 +197,16 @@
         "es": "Español",
         "fr": "Français",
         "de": "Deutsch",
-        "it": "Italiano"
+        "it": "Italiano",
+        "uk": "Українська"
       },
       "display_language_current_lang": {
         "en": "Inglese",
         "es": "Spagnolo",
         "fr": "Francese",
         "de": "Tedesco",
-        "it": "Italiano"
+        "it": "Italiano",
+        "uk": "Ucraino"
       }
     },
     "timezone": {

--- a/webapp/IronCalc/src/locale/uk_ua.json
+++ b/webapp/IronCalc/src/locale/uk_ua.json
@@ -1,0 +1,218 @@
+{
+  "toolbar": {
+    "redo": "Повторити",
+    "undo": "Скасувати",
+    "copy_styles": "Копіювати стилі",
+    "clear_formatting": "Очистити форматування",
+    "currency": "Формат валюти",
+    "percentage": "Формат відсотків",
+    "bold": "Жирний",
+    "italic": "Курсив",
+    "underline": "Підкреслення",
+    "strike_through": "Закреслення",
+    "align_left": "Вирівняти ліворуч",
+    "align_right": "Вирівняти праворуч",
+    "align_center": "Вирівняти по центру",
+    "format_number": "Формат числа",
+    "font_color": "Колір шрифту",
+    "fill_color": "Колір заливки",
+    "increase_font_size": "Збільшити розмір шрифту",
+    "decrease_font_size": "Зменшити розмір шрифту",
+    "decimal_places_increase": "Збільшити кількість десяткових знаків",
+    "decimal_places_decrease": "Зменшити кількість десяткових знаків",
+    "show_hide_grid_lines": "Показати/приховати лінії сітки",
+    "named_ranges": "Іменовані діапазони",
+    "vertical_align_bottom": "Вирівняти знизу",
+    "vertical_align_middle": "Вирівняти посередині",
+    "vertical_align_top": "Вирівняти зверху",
+    "selected_png": "Експортувати виділену область як PNG",
+    "wrap_text": "Перенос тексту",
+    "scroll_left": "Прокрутити ліворуч",
+    "scroll_right": "Прокрутити праворуч",
+    "format_menu": {
+      "auto": "Авто",
+      "number": "Число",
+      "percentage": "Відсотки",
+      "currency_eur": "Євро (EUR)",
+      "currency_usd": "Долар (USD)",
+      "currency_gbp": "Британський фунт (GBP)",
+      "date_short": "Коротка дата",
+      "date_long": "Повна дата",
+      "custom": "Користувацький",
+      "number_example": "1 000,00",
+      "percentage_example": "10%",
+      "currency_eur_example": "€",
+      "currency_usd_example": "$",
+      "currency_gbp_example": "£"
+    },
+    "borders": {
+      "title": "Межі",
+      "all": "Усі межі",
+      "inner": "Внутрішні межі",
+      "outer": "Зовнішні межі",
+      "top": "Верхні межі",
+      "bottom": "Нижні межі",
+      "clear": "Очистити межі",
+      "left": "Ліві межі",
+      "right": "Праві межі",
+      "horizontal": "Горизонтальні межі",
+      "vertical": "Вертикальні межі",
+      "color": "Колір межі",
+      "style": "Стиль межі"
+    }
+  },
+  "num_fmt": {
+    "title": "Користувацький формат числа",
+    "label": "Формат числа",
+    "close": "Закрити діалог",
+    "save": "Зберегти"
+  },
+  "sheet_rename": {
+    "rename": "Зберегти",
+    "label": "Нова назва",
+    "title": "Перейменувати аркуш",
+    "close": "Закрити діалог"
+  },
+  "sheet_delete": {
+    "title": "Ви впевнені?",
+    "message": "Аркуш '{{sheetName}}' буде видалено.",
+    "confirm": "Так, видалити аркуш",
+    "cancel": "Скасувати"
+  },
+  "sheet_tab": {
+    "rename": "Перейменувати",
+    "change_color": "Змінити колір",
+    "delete": "Видалити",
+    "hide_sheet": "Приховати",
+    "open_menu": "Відкрити меню аркуша"
+  },
+  "formula_input": {
+    "update": "Оновити",
+    "label": "Формула",
+    "title": "Оновити формулу"
+  },
+  "formula_bar": {
+    "manage_named_ranges": "Керувати іменованими діапазонами"
+  },
+  "navigation": {
+    "add_sheet": "Додати аркуш",
+    "sheet_list": "Список аркушів"
+  },
+  "name_manager_dialog": {
+    "title": "Іменовані діапазони",
+    "empty_message1": "Іменованих діапазонів ще не додано.",
+    "empty_message2": "Натисніть «Додати новий», щоб створити.",
+    "name": "Назва",
+    "range": "Область",
+    "scope": "Діапазон",
+    "help": "Про іменовані діапазони",
+    "new": "Додати новий",
+    "workbook": "Книга",
+    "global": "(Глобальний)",
+    "close": "Закрити діалог",
+    "delete": "Видалити діапазон",
+    "edit": "Редагувати діапазон",
+    "back_to_list": "Повернутися до списку",
+    "add_new_range": "Додати новий діапазон",
+    "edit_range": "Редагувати діапазон",
+    "new_named_range": "Новий іменований діапазон",
+    "range_name": "Назва діапазону",
+    "enter_range_name": "Введіть назву діапазону",
+    "scope_label": "Область",
+    "scope_helper": "Область іменованого діапазону визначає, де він доступний.",
+    "refers_to": "Посилається на",
+    "enter_formula": "Введіть формулу",
+    "cancel": "Скасувати",
+    "apply": "Застосувати зміни",
+    "discard": "Відхилити зміни",
+    "default_range_prefix": "Діапазон",
+    "errors": {
+      "range_name_required": "Назва діапазону обов'язкова",
+      "name_cannot_contain_spaces": "Назва не може містити пробіли",
+      "name_cannot_start_with_number": "Назва не може починатися з цифри",
+      "name_invalid_characters": "Назва містить недопустимі символи. Використовуйте лише літери, цифри, підкреслення та крапки. Має починатися з літери або підкреслення.",
+      "name_already_exists": "Ця назва вже існує у вибраній області"
+    }
+  },
+  "context_menu": {
+    "column_header": {
+      "delete_column": "Видалити стовпець '{{column}}'",
+      "delete_columns": "Видалити стовпці {{columnStart}} - {{columnEnd}}",
+      "freeze_columns": "Закріпити до стовпця '{{column}}'",
+      "hide_column": "Приховати стовпець '{{column}}'",
+      "hide_columns": "Приховати стовпці {{columnStart}} - {{columnEnd}}",
+      "insert_columns_before": "Вставити {{count}} стовпець(-ці) ліворуч",
+      "insert_columns_after": "Вставити {{count}} стовпець(-ці) праворуч",
+      "move_columns_left": "Перемістити стовпці ліворуч",
+      "move_columns_right": "Перемістити стовпці праворуч",
+      "show_hidden_columns": "Показати приховані стовпці",
+      "unfreeze_columns": "Відкріпити стовпці"
+    },
+    "row_header": {
+      "delete_row": "Видалити рядок '{{row}}'",
+      "delete_rows": "Видалити рядки {{rowStart}} - {{rowEnd}}",
+      "freeze_rows": "Закріпити до рядка '{{row}}'",
+      "hide_row": "Приховати рядок '{{row}}'",
+      "hide_rows": "Приховати рядки {{rowStart}} - {{rowEnd}}",
+      "insert_rows_above": "Вставити {{count}} рядок(-ки) вище",
+      "insert_rows_below": "Вставити {{count}} рядок(-ки) нижче",
+      "move_rows_up": "Перемістити рядки вгору",
+      "move_rows_down": "Перемістити рядки вниз",
+      "show_hidden_rows": "Показати приховані рядки",
+      "unfreeze_rows": "Відкріпити рядки"
+    }
+  },
+  "color_picker": {
+    "apply": "Додати колір",
+    "cancel": "Скасувати",
+    "add": "Додати новий колір",
+    "default": "Колір за замовчуванням",
+    "no_fill": "Без заливки",
+    "recent": "Нещодавні",
+    "title": "Вибір кольору"
+  },
+  "right_drawer": {
+    "resize_drawer": "Змінити розмір панелі",
+    "close": "Закрити"
+  },
+  "regional_settings": {
+    "open_regional_settings": "Відкрити регіональні налаштування",
+    "title": "Регіональні налаштування",
+    "close": "Закрити діалогове вікно",
+    "locale": {
+      "title": "Регіон",
+      "locale_label": "Регіон",
+      "locale_example1": "Число",
+      "locale_example2": "Дата й час",
+      "locale_example3": "Роздільник в формулах",
+      "delimiter_comma": "Кома",
+      "delimiter_semicolon": "Крапка з комою"
+    },
+    "language": {
+      "title": "Мова",
+      "language_label": "Мова двигуна",
+      "language_helper": "Визначає мову, яка використовується в іменах функцій та повідомленнях про помилки.",
+      "display_language": {
+        "en": "English",
+        "es": "Español",
+        "fr": "Français",
+        "de": "Deutsch",
+        "it": "Italiano",
+        "uk": "Українська"
+      },
+      "display_language_current_lang": {
+        "en": "Англійська",
+        "es": "Іспанська",
+        "fr": "Французька",
+        "de": "Німецька",
+        "it": "Італійська",
+        "uk": "Українська"
+      }
+    },
+    "timezone": {
+      "title": "Часовий пояс",
+      "timezone_label": "Часовий пояс",
+      "timezone_helper": "Зміна цього параметра вплине на функції дати й часу, зокрема TODAY() та NOW()."
+    }
+  }
+}

--- a/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileMenu.tsx
@@ -220,6 +220,14 @@ export function FileMenu(props: {
           )}
           Italiano (it-IT)
         </MenuItemWrapper>
+        <MenuItemWrapper onClick={() => handleLanguageItemSelect("uk-UA")}>
+          {i18n.language === "uk-UA" ? (
+              <Check size={16} />
+          ) : (
+              <IconPlaceholder />
+          )}
+          Українська (uk-UA)
+        </MenuItemWrapper>
       </Menu>
       <Modal
         open={isImportMenuOpen}

--- a/webapp/app.ironcalc.com/frontend/src/components/storage.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/storage.ts
@@ -14,7 +14,7 @@ type ModelsMetadata = Record<
 >;
 
 // Returns the default UI language based on the browser settings
-// ['en-US', 'en-GB', 'es-ES', 'fr-FR', 'de-DE', 'it-IT']
+// ['en-US', 'en-GB', 'es-ES', 'fr-FR', 'de-DE', 'it-IT', 'uk-UA']
 function getDefaultUILocale(): string {
   const lang = navigator.language || navigator.languages[0] || "en-US";
   if (lang.startsWith("es")) {
@@ -27,6 +27,8 @@ function getDefaultUILocale(): string {
     return "en-GB";
   } else if (lang.startsWith("it")) {
     return "it-IT";
+  } else if (lang.startsWith("uk")) {
+    return "uk-UA";
   }
 
   return "en-US";
@@ -46,6 +48,9 @@ export function getShortLocaleCode(longCode: string): string {
     }
     case "it-IT": {
       return "it";
+    }
+    case "uk-UA": {
+      return "uk";
     }
     case "en-GB": {
       return "en-GB";

--- a/webapp/app.ironcalc.com/frontend/src/i18n.ts
+++ b/webapp/app.ironcalc.com/frontend/src/i18n.ts
@@ -5,6 +5,7 @@ import translationEN from "./locale/en_us.json";
 import translationES from "./locale/es_es.json";
 import translationFR from "./locale/fr_fr.json";
 import translationIT from "./locale/it_it.json";
+import translationUK from "./locale/uk_ua.json";
 
 const resources = {
   "en-US": { translation: translationEN },
@@ -13,6 +14,7 @@ const resources = {
   "fr-FR": { translation: translationFR },
   "de-DE": { translation: translationDE },
   "it-IT": { translation: translationIT },
+  "uk-UA": { translation: translationUK },
 };
 
 i18n.use(initReactI18next).init({

--- a/webapp/app.ironcalc.com/frontend/src/locale/uk_ua.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/uk_ua.json
@@ -1,0 +1,93 @@
+{
+  "app": {
+    "title": "IronCalc"
+  },
+  "default_workbook_name": "Книга",
+  "errors": {
+    "model_not_found": "Модель не знайдено або не вдалося завантажити",
+    "example_not_found": "Файл-приклад не знайдено або не вдалося завантажити"
+  },
+  "welcome_dialog": {
+    "title": "Ласкаво просимо до IronCalc",
+    "subtitle": "Почніть з порожньої книги або готового шаблону.",
+    "close_dialog": "Закрити діалог",
+    "new": "Новий",
+    "blank_workbook": "Порожня книга",
+    "blank_workbook_description": "Створіть з нуля або завантажте власний файл.",
+    "templates": {
+      "choose_template": "Оберіть шаблон",
+      "templates": "Шаблони",
+      "mortgage_calculator": "Іпотечний калькулятор",
+      "mortgage_calculator_description": "Розрахунок платежів, відсотків та загальної вартості.",
+      "travel_expenses_tracker": "Трекер витрат на подорожі",
+      "travel_expenses_tracker_description": "Відстежуйте витрати на поїздки та дотримуйтесь бюджету."
+    },
+    "create_workbook": "Створити книгу"
+  },
+  "left_drawer": {
+    "new_workbook": "Нова книга",
+    "pinned": "Закріплені",
+    "today": "Сьогодні",
+    "last_30_days": "Останні 30 днів",
+    "older": "Старіші",
+    "workbook_menu": {
+      "download": "Завантажити (.xlsx)",
+      "pin": "Закріпити",
+      "unpin": "Відкріпити",
+      "duplicate": "Дублювати",
+      "delete": "Видалити книгу"
+    },
+    "alert": {
+      "title": "Зверніть увагу!",
+      "subtitle": "IronCalc зберігає ваші дані лише у локальному сховищі браузера.",
+      "subtitle2": "<bold>Завантажуйте XLSX частіше</bold> — майбутні версії можуть не відкрити поточні книги, навіть якщо вони були надіслані."
+    },
+    "documentation": "Документація"
+  },
+  "file_bar": {
+    "open_sidebar": "Відкрити бічну панель",
+    "close_sidebar": "Закрити бічну панель",
+    "file_menu": {
+      "button": "Файл",
+      "new_blank_workbook": "Нова порожня книга",
+      "new_from_template": "Новий із шаблону",
+      "import": {
+        "button": "Імпорт",
+        "title": "Імпортувати файл .xlsx",
+        "subtitle": "Перетягніть файл сюди або",
+        "subtitle_link": "натисніть для вибору",
+        "learn_more": "Дізнатися більше про імпорт файлів в IronCalc",
+        "close_dialog": "Закрити діалог",
+        "uploading": "Завантаження {{fileName}}...",
+        "drop_file_here": "Перетягніть файл сюди"
+      },
+      "download": "Завантажити (.xlsx)",
+      "delete_workbook": {
+        "button": "Видалити книгу",
+        "title": "Ви впевнені?",
+        "subtitle": "Книгу <bold>'{{workbookName}}'</bold> буде остаточно видалено. Цю дію неможливо скасувати.",
+        "confirm_button": "Так, видалити книгу",
+        "cancel_button": "Скасувати"
+      },
+      "default_language": "Мова за замовчуванням"
+    },
+    "help_menu": {
+      "button": "Довідка",
+      "documentation": "Документація",
+      "keyboard_shortcuts": "Гарячі клавіші"
+    },
+    "title_input": {
+      "warning_text1": "Ця книга зберігається лише у вашому браузері. Для збереження завантажте її як .xlsx.",
+      "warning_text2": " Майбутні версії можуть бути несумісними."
+    },
+    "share_popover": {
+      "button": "Поділитися",
+      "copy_url": "Копіювати URL",
+      "copied": "Скопійовано!",
+      "info_text": "Будь-хто з посиланням зможе отримати копію цієї книги"
+    }
+  },
+  "loading_screen": {
+    "message": "Завантаження IronCalc"
+  }
+}


### PR DESCRIPTION
Summary                                                                                                                                                                                                         
  
  - Add Ukrainian translation files for both @ironcalc/workbook and the frontend app                                                                                                                              
  - Register uk-UA locale in i18n configs, language switcher menu, and storage utilities
  - Add browser language auto-detection and locale code mapping for Ukrainian                                                                                                                                     
                                                                                                                                                                                                                  