### PR TITLE
UPDATE: Use the browser's tz database in the wasm build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,7 @@ dependencies = [
  "serde",
  "serde_json",
  "statrs",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -11,28 +11,24 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 ryu = "1.0"
 chrono = "0.4"
-chrono-tz = "0.10"
-regex = { version = "1.0", optional = true}
-regex-lite = { version = "0.1.6", optional = true}
 bitcode = "0.6.8"
 csv = "1.3.0"
 statrs = { version = "0.18.0", default-features = false, features = [] }
-
-[features]
-default = ["use_regex_full"]
-use_regex_full = ["regex"]
-use_regex_lite = ["regex-lite"]
 
 [dev-dependencies]
 serde_json = "1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { version = "0.3.69" }
+wasm-bindgen = { version = "0.2" }
+regex-lite = { version = "0.1.6" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rand = "0.8.5"
+chrono-tz = "0.10"
+regex = "1.0"
 
 

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 ryu = "1.0"
 chrono = "0.4"
 bitcode = "0.6.8"

--- a/base/src/expressions/parser/static_analysis.rs
+++ b/base/src/expressions/parser/static_analysis.rs
@@ -2,7 +2,7 @@ use crate::functions::Function;
 
 use super::Node;
 
-#[cfg(feature = "use_regex_lite")]
+#[cfg(target_arch = "wasm32")]
 use regex_lite as regex;
 
 use regex::Regex;

--- a/base/src/functions/date_and_time.rs
+++ b/base/src/functions/date_and_time.rs
@@ -1,10 +1,10 @@
+use crate::tz::Tz;
 use chrono::DateTime;
 use chrono::Datelike;
 use chrono::Months;
 use chrono::NaiveDateTime;
 use chrono::NaiveTime;
 use chrono::Timelike;
-use chrono_tz::Tz;
 
 const SECONDS_PER_DAY: i32 = 86_400;
 const SECONDS_PER_DAY_F64: f64 = SECONDS_PER_DAY as f64;
@@ -86,7 +86,6 @@ use crate::expressions::types::CellReferenceIndex;
 use crate::formatter::dates::date_to_serial_number;
 use crate::formatter::dates::permissive_date_to_serial_number;
 use crate::formatter::dates::DATE_OUT_OF_RANGE_MESSAGE;
-use crate::model::get_milliseconds_since_epoch;
 use crate::number_format::to_precision;
 use crate::{
     calc_result::CalcResult,
@@ -779,18 +778,6 @@ impl<'a> Model<'a> {
         Ok(values)
     }
 
-    // Returns the current date/time as an Excel serial number in the given timezone.
-    // Used by TODAY() and NOW().
-    pub(crate) fn current_excel_serial_with_timezone(&self, tz: Tz) -> Option<f64> {
-        let seconds = get_milliseconds_since_epoch() / 1000;
-        DateTime::from_timestamp(seconds, 0).map(|dt| {
-            let local_time = dt.with_timezone(&tz);
-            let days_from_1900 = local_time.num_days_from_ce() - EXCEL_DATE_BASE;
-            let fraction = (local_time.num_seconds_from_midnight() as f64) / (60.0 * 60.0 * 24.0);
-            days_from_1900 as f64 + fraction
-        })
-    }
-
     pub(crate) fn fn_networkdays(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
         if !(2..=3).contains(&args.len()) {
             return CalcResult::new_args_number_error(cell);
@@ -987,7 +974,7 @@ impl<'a> Model<'a> {
                 message: "Wrong number of arguments".to_string(),
             };
         }
-        match self.current_excel_serial_with_timezone(self.tz) {
+        match crate::tz::excel_serial_for_now(&self.tz) {
             Some(serial) => CalcResult::Number(serial.floor()),
             None => CalcResult::Error {
                 error: Error::ERROR,
@@ -1005,14 +992,14 @@ impl<'a> Model<'a> {
                 message: "Wrong number of arguments".to_string(),
             };
         }
-        let tz = match args.first() {
+        let tz_owned;
+        let tz: &Tz = match args.first() {
             Some(arg0) => {
-                // Parse timezone argument
                 let tz_str = match self.get_string(arg0, cell) {
                     Ok(s) => s,
                     Err(e) => return e,
                 };
-                let tz: Tz = match tz_str.parse() {
+                tz_owned = match Tz::parse(&tz_str) {
                     Ok(tz) => tz,
                     Err(_) => {
                         return CalcResult::Error {
@@ -1022,11 +1009,11 @@ impl<'a> Model<'a> {
                         }
                     }
                 };
-                tz
+                &tz_owned
             }
-            None => self.tz,
+            None => &self.tz,
         };
-        match self.current_excel_serial_with_timezone(tz) {
+        match crate::tz::excel_serial_for_now(tz) {
             Some(serial) => CalcResult::Number(serial),
             None => CalcResult::Error {
                 error: Error::ERROR,

--- a/base/src/functions/util.rs
+++ b/base/src/functions/util.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "use_regex_lite")]
+#[cfg(target_arch = "wasm32")]
 use regex_lite as regex;
 
 use crate::{

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -46,6 +46,7 @@ mod functions;
 mod implicit_intersection;
 mod model;
 mod styles;
+mod tz;
 mod units;
 mod user_model;
 mod utils;

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1413,8 +1413,7 @@ impl<'a> Model<'a> {
         let cells = HashMap::new();
         let locale =
             get_locale(&workbook.settings.locale).map_err(|_| "Invalid locale".to_string())?;
-        let tz = Tz::parse(&workbook.settings.tz)
-            .map_err(|_| format!("Invalid timezone: {}", workbook.settings.tz))?;
+        let tz = Tz::parse(&workbook.settings.tz)?;
 
         let language = match get_language(language_id) {
             Ok(lang) => lang,

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -31,7 +31,7 @@ use crate::{
     utils as common,
 };
 
-use chrono_tz::Tz;
+use crate::tz::Tz;
 
 #[cfg(test)]
 pub use crate::mock_time::get_milliseconds_since_epoch;
@@ -1413,10 +1413,7 @@ impl<'a> Model<'a> {
         let cells = HashMap::new();
         let locale =
             get_locale(&workbook.settings.locale).map_err(|_| "Invalid locale".to_string())?;
-        let tz: Tz = workbook
-            .settings
-            .tz
-            .parse()
+        let tz = Tz::parse(&workbook.settings.tz)
             .map_err(|_| format!("Invalid timezone: {}", workbook.settings.tz))?;
 
         let language = match get_language(language_id) {
@@ -3353,8 +3350,8 @@ impl<'a> Model<'a> {
 
     /// Sets the timezone of the model
     pub fn set_timezone(&mut self, timezone: &str) -> Result<(), String> {
-        let tz: Tz = match &timezone.parse() {
-            Ok(tz) => *tz,
+        let tz = match Tz::parse(timezone) {
+            Ok(tz) => tz,
             Err(_) => return Err(format!("Invalid timezone: {}", &timezone)),
         };
         self.tz = tz;

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -24,7 +24,7 @@ use crate::{
     utils::ParsedReference,
 };
 
-use chrono_tz::Tz;
+use crate::tz::Tz;
 
 pub const APPLICATION: &str = "IronCalc Sheets";
 pub const APP_VERSION: &str = "10.0000";
@@ -410,8 +410,8 @@ impl<'a> Model<'a> {
         timezone: &'a str,
         language_id: &'a str,
     ) -> Result<Model<'a>, String> {
-        let tz: Tz = match &timezone.parse() {
-            Ok(tz) => *tz,
+        let tz = match Tz::parse(timezone) {
+            Ok(tz) => tz,
             Err(_) => return Err(format!("Invalid timezone: {}", &timezone)),
         };
         let locale = match get_locale(locale_id) {

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -412,7 +412,7 @@ impl<'a> Model<'a> {
     ) -> Result<Model<'a>, String> {
         let tz = match Tz::parse(timezone) {
             Ok(tz) => tz,
-            Err(_) => return Err(format!("Invalid timezone: {}", &timezone)),
+            Err(e) => return Err(e),
         };
         let locale = match get_locale(locale_id) {
             Ok(l) => l,

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -410,10 +410,7 @@ impl<'a> Model<'a> {
         timezone: &'a str,
         language_id: &'a str,
     ) -> Result<Model<'a>, String> {
-        let tz = match Tz::parse(timezone) {
-            Ok(tz) => tz,
-            Err(e) => return Err(e),
-        };
+        let tz = Tz::parse(timezone)?;
         let locale = match get_locale(locale_id) {
             Ok(l) => l,
             Err(_) => return Err(format!("Invalid locale: {locale_id}")),

--- a/base/src/tz/browser_tz.rs
+++ b/base/src/tz/browser_tz.rs
@@ -3,8 +3,6 @@ use crate::constants::EXCEL_DATE_BASE;
 #[derive(Clone)]
 pub(crate) struct Tz(String);
 
-
-
 mod js {
     use wasm_bindgen::prelude::*;
 

--- a/base/src/tz/browser_tz.rs
+++ b/base/src/tz/browser_tz.rs
@@ -1,31 +1,54 @@
 use crate::constants::EXCEL_DATE_BASE;
 
+#[derive(Clone)]
 pub(crate) struct Tz(String);
 
-impl Clone for Tz {
-    fn clone(&self) -> Self {
-        Tz(self.0.clone())
-    }
-}
+
 
 mod js {
     use wasm_bindgen::prelude::*;
 
+    // Weirdly enough Intl.supportedValuesOf('timeZone') doesn't include "UTC" or "GMT"
+    // but Intl.DateTimeFormat does support them, so we add them manually.
     #[wasm_bindgen(inline_js = r#"
+        const _fmtCache = new Map();
+        function getFormatter(tz) {
+            let f = _fmtCache.get(tz);
+            if (!f) {
+                f = new Intl.DateTimeFormat('en-US', {
+                    timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
+                    hour: '2-digit', minute: '2-digit', second: '2-digit', hourCycle: 'h23'
+                });
+                _fmtCache.set(tz, f);
+            }
+            return f;
+        }
         export function ic_tz_validate(name) {
-            try { new Intl.DateTimeFormat(undefined, {timeZone: name}); return true; }
+            try { getFormatter(name); return true; }
             catch(_) { return false; }
         }
         export function ic_tz_all() {
-            try { return Intl.supportedValuesOf('timeZone'); }
-            catch(_) { return []; }
+            try {
+                const list = Intl.supportedValuesOf('timeZone');
+
+                const zones = new Set(list);
+
+                const extras = [ 'UTC', 'GMT' ];
+
+                for (const tz of extras) {
+                    zones.add(tz);
+                }
+
+                return Array.from(zones);
+            } catch(e) {
+                // no support
+                console.log(e);
+                return [ ];
+            }
         }
         export function ic_tz_parts(ms, tz) {
             const p = {};
-            for (const x of new Intl.DateTimeFormat('en-US', {
-                timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
-                hour: '2-digit', minute: '2-digit', second: '2-digit', hourCycle: 'h23'
-            }).formatToParts(new Date(ms))) p[x.type] = x.value | 0;
+            for (const x of getFormatter(tz).formatToParts(new Date(ms))) p[x.type] = x.value | 0;
             return [p.year, p.month, p.day, p.hour, p.minute, p.second];
         }
     "#)]
@@ -56,8 +79,12 @@ pub fn get_all_timezone_names() -> Vec<String> {
 pub(crate) fn excel_serial_for_now(tz: &Tz) -> Option<f64> {
     let ms = crate::model::get_milliseconds_since_epoch();
     let parts = js::ic_tz_parts(ms as f64, &tz.0);
+    if parts.length() != 6 {
+        return None;
+    }
 
     let get = |i: u32| parts.get(i).as_f64().unwrap_or(0.0) as i32;
+    // TODO: handle invalid dates
     let (year, month, day) = (get(0), get(1), get(2));
     let (hour, minute, second) = (get(3), get(4), get(5));
 

--- a/base/src/tz/browser_tz.rs
+++ b/base/src/tz/browser_tz.rs
@@ -1,0 +1,76 @@
+use crate::constants::EXCEL_DATE_BASE;
+
+pub(crate) struct Tz(String);
+
+impl Clone for Tz {
+    fn clone(&self) -> Self {
+        Tz(self.0.clone())
+    }
+}
+
+mod js {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen(inline_js = r#"
+        export function ic_tz_validate(name) {
+            try { new Intl.DateTimeFormat(undefined, {timeZone: name}); return true; }
+            catch(_) { return false; }
+        }
+        export function ic_tz_all() {
+            try { return Intl.supportedValuesOf('timeZone'); }
+            catch(_) { return []; }
+        }
+        export function ic_tz_parts(ms, tz) {
+            const p = {};
+            for (const x of new Intl.DateTimeFormat('en-US', {
+                timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
+                hour: '2-digit', minute: '2-digit', second: '2-digit', hourCycle: 'h23'
+            }).formatToParts(new Date(ms))) p[x.type] = x.value | 0;
+            return [p.year, p.month, p.day, p.hour, p.minute, p.second];
+        }
+    "#)]
+    extern "C" {
+        pub fn ic_tz_validate(name: &str) -> bool;
+        pub fn ic_tz_all() -> js_sys::Array;
+        pub fn ic_tz_parts(ms: f64, tz: &str) -> js_sys::Array;
+    }
+}
+
+impl Tz {
+    pub(crate) fn parse(s: &str) -> Result<Tz, String> {
+        if js::ic_tz_validate(s) {
+            Ok(Tz(s.to_string()))
+        } else {
+            Err(format!("Invalid timezone: {s}"))
+        }
+    }
+}
+
+pub fn get_all_timezone_names() -> Vec<String> {
+    js::ic_tz_all()
+        .iter()
+        .filter_map(|v| v.as_string())
+        .collect()
+}
+
+pub(crate) fn excel_serial_for_now(tz: &Tz) -> Option<f64> {
+    let ms = crate::model::get_milliseconds_since_epoch();
+    let parts = js::ic_tz_parts(ms as f64, &tz.0);
+
+    let get = |i: u32| parts.get(i).as_f64().unwrap_or(0.0) as i32;
+    let (year, month, day) = (get(0), get(1), get(2));
+    let (hour, minute, second) = (get(3), get(4), get(5));
+
+    let y = year - 1;
+    let n = 365 * y + y / 4 - y / 100 + y / 400;
+    let month_starts: [i32; 12] = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    let leap = if month > 2 && year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) {
+        1
+    } else {
+        0
+    };
+    let days_from_ce = n + month_starts[(month - 1) as usize] + leap + day;
+    let secs = hour * 3600 + minute * 60 + second;
+
+    Some((days_from_ce - EXCEL_DATE_BASE) as f64 + secs as f64 / 86400.0)
+}

--- a/base/src/tz/mod.rs
+++ b/base/src/tz/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(target_arch = "wasm32")]
 mod browser_tz;
 #[cfg(target_arch = "wasm32")]
-pub use browser_tz::*;
+pub(crate) use browser_tz::*;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod os_tz;
 #[cfg(not(target_arch = "wasm32"))]
-pub use os_tz::*;
+pub(crate) use os_tz::*;

--- a/base/src/tz/mod.rs
+++ b/base/src/tz/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(target_arch = "wasm32")]
+mod browser_tz;
+#[cfg(target_arch = "wasm32")]
+pub use browser_tz::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod os_tz;
+#[cfg(not(target_arch = "wasm32"))]
+pub use os_tz::*;

--- a/base/src/tz/os_tz.rs
+++ b/base/src/tz/os_tz.rs
@@ -1,12 +1,7 @@
 use crate::constants::EXCEL_DATE_BASE;
 
+#[derive(Clone)]
 pub(crate) struct Tz(chrono_tz::Tz);
-
-impl Clone for Tz {
-    fn clone(&self) -> Self {
-        Tz(self.0)
-    }
-}
 
 impl Tz {
     pub(crate) fn parse(s: &str) -> Result<Tz, String> {

--- a/base/src/tz/os_tz.rs
+++ b/base/src/tz/os_tz.rs
@@ -1,0 +1,35 @@
+use crate::constants::EXCEL_DATE_BASE;
+
+pub(crate) struct Tz(chrono_tz::Tz);
+
+impl Clone for Tz {
+    fn clone(&self) -> Self {
+        Tz(self.0)
+    }
+}
+
+impl Tz {
+    pub(crate) fn parse(s: &str) -> Result<Tz, String> {
+        s.parse::<chrono_tz::Tz>()
+            .map(Tz)
+            .map_err(|_| format!("Invalid timezone: {s}"))
+    }
+}
+
+pub fn get_all_timezone_names() -> Vec<String> {
+    chrono_tz::TZ_VARIANTS
+        .iter()
+        .map(|t| t.name().to_string())
+        .collect()
+}
+
+pub(crate) fn excel_serial_for_now(tz: &Tz) -> Option<f64> {
+    use chrono::{DateTime, Datelike, Timelike};
+    let seconds = crate::model::get_milliseconds_since_epoch() / 1000;
+    DateTime::from_timestamp(seconds, 0).map(|dt| {
+        let local = dt.with_timezone(&tz.0);
+        let days = local.num_days_from_ce() - EXCEL_DATE_BASE;
+        let fraction = local.num_seconds_from_midnight() as f64 / (60.0 * 60.0 * 24.0);
+        days as f64 + fraction
+    })
+}

--- a/base/src/utils.rs
+++ b/base/src/utils.rs
@@ -135,10 +135,7 @@ pub(crate) fn value_needs_quoting(value: &str, language: &Language) -> bool {
 
 /// Gets all timezones
 pub fn get_all_timezones() -> Vec<String> {
-    chrono_tz::TZ_VARIANTS
-        .iter()
-        .map(|tz| tz.name().to_string())
-        .collect()
+    crate::tz::get_all_timezone_names()
 }
 
 /// Valid hex colors are #FFAABB

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 # Uses `../ironcalc/base` when used locally, and uses
 # the inicated version from crates.io when published.
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
-ironcalc_base = { path = "../../base", version = "0.7", default-features = false, features = ["use_regex_lite"] }
+ironcalc_base = { path = "../../base", version = "0.7" }
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = "0.2.100"
 serde-wasm-bindgen = "0.4"


### PR DESCRIPTION
This is great but leaves a part of the code untested. In practical terms in NOW works, then everything should be ok...

The size of the binary is now 1.4Mb