### PR TITLE
update: add reusable `Tooltip` component

### DIFF
--- a/webapp/IronCalc/src/components/Tooltip/Tooltip.stories.tsx
+++ b/webapp/IronCalc/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ReactNode } from "react";
+import { Button } from "../Button/Button";
+import { Tooltip, type TooltipProperties } from "./Tooltip";
+
+function Btn({ children }: { children: ReactNode }) {
+  return <Button variant="secondary">{children}</Button>;
+}
+
+type TooltipStoryProps = Omit<TooltipProperties, "children">;
+
+function TooltipStory({ title }: TooltipStoryProps) {
+  return (
+    <Tooltip title={title}>
+      <Btn>Hover me</Btn>
+    </Tooltip>
+  );
+}
+
+const meta = {
+  title: "Components/Tooltip",
+  component: TooltipStory,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    title: {
+      control: "text",
+      description: "Tooltip text content",
+    },
+  },
+} satisfies Meta<typeof TooltipStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "This is a tooltip",
+  },
+};
+
+export const CornerPositioning: Story = {
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    title: "Tooltip text content",
+  },
+  render: ({ title }) => (
+    <div>
+      <div style={{ position: "absolute", top: 8, left: 8 }}>
+        <Tooltip title={title}>
+          <Btn>Top-left</Btn>
+        </Tooltip>
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          top: 8,
+          left: "50%",
+          transform: "translateX(-50%)",
+        }}
+      >
+        <Tooltip title={title}>
+          <Btn>Top-center</Btn>
+        </Tooltip>
+      </div>
+
+      <div style={{ position: "absolute", top: 8, right: 8 }}>
+        <Tooltip title={title}>
+          <Btn>Top-right</Btn>
+        </Tooltip>
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: 8,
+          transform: "translateY(-50%)",
+        }}
+      >
+        <Tooltip title={title}>
+          <Btn>Left-center</Btn>
+        </Tooltip>
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+        }}
+      >
+        <Tooltip title={title}>
+          <Btn>Center</Btn>
+        </Tooltip>
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          top: "50%",
+          right: 8,
+          transform: "translateY(-50%)",
+        }}
+      >
+        <Tooltip title={title}>
+          <Btn>Right-center</Btn>
+        </Tooltip>
+      </div>
+
+      <div style={{ position: "absolute", bottom: 8, left: 8 }}>
+        <Tooltip title={title}>
+          <Btn>Bottom-left</Btn>
+        </Tooltip>
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          bottom: 8,
+          left: "50%",
+          transform: "translateX(-50%)",
+        }}
+      >
+        <Tooltip title={title}>
+          <Btn>Bottom-center</Btn>
+        </Tooltip>
+      </div>
+
+      <div style={{ position: "absolute", bottom: 8, right: 8 }}>
+        <Tooltip title={title}>
+          <Btn>Bottom-right</Btn>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};

--- a/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
+++ b/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
@@ -1,14 +1,54 @@
-import type { ReactElement } from "react";
+import { type ReactElement, useId, useState } from "react";
+import { createPortal } from "react-dom";
 
-type TooltipProperties = {
+import "./tooltip.css";
+import { useTooltipPosition } from "./useTooltipPosition";
+
+/**
+ * Reusable Tooltip component
+ * Placed on top by default, fallbacks to bottom when there's no space
+ */
+
+export interface TooltipProperties {
   title: string;
   children: ReactElement;
-};
+}
 
 export function Tooltip({ title, children }: TooltipProperties) {
+  const tooltipId = useId();
+  const [visible, setVisible] = useState(false);
+  const { triggerRef, tooltipRef, position } = useTooltipPosition(visible);
+
   return (
-    <span title={title} style={{ display: "inline-flex" }}>
-      {children}
-    </span>
+    <>
+      <span
+        ref={triggerRef}
+        role="none"
+        className="ic-tooltip-trigger"
+        aria-describedby={visible ? tooltipId : undefined}
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        onFocus={() => setVisible(true)}
+        onBlur={() => setVisible(false)}
+      >
+        {children}
+      </span>
+
+      {createPortal(
+        <div
+          ref={tooltipRef}
+          id={tooltipId}
+          role="tooltip"
+          className="ic-tooltip"
+          data-visible={visible}
+          style={position}
+        >
+          {title}
+        </div>,
+        document.body,
+      )}
+    </>
   );
 }
