### PR TITLE
update: allow confirm via `enter` in `Alert` and `Confirm` modals

### DIFF
--- a/webapp/IronCalc/src/components/Modal/Alert.tsx
+++ b/webapp/IronCalc/src/components/Modal/Alert.tsx
@@ -39,7 +39,6 @@ export function Alert({
     focusableElements: [closeButtonRef, confirmButtonRef],
     onClose: closeModal,
     onConfirm: closeModal,
-    enterConfirm: true,
   });
 
   if (!open) {
@@ -71,7 +70,12 @@ export function Alert({
           {typeof message === "string" ? <p>{message}</p> : message}
         </div>
         <div className="ic-modal-dialog-footer">
-          <Button ref={confirmButtonRef} size="md" onClick={closeModal}>
+          <Button
+            ref={confirmButtonRef}
+            size="md"
+            onClick={closeModal}
+            autoFocus
+          >
             {confirmLabel}
           </Button>
         </div>

--- a/webapp/IronCalc/src/components/Modal/Alert.tsx
+++ b/webapp/IronCalc/src/components/Modal/Alert.tsx
@@ -39,6 +39,7 @@ export function Alert({
     focusableElements: [closeButtonRef, confirmButtonRef],
     onClose: closeModal,
     onConfirm: closeModal,
+    enterConfirm: true,
   });
 
   if (!open) {

--- a/webapp/IronCalc/src/components/Modal/Confirm.tsx
+++ b/webapp/IronCalc/src/components/Modal/Confirm.tsx
@@ -50,7 +50,6 @@ export function Confirm({
     focusableElements: [closeButtonRef, confirmButtonRef],
     onClose: closeModal,
     onConfirm: handleConfirm,
-    enterConfirm: true,
   });
 
   if (!open) {
@@ -88,6 +87,7 @@ export function Confirm({
           <Button
             ref={confirmButtonRef}
             size="md"
+            autoFocus
             variant={variant === "destructive" ? "destructive" : undefined}
             onClick={handleConfirm}
           >

--- a/webapp/IronCalc/src/components/Modal/Confirm.tsx
+++ b/webapp/IronCalc/src/components/Modal/Confirm.tsx
@@ -50,6 +50,7 @@ export function Confirm({
     focusableElements: [closeButtonRef, confirmButtonRef],
     onClose: closeModal,
     onConfirm: handleConfirm,
+    enterConfirm: true,
   });
 
   if (!open) {

--- a/webapp/IronCalc/src/components/Modal/useModalFocus.ts
+++ b/webapp/IronCalc/src/components/Modal/useModalFocus.ts
@@ -17,7 +17,9 @@ export function useModalFocus(open: boolean) {
     previousFocusRef.current = document.activeElement as HTMLElement | null;
 
     requestAnimationFrame(() => {
-      modalRef.current?.focus();
+      if (!modalRef.current?.contains(document.activeElement)) {
+        modalRef.current?.focus();
+      }
     });
   }, [open]);
 

--- a/webapp/IronCalc/src/components/Modal/useModalKeyDown.ts
+++ b/webapp/IronCalc/src/components/Modal/useModalKeyDown.ts
@@ -4,14 +4,12 @@ interface Options {
   focusableElements: RefObject<HTMLElement | null>[];
   onClose: () => void;
   onConfirm?: () => void;
-  enterConfirm?: boolean;
 }
 
 export function useModalKeyDown({
   focusableElements,
   onClose,
   onConfirm,
-  enterConfirm,
 }: Options) {
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {
@@ -21,10 +19,7 @@ export function useModalKeyDown({
         return;
       }
 
-      if (
-        event.key === "Enter" &&
-        (event.metaKey || event.ctrlKey || enterConfirm)
-      ) {
+      if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
         onConfirm?.();
         return;
@@ -48,7 +43,7 @@ export function useModalKeyDown({
         }
       }
     },
-    [focusableElements, onClose, onConfirm, enterConfirm],
+    [focusableElements, onClose, onConfirm],
   );
 
   return { onKeyDown };

--- a/webapp/IronCalc/src/components/Modal/useModalKeyDown.ts
+++ b/webapp/IronCalc/src/components/Modal/useModalKeyDown.ts
@@ -4,12 +4,14 @@ interface Options {
   focusableElements: RefObject<HTMLElement | null>[];
   onClose: () => void;
   onConfirm?: () => void;
+  enterConfirm?: boolean;
 }
 
 export function useModalKeyDown({
   focusableElements,
   onClose,
   onConfirm,
+  enterConfirm,
 }: Options) {
   const onKeyDown = useCallback(
     (event: KeyboardEvent) => {
@@ -19,7 +21,10 @@ export function useModalKeyDown({
         return;
       }
 
-      if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      if (
+        event.key === "Enter" &&
+        (event.metaKey || event.ctrlKey || enterConfirm)
+      ) {
         event.preventDefault();
         onConfirm?.();
         return;
@@ -43,7 +48,7 @@ export function useModalKeyDown({
         }
       }
     },
-    [focusableElements, onClose, onConfirm],
+    [focusableElements, onClose, onConfirm, enterConfirm],
   );
 
   return { onKeyDown };


### PR DESCRIPTION
This PR should fix the issue that prevented `Alert` and `Confirm` modals from being closed when pressing the `Enter` key.