### PR TITLE
fix: improve keyboard navigation in `Prompt`

### DIFF
--- a/webapp/IronCalc/src/components/Modal/Prompt.tsx
+++ b/webapp/IronCalc/src/components/Modal/Prompt.tsx
@@ -93,6 +93,7 @@ export function Prompt({
           {message &&
             (typeof message === "string" ? <p>{message}</p> : message)}
           <Input
+            autoFocus
             {...inputProps}
             value={value}
             onChange={(event) => setValue(event.target.value)}
@@ -101,12 +102,9 @@ export function Prompt({
               if (event.key === "Escape") {
                 event.preventDefault();
                 closeModal();
-              } else if (
-                event.key === "Enter" &&
-                (event.metaKey || event.ctrlKey)
-              ) {
+              } else if (event.key === "Enter") {
                 event.preventDefault();
-                handleSubmit();
+                submitButtonRef.current?.focus();
               }
               inputProps?.onKeyDown?.(event);
             }}


### PR DESCRIPTION
We had in issue in which it wasn't possible to quickly close prompt modals when hitting the `Enter` key. This was possible by pressing `cmd/ctrl+enter` but this is not discoverable enough.

Now, when opening a prompt modal, we autofocus on the input and, after hitting `Enter`, we switch the focus to the Confirmation button, which triggers on `Enter`.