### PR TITLE
FIX: Uses regex-lite in the wasm build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,3 @@ exclude = [
 
 [profile.release]
 lto = true
-panic = "abort"
-opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ exclude = [
 
 [profile.release]
 lto = true
+panic = "abort"
+opt-level = "z"

--- a/base/src/expressions/parser/static_analysis.rs
+++ b/base/src/expressions/parser/static_analysis.rs
@@ -2,6 +2,9 @@ use crate::functions::Function;
 
 use super::Node;
 
+#[cfg(feature = "use_regex_lite")]
+use regex_lite as regex;
+
 use regex::Regex;
 use std::sync::OnceLock;
 

--- a/bindings/wasm/.cargo/config.toml
+++ b/bindings/wasm/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "panic=abort", "-C", "opt-level=z", "-C", "codegen-units=1"]

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 # Uses `../ironcalc/base` when used locally, and uses
 # the inicated version from crates.io when published.
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
-ironcalc_base = { path = "../../base", version = "0.7", features = ["use_regex_lite"] }
+ironcalc_base = { path = "../../base", version = "0.7", default-features = false, features = ["use_regex_lite"] }
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = "0.2.100"
 serde-wasm-bindgen = "0.4"


### PR DESCRIPTION
This alone reduces the size of the binary in 1Mb

We also use "panic"="abort", which removes a lot of unused code and a more aggressive optimization.
Those two reduce the size further 700 or 800kb

Altogether we are now in 2.3Mb

Also on my slow computer make now goes from ~ 2 minutes to 45 seconds