### PR TITLE
FIX: editor font not themed

### DIFF
--- a/webapp/IronCalc/src/components/Editor/Editor.tsx
+++ b/webapp/IronCalc/src/components/Editor/Editor.tsx
@@ -187,7 +187,7 @@ const Editor = (options: EditorOptions) => {
         overflow: "hidden",
         display: showEditor,
         background: "#FFF",
-        fontFamily: "Inter",
+        fontFamily: "var(--palette-sheet-default-cell-font-family)",
         fontSize: "13px",
       }}
     >


### PR DESCRIPTION
I'm deploying IronCalc without the Inter font (configuring another via theme variable instead) and the cell editor showed up as Times. This change fixes it.