### PR TITLE
FIX: Issues with Array formulas and undo/redo

### DIFF
--- a/base/src/expressions/utils/mod.rs
+++ b/base/src/expressions/utils/mod.rs
@@ -161,12 +161,8 @@ pub fn parse_reference_a1(r: &str) -> Option<ParsedReference> {
 
     for ch in chars {
         match ch {
-            'A'..='Z' => {
-                if state == 1 {
-                    column.push(ch);
-                } else {
-                    return None;
-                }
+            'A'..='Z' if state == 1 => {
+                column.push(ch);
             }
             '0'..='9' => {
                 if state == 1 {

--- a/base/src/functions/information.rs
+++ b/base/src/functions/information.rs
@@ -91,13 +91,10 @@ impl<'a> Model<'a> {
     pub(crate) fn fn_isna(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
         if args.len() == 1 {
             match self.evaluate_node_in_context(&args[0], cell) {
-                CalcResult::Error { error, .. } => {
-                    if error == Error::NA {
+                CalcResult::Error { error, .. }
+                    if error == Error::NA => {
                         return CalcResult::Boolean(true);
-                    } else {
-                        return CalcResult::Boolean(false);
                     }
-                }
                 _ => {
                     return CalcResult::Boolean(false);
                 }

--- a/base/src/functions/information.rs
+++ b/base/src/functions/information.rs
@@ -91,10 +91,11 @@ impl<'a> Model<'a> {
     pub(crate) fn fn_isna(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
         if args.len() == 1 {
             match self.evaluate_node_in_context(&args[0], cell) {
-                CalcResult::Error { error, .. }
-                    if error == Error::NA => {
-                        return CalcResult::Boolean(true);
-                    }
+                CalcResult::Error {
+                    error: Error::NA, ..
+                } => {
+                    return CalcResult::Boolean(true);
+                }
                 _ => {
                     return CalcResult::Boolean(false);
                 }

--- a/base/src/functions/mathematical_sum.rs
+++ b/base/src/functions/mathematical_sum.rs
@@ -24,7 +24,7 @@ impl<'a> Model<'a> {
         let (_, _, values_left, values_right) = result;
 
         let mut sum = 0.0;
-        for (x_opt, y_opt) in values_left.into_iter().zip(values_right.into_iter()) {
+        for (x_opt, y_opt) in values_left.into_iter().zip(values_right) {
             let x = x_opt.unwrap_or(0.0);
             let y = y_opt.unwrap_or(0.0);
             sum += x * x - y * y;
@@ -43,7 +43,7 @@ impl<'a> Model<'a> {
         let (_rows, _cols, values_left, values_right) = result;
 
         let mut sum = 0.0;
-        for (x_opt, y_opt) in values_left.into_iter().zip(values_right.into_iter()) {
+        for (x_opt, y_opt) in values_left.into_iter().zip(values_right) {
             let x = x_opt.unwrap_or(0.0);
             let y = y_opt.unwrap_or(0.0);
             sum += x * x + y * y;
@@ -62,7 +62,7 @@ impl<'a> Model<'a> {
         let (_, _, values_left, values_right) = result;
 
         let mut sum = 0.0;
-        for (x_opt, y_opt) in values_left.into_iter().zip(values_right.into_iter()) {
+        for (x_opt, y_opt) in values_left.into_iter().zip(values_right) {
             let x = x_opt.unwrap_or(0.0);
             let y = y_opt.unwrap_or(0.0);
             let diff = x - y;

--- a/base/src/functions/statistical/correl.rs
+++ b/base/src/functions/statistical/correl.rs
@@ -18,7 +18,7 @@ impl<'a> Model<'a> {
         let mut sum_y2 = 0.0;
         let mut sum_xy = 0.0;
 
-        for (x_opt, y_opt) in values_left.into_iter().zip(values_right.into_iter()) {
+        for (x_opt, y_opt) in values_left.into_iter().zip(values_right) {
             if let (Some(x), Some(y)) = (x_opt, y_opt) {
                 n += 1.0;
                 sum_x += x;

--- a/base/src/functions/statistical/count_and_average.rs
+++ b/base/src/functions/statistical/count_and_average.rs
@@ -22,22 +22,18 @@ impl<'a> Model<'a> {
                 CalcResult::Number(value) => {
                     f(value);
                 }
-                CalcResult::Boolean(value) => {
-                    if !matches!(arg, Node::ReferenceKind { .. }) {
-                        f(if value { 1.0 } else { 0.0 });
-                    }
+                CalcResult::Boolean(value) if !matches!(arg, Node::ReferenceKind { .. }) => {
+                    f(if value { 1.0 } else { 0.0 });
                 }
-                CalcResult::String(value) => {
-                    if !matches!(arg, Node::ReferenceKind { .. }) {
-                        if let Some(parsed) = self.cast_number(&value) {
-                            f(parsed);
-                        } else {
-                            return Err(CalcResult::new_error(
-                                Error::VALUE,
-                                cell,
-                                "Argument cannot be cast into number".to_string(),
-                            ));
-                        }
+                CalcResult::String(value) if !matches!(arg, Node::ReferenceKind { .. }) => {
+                    if let Some(parsed) = self.cast_number(&value) {
+                        f(parsed);
+                    } else {
+                        return Err(CalcResult::new_error(
+                            Error::VALUE,
+                            cell,
+                            "Argument cannot be cast into number".to_string(),
+                        ));
                     }
                 }
                 CalcResult::Array(array) => {
@@ -119,22 +115,18 @@ impl<'a> Model<'a> {
                 CalcResult::Number(value) => {
                     f(value);
                 }
-                CalcResult::Boolean(value) => {
-                    if !matches!(arg, Node::ReferenceKind { .. }) {
-                        f(if value { 1.0 } else { 0.0 });
-                    }
+                CalcResult::Boolean(value) if !matches!(arg, Node::ReferenceKind { .. }) => {
+                    f(if value { 1.0 } else { 0.0 });
                 }
-                CalcResult::String(value) => {
-                    if !matches!(arg, Node::ReferenceKind { .. }) {
-                        if let Some(parsed) = self.cast_number(&value) {
-                            f(parsed);
-                        } else {
-                            return Err(CalcResult::new_error(
-                                Error::VALUE,
-                                cell,
-                                "Argument cannot be cast into number".to_string(),
-                            ));
-                        }
+                CalcResult::String(value) if !matches!(arg, Node::ReferenceKind { .. }) => {
+                    if let Some(parsed) = self.cast_number(&value) {
+                        f(parsed);
+                    } else {
+                        return Err(CalcResult::new_error(
+                            Error::VALUE,
+                            cell,
+                            "Argument cannot be cast into number".to_string(),
+                        ));
                     }
                 }
                 CalcResult::Array(array) => {
@@ -341,15 +333,13 @@ impl<'a> Model<'a> {
                 CalcResult::Number(_) => {
                     result += 1.0;
                 }
-                CalcResult::Boolean(_) => {
-                    if !matches!(arg, Node::ReferenceKind { .. }) {
-                        result += 1.0;
-                    }
+                CalcResult::Boolean(_) if !matches!(arg, Node::ReferenceKind { .. }) => {
+                    result += 1.0;
                 }
-                CalcResult::String(s) => {
-                    if !matches!(arg, Node::ReferenceKind { .. }) && s.parse::<f64>().is_ok() {
-                        result += 1.0;
-                    }
+                CalcResult::String(s)
+                    if !matches!(arg, Node::ReferenceKind { .. }) && s.parse::<f64>().is_ok() =>
+                {
+                    result += 1.0;
                 }
                 CalcResult::Range { left, right } => {
                     if left.sheet != right.sheet {
@@ -427,11 +417,7 @@ impl<'a> Model<'a> {
         for arg in args {
             match self.evaluate_node_in_context(arg, cell) {
                 CalcResult::EmptyCell | CalcResult::EmptyArg => result += 1.0,
-                CalcResult::String(s) => {
-                    if s.is_empty() {
-                        result += 1.0
-                    }
-                }
+                CalcResult::String(s) if s.is_empty() => result += 1.0,
                 CalcResult::Range { left, right } => {
                     if left.sheet != right.sheet {
                         return CalcResult::new_error(
@@ -448,11 +434,7 @@ impl<'a> Model<'a> {
                                 column,
                             }) {
                                 CalcResult::EmptyCell | CalcResult::EmptyArg => result += 1.0,
-                                CalcResult::String(s) => {
-                                    if s.is_empty() {
-                                        result += 1.0
-                                    }
-                                }
+                                CalcResult::String(s) if s.is_empty() => result += 1.0,
                                 _ => {}
                             }
                         }

--- a/base/src/functions/statistical/covariance.rs
+++ b/base/src/functions/statistical/covariance.rs
@@ -94,7 +94,7 @@ impl<'a> Model<'a> {
         let mut xs: Vec<f64> = Vec::with_capacity(count1);
         let mut ys: Vec<f64> = Vec::with_capacity(count2);
 
-        for (v1_opt, v2_opt) in values1_opts.into_iter().zip(values2_opts.into_iter()) {
+        for (v1_opt, v2_opt) in values1_opts.into_iter().zip(values2_opts) {
             if let (Some(x), Some(y)) = (v1_opt, v2_opt) {
                 xs.push(x);
                 ys.push(y);
@@ -223,7 +223,7 @@ impl<'a> Model<'a> {
         let mut xs: Vec<f64> = Vec::with_capacity(count1);
         let mut ys: Vec<f64> = Vec::with_capacity(count2);
 
-        for (v1_opt, v2_opt) in values1_opts.into_iter().zip(values2_opts.into_iter()) {
+        for (v1_opt, v2_opt) in values1_opts.into_iter().zip(values2_opts) {
             if let (Some(x), Some(y)) = (v1_opt, v2_opt) {
                 xs.push(x);
                 ys.push(y);

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1178,7 +1178,21 @@ impl<'a> Model<'a> {
                             if r == cell_reference.row && c == cell_reference.column {
                                 continue;
                             }
-                            let _ = ws.cell_clear_contents(r, c);
+                            // Only clear cells that are spill cells belonging to this anchor.
+                            // Non-SpillCell content must remain
+                            // so they can block the spill on re-evaluation.
+                            let is_own_spill = ws
+                                .sheet_data
+                                .get(&r)
+                                .and_then(|row_data| row_data.get(&c))
+                                .map(|cell| {
+                                    matches!(cell, Cell::SpillCell { a, .. }
+                                        if *a == (cell_reference.row, cell_reference.column))
+                                })
+                                .unwrap_or(false);
+                            if is_own_spill {
+                                let _ = ws.cell_clear_contents(r, c);
+                            }
                         }
                     }
                 }

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -10,6 +10,7 @@ mod test_cut_n_paste;
 mod test_defined_names;
 mod test_delete_row_column_formatting;
 mod test_diff_queue;
+mod test_dynamic_arrays;
 mod test_evaluation;
 mod test_fn_formulatext;
 mod test_general;

--- a/base/src/test/user_model/test_dynamic_arrays.rs
+++ b/base/src/test/user_model/test_dynamic_arrays.rs
@@ -31,7 +31,7 @@ fn undo_redo_dynamic_array() {
         Ok("#SPILL!".to_string())
     );
 
-    // Undo the formula entry
+    // Undo the spill-blocking entry so the dynamic array can spill again
     model.undo().unwrap();
     assert_eq!(
         model.get_formatted_cell_value(0, 1, 1),
@@ -44,6 +44,13 @@ fn undo_redo_dynamic_array() {
     assert_eq!(
         model.get_formatted_cell_value(0, 3, 1),
         Ok("30".to_string())
+    );
+
+    // Redo the blocking entry
+    model.redo().unwrap();
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 1),
+        Ok("#SPILL!".to_string())
     );
 }
 
@@ -81,7 +88,7 @@ fn undo_redo_dynamic_array_with_cse() {
         Ok("#SPILL!".to_string())
     );
 
-    // Undo the formula entry
+    // Undo the CSE entry
     model.undo().unwrap();
     assert_eq!(
         model.get_formatted_cell_value(0, 1, 1),
@@ -94,6 +101,13 @@ fn undo_redo_dynamic_array_with_cse() {
     assert_eq!(
         model.get_formatted_cell_value(0, 3, 1),
         Ok("30".to_string())
+    );
+
+    // Redo the CSE entry
+    model.redo().unwrap();
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 1),
+        Ok("#SPILL!".to_string())
     );
 }
 

--- a/base/src/test/user_model/test_dynamic_arrays.rs
+++ b/base/src/test/user_model/test_dynamic_arrays.rs
@@ -1,0 +1,151 @@
+#![allow(clippy::unwrap_used)]
+use crate::test::user_model::util::new_empty_user_model;
+
+#[test]
+fn undo_redo_dynamic_array() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 2, "10").unwrap();
+    model.set_user_input(0, 2, 2, "20").unwrap();
+    model.set_user_input(0, 3, 2, "30").unwrap();
+
+    // Dynamic formula in A1 that returns a 5×1 array
+    model.set_user_input(0, 1, 1, "=B1:B5").unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 1),
+        Ok("10".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("20".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 3, 1),
+        Ok("30".to_string())
+    );
+
+    model.set_user_input(0, 3, 1, "Bong!").unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 1),
+        Ok("#SPILL!".to_string())
+    );
+
+    // Undo the formula entry
+    model.undo().unwrap();
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 1),
+        Ok("10".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("20".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 3, 1),
+        Ok("30".to_string())
+    );
+}
+
+#[test]
+fn undo_redo_dynamic_array_with_cse() {
+    let mut model = new_empty_user_model();
+    // B1
+    model.set_user_input(0, 1, 2, "10").unwrap();
+    // B2
+    model.set_user_input(0, 2, 2, "20").unwrap();
+    // B3
+    model.set_user_input(0, 3, 2, "30").unwrap();
+
+    // Dynamic formula in A1 that returns a dynamic array
+    model.set_user_input(0, 1, 1, "=B1:B5").unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 1),
+        Ok("10".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("20".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 3, 1),
+        Ok("30".to_string())
+    );
+
+    // value in A3 causes SPILL! (CSE range A3:E3, anchor overlaps dynamic spill)
+    model.set_user_array_formula(0, 3, 1, 5, 1, "=123").unwrap();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 1),
+        Ok("#SPILL!".to_string())
+    );
+
+    // Undo the formula entry
+    model.undo().unwrap();
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 1),
+        Ok("10".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 2, 1),
+        Ok("20".to_string())
+    );
+    assert_eq!(
+        model.get_formatted_cell_value(0, 3, 1),
+        Ok("30".to_string())
+    );
+}
+
+#[test]
+fn spill_array_dynamic() {
+    let mut model = new_empty_user_model();
+    // A13
+    model.set_user_input(0, 13, 1, "10").unwrap();
+    // A14
+    model.set_user_input(0, 14, 1, "20").unwrap();
+    // A15
+    model.set_user_input(0, 15, 1, "30").unwrap();
+    // A16
+    model.set_user_input(0, 16, 1, "40").unwrap();
+
+    // Dynamic array formula in D13
+    model.set_user_input(0, 13, 4, "=A13:A16").unwrap();
+
+    // Array formula is C15:G15 — D15 is in D13's spill range
+    model
+        .set_user_array_formula(0, 15, 3, 5, 1, "=123")
+        .unwrap();
+
+    // The dynamic array in D13 should show #SPILL! because D15 (part of C15:G15) is in the spill range
+    assert_eq!(
+        model.get_formatted_cell_value(0, 13, 4),
+        Ok("#SPILL!".to_string())
+    );
+}
+
+#[test]
+fn array_in_spill_formula() {
+    let mut model = new_empty_user_model();
+    // A13
+    model.set_user_input(0, 13, 1, "10").unwrap();
+    // A14
+    model.set_user_input(0, 14, 1, "20").unwrap();
+    // A15
+    model.set_user_input(0, 15, 1, "30").unwrap();
+    // A16
+    model.set_user_input(0, 16, 1, "40").unwrap();
+
+    model.set_user_input(0, 13, 4, "=A13:A16").unwrap();
+
+    // an array formula with anchor in the spill range of the dynamic array formula
+    model
+        .set_user_array_formula(0, 15, 4, 1, 5, "=123")
+        .unwrap();
+
+    // The dynamic array in D13 should now spill into E13, F13, G13 and show #SPILL! error because of the array formula in D15:D19
+    assert_eq!(
+        model.get_formatted_cell_value(0, 13, 4),
+        Ok("#SPILL!".to_string())
+    );
+}

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -443,6 +443,12 @@ impl<'a> UserModel<'a> {
             .worksheet(sheet)?
             .cell(row, column)
             .cloned();
+        // If it is a spill cell we want to save the old value as None, because the value of a spill cell is determined by the anchor cell
+        let old_value = if matches!(old_value, Some(Cell::SpillCell { .. })) {
+            None
+        } else {
+            old_value
+        };
         self.model
             .set_user_input(sheet, row, column, value.to_string())?;
 
@@ -2050,12 +2056,22 @@ impl<'a> UserModel<'a> {
         height: i32,
         formula: &str,
     ) -> Result<(), String> {
-        let old_value = self
-            .model
-            .workbook
-            .worksheet(sheet)?
-            .cell(row, column)
-            .cloned();
+        let ws = self.model.workbook.worksheet(sheet)?;
+        let mut old_values = Vec::new();
+        for r in row..row + height {
+            let mut row_vals = Vec::new();
+            for c in column..column + width {
+                let cell = ws.cell(r, c).cloned();
+                // SpillCells are transient — restored by re-evaluation, so store as None.
+                let cell = if matches!(cell, Some(Cell::SpillCell { .. })) {
+                    None
+                } else {
+                    cell
+                };
+                row_vals.push(cell);
+            }
+            old_values.push(row_vals);
+        }
         self.model
             .set_user_array_formula(sheet, row, column, width, height, formula)?;
         self.push_diff_list(vec![Diff::SetArrayValue {
@@ -2065,7 +2081,7 @@ impl<'a> UserModel<'a> {
             width,
             height,
             new_value: formula.to_string(),
-            old_value: Box::new(old_value),
+            old_values,
         }]);
         self.evaluate_if_not_paused();
         Ok(())
@@ -2514,24 +2530,29 @@ impl<'a> UserModel<'a> {
                     width,
                     height,
                     new_value: _,
-                    old_value,
+                    old_values,
                 } => {
                     needs_evaluation = true;
                     // Clear all cells in the array formula range (anchor + spill cells).
-                    // We use worksheet's cell_clear_contents directly to bypass the
-                    // SpillArray guard that cell_clear_all has.
                     let ws = self.model.workbook.worksheet_mut(*sheet)?;
                     for r in *row..*row + *height {
                         for c in *column..*column + *width {
                             let _ = ws.cell_clear_contents(r, c);
                         }
                     }
-                    // Restore the anchor cell if it had a value before the array formula.
-                    if let Some(value) = *old_value.clone() {
-                        self.model
-                            .workbook
-                            .worksheet_mut(*sheet)?
-                            .update_cell(*row, *column, value)?;
+                    // Restore all cells that existed before the array formula was placed.
+                    for (ri, row_vals) in old_values.iter().enumerate() {
+                        for (ci, cell) in row_vals.iter().enumerate() {
+                            if let Some(cell) = cell {
+                                let r = *row + ri as i32;
+                                let c = *column + ci as i32;
+                                self.model.workbook.worksheet_mut(*sheet)?.update_cell(
+                                    r,
+                                    c,
+                                    cell.clone(),
+                                )?;
+                            }
+                        }
                     }
                 }
                 Diff::SetColumnWidth {
@@ -2913,7 +2934,7 @@ impl<'a> UserModel<'a> {
                     width,
                     height,
                     new_value,
-                    old_value: _,
+                    old_values: _,
                 } => {
                     needs_evaluation = true;
                     self.model.set_user_array_formula(

--- a/base/src/user_model/history.rs
+++ b/base/src/user_model/history.rs
@@ -33,7 +33,7 @@ pub(crate) enum Diff {
         width: i32,
         height: i32,
         new_value: String,
-        old_value: Box<Option<Cell>>,
+        old_values: Vec<Vec<Option<Cell>>>,
     },
     RangeClearContents {
         sheet: u32,


### PR DESCRIPTION
We keep all the old cell values when entering an array formula We do dot clear the whole spill range of a dynamic array as some of those cells might not be our spill anymore

Adds regression tests