### PR TITLE
fix: stop event propagation at Input component level

### DIFF
--- a/webapp/IronCalc/src/components/Input/Input.tsx
+++ b/webapp/IronCalc/src/components/Input/Input.tsx
@@ -84,6 +84,8 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
             required={required}
             aria-invalid={error || undefined}
             aria-describedby={helperText ? helperId : undefined}
+            onKeyDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
             {...rest}
           />
 

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
@@ -129,8 +129,6 @@ const EditNamedRange = ({
             error={!!nameError}
             helperText={nameError}
             onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
           />
           <Select
             label={t("name_manager_dialog.scope_label")}

--- a/webapp/IronCalc/src/components/RightDrawer/RightDrawer.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/RightDrawer.tsx
@@ -81,8 +81,6 @@ const RightDrawer = ({
         return;
       }
 
-      e.preventDefault();
-      e.stopPropagation();
       setDrawerWidth(nextWidth);
       onWidthChange(nextWidth);
     },


### PR DESCRIPTION
We've moved `stopPropagation` for `keydown` and `click` events into the `Input` component directly, so callers don't need to handle it individually.