+
+Tooltip.displayName = "Tooltip";

--- a/webapp/IronCalc/src/components/Tooltip/tooltip.css
+++ b/webapp/IronCalc/src/components/Tooltip/tooltip.css
@@ -4,7 +4,6 @@
 
 .ic-tooltip {
   position: fixed;
-  z-index: 9999;
   pointer-events: none;
   white-space: nowrap;
   font-family: var(--typography-font-family);

--- a/webapp/IronCalc/src/components/Tooltip/tooltip.css
+++ b/webapp/IronCalc/src/components/Tooltip/tooltip.css
@@ -1,0 +1,33 @@
+.ic-tooltip-trigger {
+  display: inline-flex;
+}
+
+.ic-tooltip {
+  position: fixed;
+  z-index: 9999;
+  pointer-events: none;
+  white-space: nowrap;
+  font-family: var(--typography-font-family);
+  font-size: calc(var(--typography-font-size) - 1px);
+  color: var(--palette-common-white);
+  background-color: color-mix(
+    in srgb,
+    var(--palette-common-black) 80%,
+    transparent
+  );
+  border-radius: 4px;
+  padding: 4px 8px;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 150ms ease-out,
+    visibility 0s linear 150ms;
+}
+
+.ic-tooltip[data-visible="true"] {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity 150ms ease-out,
+    visibility 0s;
+}

--- a/webapp/IronCalc/src/components/Tooltip/useTooltipPosition.ts
+++ b/webapp/IronCalc/src/components/Tooltip/useTooltipPosition.ts
@@ -1,0 +1,64 @@
+import { type CSSProperties, useLayoutEffect, useRef, useState } from "react";
+
+function getTooltipPosition(trigger: HTMLElement, tooltip: HTMLElement) {
+  const triggerRect = trigger.getBoundingClientRect();
+  const tooltipWidth = tooltip.offsetWidth;
+  const tooltipHeight = tooltip.offsetHeight;
+  const viewportWidth = window.innerWidth;
+
+  const offset = 6; // Distance between trigger and tooltip
+  const margin = 8; // Safety margin from viewport edges
+
+  // Centered horizontally over the trigger, falls back to clamped position
+  let left = triggerRect.left + triggerRect.width / 2 - tooltipWidth / 2;
+
+  // Above by default, falls back to below when there's not enough space
+  let top = triggerRect.top - tooltipHeight - offset;
+  if (top < margin) {
+    top = triggerRect.bottom + offset;
+  }
+
+  if (left + tooltipWidth > viewportWidth - margin) {
+    left = viewportWidth - tooltipWidth - margin;
+  }
+  if (left < margin) {
+    left = margin;
+  }
+
+  return { top, left };
+}
+
+export function useTooltipPosition(visible: boolean) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<CSSProperties>({});
+
+  useLayoutEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    function updatePosition() {
+      const trigger = triggerRef.current;
+      const tooltip = tooltipRef.current;
+      if (!trigger || !tooltip) {
+        return;
+      }
+
+      const { top, left } = getTooltipPosition(trigger, tooltip);
+      setPosition({ top, left });
+    }
+
+    updatePosition();
+
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [visible]);
+
+  return { triggerRef, tooltipRef, position };
+}


### PR DESCRIPTION
Replaces the previous `Tooltip` with a custom one. The tooltip renders via a portal, positions itself relative to its trigger and has with viewport-aware clamping so it doesn't crop when it's too close to the window's edge.

### Changes

1. `Tooltip.tsx`
- Renders a wrapper span around the trigger that listens to mouseenter/mouseleave and focus/blur to control visibility.
- Renders the tooltip itself into document.body via createPortal, keeping it out of any overflow/stacking context

2. `useTooltipPosition.ts`
Consistent with what we recently added in the `Select` component.

3. `tooltip.css`
Very simple styling with a subtle animation. The tooltip takes 150ms to set the opacity to 1 (on mouse enter) and the same to set it to 0 (on mouse leave).

4. `Tooltip.stories.tsx`: 2 stories added:
- Default: simple button with a tooltip
- Corner positioning: 9 cases to see how the tooltip works on the corners and the sides
