### PR TITLE
update: adds unit testing for GCD, LCM

### DIFF
--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -39,6 +39,7 @@ mod test_fn_textjoin;
 mod test_fn_time;
 mod test_fn_unicode;
 mod test_frozen_rows_columns;
+mod test_gcd_lcm;
 mod test_general;
 mod test_inverted_ranges;
 mod test_issue_623;

--- a/base/src/test/test_gcd_lcm.rs
+++ b/base/src/test/test_gcd_lcm.rs
@@ -1,0 +1,32 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+#[test]
+fn arguments() {
+    let mut model = new_empty_model();
+    model._set("A1", "=LCM()");
+    model._set("A2", "=LCM(2, 3)");
+
+    model._set("A3", "=GCD()");
+    model._set("A4", "=GCD(10, 25)");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"#ERROR!");
+    assert_eq!(model._get_text("A2"), *"6");
+    assert_eq!(model._get_text("A3"), *"#ERROR!");
+    assert_eq!(model._get_text("A4"), *"5");
+}
+
+#[test]
+fn arrays() {
+    let mut model = new_empty_model();
+    model._set("A1", "=LCM({2, 3}, {4, 5, 6})");
+    model._set("A2", "=GCD({10, 25}, {35, 40, 50})");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"60");
+    assert_eq!(model._get_text("A2"), *"5");
+}


### PR DESCRIPTION
This PR adds argument testing for GCD and LCM functions, basically testing that passing no arguments to the functions returns an `#ERROR!`. It also includes a few array smoke tests to check that the functions accept them as arguments.

A full xlsx test with many more test cases can be found in #757 