### PR TITLE
Implement INFO function

### DIFF
--- a/base/build.rs
+++ b/base/build.rs
@@ -17,20 +17,5 @@ fn main() {
         .or_else(|| run_git(&["describe", "--tags", "--dirty", "--always"]))
         .unwrap_or_else(|| "unknown".into());
 
-    let commit = run_git(&["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".into());
-    let branch =
-        run_git(&["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|| "unknown".into());
-
-    let dirty = run_git(&["status", "--porcelain"])
-        .map(|s| if s.is_empty() { "false" } else { "true" })
-        .unwrap_or("unknown");
-
-    let build_time = {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        secs.to_string()
-    };
+    println!("cargo:rustc-env=GIT_VERSION={}", version);
 }

--- a/base/build.rs
+++ b/base/build.rs
@@ -1,3 +1,5 @@
+// At build time, we grab the release version from the git tag.
+// This is used by INFO("release")
 use std::process::Command;
 
 fn run_git(args: &[&str]) -> Option<String> {

--- a/base/build.rs
+++ b/base/build.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+
+fn run_git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs");
+
+    // Prefer exact tag
+    let version = run_git(&["describe", "--tags", "--exact-match"])
+        .or_else(|| run_git(&["describe", "--tags", "--dirty", "--always"]))
+        .unwrap_or_else(|| "unknown".into());
+
+    let commit = run_git(&["rev-parse", "HEAD"]).unwrap_or_else(|| "unknown".into());
+    let branch =
+        run_git(&["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|| "unknown".into());
+
+    let dirty = run_git(&["status", "--porcelain"])
+        .map(|s| if s.is_empty() { "false" } else { "true" })
+        .unwrap_or("unknown");
+
+    let build_time = {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        secs.to_string()
+    };
+}

--- a/base/src/functions/information.rs
+++ b/base/src/functions/information.rs
@@ -4,6 +4,16 @@ use crate::{
     model::{Model, ParsedDefinedName},
 };
 
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_system() -> String {
+    std::env::consts::OS.to_string()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn get_system() -> String {
+    "browser".to_string()
+}
+
 impl<'a> Model<'a> {
     pub(crate) fn fn_isnumber(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
         if args.len() == 1 {
@@ -371,7 +381,7 @@ impl<'a> Model<'a> {
         CalcResult::Number(sheet_count)
     }
 
-    /// INFO(info_type, [reference])
+    /// CELL(info_type, [reference])
     /// NB: In Excel "info_type" is localized. Here it is always in English.
     pub(crate) fn fn_cell(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
         let arg_count = args.len();
@@ -456,14 +466,36 @@ impl<'a> Model<'a> {
         }
     }
 
+    /// INFO(text_type)
+    /// NB: In Excel "text_type" is localized. Here it is always in English.
     pub(crate) fn fn_info(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
-        if args.is_empty() || args.len() > 2 {
+        if args.len() != 1 {
             return CalcResult::new_args_number_error(cell);
         }
-        CalcResult::Error {
-            error: Error::NIMPL,
-            origin: cell,
-            message: "Info function not implemented".to_string(),
+        let type_text = match self.get_string(&args[0], cell) {
+            Ok(s) => s.to_uppercase(),
+            Err(e) => return e,
+        };
+        let release = env!("GIT_VERSION");
+        match type_text.as_str() {
+            "DIRECTORY" | "ORIGIN" | "OSVERSION" => CalcResult::Error {
+                error: Error::VALUE,
+                origin: cell,
+                message: "type_text not implemented".to_string(),
+            },
+
+            // For now we just show the count of sheets in the current workbook
+            "NUMFILE" => CalcResult::Number(self.workbook.worksheets.len() as f64),
+
+            // At the moment we always do automatic recalc
+            "RECALC" => CalcResult::String("Automatic".to_string()),
+            "RELEASE" => CalcResult::String(release.to_string()),
+            "SYSTEM" => CalcResult::String(Self::get_system().to_string()),
+            _ => CalcResult::Error {
+                error: Error::VALUE,
+                origin: cell,
+                message: "Invalid type_text".to_string(),
+            },
         }
     }
 }

--- a/base/src/functions/information.rs
+++ b/base/src/functions/information.rs
@@ -476,10 +476,12 @@ impl<'a> Model<'a> {
             Ok(s) => s.to_uppercase(),
             Err(e) => return e,
         };
+        // We take the release version from the git tag at build time.
+        // See build.rs
         let release = env!("GIT_VERSION");
         match type_text.as_str() {
             "DIRECTORY" | "ORIGIN" | "OSVERSION" => CalcResult::Error {
-                error: Error::VALUE,
+                error: Error::NIMPL,
                 origin: cell,
                 message: "type_text not implemented".to_string(),
             },

--- a/base/src/functions/information.rs
+++ b/base/src/functions/information.rs
@@ -5,12 +5,12 @@ use crate::{
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn get_system() -> String {
+fn get_system() -> String {
     std::env::consts::OS.to_string()
 }
 
 #[cfg(target_arch = "wasm32")]
-pub fn get_system() -> String {
+fn get_system() -> String {
     "browser".to_string()
 }
 
@@ -490,7 +490,7 @@ impl<'a> Model<'a> {
             // At the moment we always do automatic recalc
             "RECALC" => CalcResult::String("Automatic".to_string()),
             "RELEASE" => CalcResult::String(release.to_string()),
-            "SYSTEM" => CalcResult::String(Self::get_system().to_string()),
+            "SYSTEM" => CalcResult::String(get_system()),
             _ => CalcResult::Error {
                 error: Error::VALUE,
                 origin: cell,

--- a/base/src/test/test_cell_info_n_sheets.rs
+++ b/base/src/test/test_cell_info_n_sheets.rs
@@ -8,7 +8,7 @@ fn arguments() {
     model._set("A1", "=CELL(\"address\",A1)");
     model._set("A2", "=CELL()");
 
-    model._set("A3", "=INFO(\"system\")");
+    model._set("A3", "=INFO(\"recalc\")");
     model._set("A4", "=INFO()");
 
     model._set("A5", "=N(TRUE)");
@@ -23,7 +23,7 @@ fn arguments() {
     assert_eq!(model._get_text("A1"), *"$A$1");
     assert_eq!(model._get_text("A2"), *"#ERROR!");
 
-    assert_eq!(model._get_text("A3"), *"#N/IMPL!");
+    assert_eq!(model._get_text("A3"), *"Automatic");
     assert_eq!(model._get_text("A4"), *"#ERROR!");
 
     assert_eq!(model._get_text("A5"), *"1");


### PR DESCRIPTION
### Summary
This PR implements the INFO function and introduces a build.rs script that embeds version/build metadata at compile time. Previously INFO was not implemented and just returned `#NIMPL!` for all arguments.

### Changes
`build.rs` (new file)
A Cargo build script that determines the version string at compile time and exposes it as the GIT_VERSION environment variable. The version is found by running `git describe` in two passes:
- Exact tag (`git describe --tags --exact-match`). Succeeds when the current commit is directly tagged (e.g. _v0.7.1_).
- Dirty/always fallback (`git describe --tags --dirty --always`). Produces a string like _v0.7.1-15-g0703e60_ including version tag, number of commits ahead and commit id or _v0.7.1-15-g0703e60-dirty_ when there are uncommitted changes.
- If git is unavailable, the value falls back to "unknown".

`base/src/functions/information.rs`
type_text | Description
-- | --
"RELEASE" | Git-derived version string from env!("GIT_VERSION")
"SYSTEM" | Output of `std::env::consts::OS` on native targets or "browser" on WASM. 
"RECALC" | "Automatic" As of now, IronCalc always recalculates automatically
"NUMFILE" | Count of worksheets in the current workbook (similarly to SHEETS function)
"DIRECTORY", "ORIGIN", "OSVERSION" | #VALUE! (not yet implemented)

`base/src/test/test_cell_info_n_sheets.rs`
The test for INFO("recalc") previously expected #NIMPL!. It now asserts the correct return value "Automatic".

