### PR TITLE
update[app]: remove MUI from FileBar

### DIFF
--- a/webapp/IronCalc/src/index.ts
+++ b/webapp/IronCalc/src/index.ts
@@ -16,7 +16,6 @@ export { Input } from "./components/Input/Input";
 export { useModalFocus } from "./components/Modal/useModalFocus";
 export type { TooltipProperties } from "./components/Tooltip/Tooltip";
 export { Tooltip } from "./components/Tooltip/Tooltip";
-export { useTooltipPosition } from "./components/Tooltip/useTooltipPosition";
 export type { IronCalcHandle } from "./IronCalc";
 export { IronCalc, IronCalcIcon, IronCalcIconWhite, IronCalcLogo, Model };
 

--- a/webapp/IronCalc/src/index.ts
+++ b/webapp/IronCalc/src/index.ts
@@ -9,9 +9,14 @@ export type {
   ButtonVariant,
 } from "./components/Button/Button";
 export { Button } from "./components/Button/Button";
+export type { IconButtonProperties } from "./components/Button/IconButton";
+export { IconButton } from "./components/Button/IconButton";
 export type { InputProperties, InputSize } from "./components/Input/Input";
 export { Input } from "./components/Input/Input";
 export { useModalFocus } from "./components/Modal/useModalFocus";
+export type { TooltipProperties } from "./components/Tooltip/Tooltip";
+export { Tooltip } from "./components/Tooltip/Tooltip";
+export { useTooltipPosition } from "./components/Tooltip/useTooltipPosition";
 export type { IronCalcHandle } from "./IronCalc";
 export { IronCalc, IronCalcIcon, IronCalcIconWhite, IronCalcLogo, Model };
 

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -1,7 +1,6 @@
-import styled from "@emotion/styled";
-import type { Model } from "@ironcalc/workbook";
-import { ClickAwayListener, IconButton, Tooltip } from "@mui/material";
-import { CloudOff, PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { IconButton, type Model, Tooltip } from "@ironcalc/workbook";
+import { ClickAwayListener } from "@mui/material";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MIN_MAIN_CONTENT_WIDTH_FOR_MOBILE } from "../App";
@@ -11,24 +10,14 @@ import { MobileMenu } from "./MobileMenu";
 import { downloadModel } from "./rpc";
 import { ShareButton } from "./ShareWorkbook/ShareButton";
 import ShareWorkbookDialog from "./ShareWorkbook/ShareDialog";
+import { StorageWarning } from "./StorageWarning";
 import { updateNameSelectedWorkbook } from "./storage";
+import { useWindowWidth } from "./useWindowWidth";
 import { WorkbookTitle } from "./WorkbookTitle";
 
-type OpenMenu = "file" | "help" | null;
+import "./file-bar.css";
 
-// This hook is used to get the width of the window
-function useWindowWidth() {
-  const [width, setWidth] = useState(0);
-  useLayoutEffect(() => {
-    function updateWidth() {
-      setWidth(window.innerWidth);
-    }
-    window.addEventListener("resize", updateWidth);
-    updateWidth();
-    return () => window.removeEventListener("resize", updateWidth);
-  }, []);
-  return width;
-}
+type OpenMenu = "file" | "help" | null;
 
 export function FileBar(properties: {
   model: Model;
@@ -48,9 +37,6 @@ export function FileBar(properties: {
   const [maxTitleWidth, setMaxTitleWidth] = useState(0);
   const width = useWindowWidth();
   const { t } = useTranslation();
-  const cloudWarningText1 = `${t("file_bar.title_input.warning_text1")}`;
-  const cloudWarningText2 = `${t("file_bar.title_input.warning_text2")}`;
-
   const handleDownload = async () => {
     const model = properties.model;
     const bytes = model.toBytes();
@@ -59,6 +45,11 @@ export function FileBar(properties: {
   };
 
   const closeMenus = () => setOpenMenu(null);
+  const drawerLabel = t(
+    properties.isDrawerOpen
+      ? "file_bar.close_sidebar"
+      : "file_bar.open_sidebar",
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We need to update the maxTitleWidth when the width changes
   useLayoutEffect(() => {
@@ -72,32 +63,17 @@ export function FileBar(properties: {
   const isMobile = width < MIN_MAIN_CONTENT_WIDTH_FOR_MOBILE;
 
   return (
-    <FileBarWrapper>
-      <Tooltip
-        title={t(
-          properties.isDrawerOpen
-            ? "file_bar.close_sidebar"
-            : "file_bar.open_sidebar",
-        )}
-        slotProps={{
-          popper: {
-            modifiers: [
-              {
-                name: "offset",
-                options: {
-                  offset: [0, -8],
-                },
-              },
-            ],
-          },
-        }}
-      >
-        <DrawerButton
+    <div className="file-bar">
+      <Tooltip title={drawerLabel}>
+        <IconButton
+          icon={
+            properties.isDrawerOpen ? <PanelLeftClose /> : <PanelLeftOpen />
+          }
+          aria-label={drawerLabel}
+          size="md"
+          className="file-bar-drawer-button"
           onClick={() => properties.setIsDrawerOpen(!properties.isDrawerOpen)}
-          disableRipple
-        >
-          {properties.isDrawerOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
-        </DrawerButton>
+        />
       </Tooltip>
       {isMobile ? (
         <MobileMenu
@@ -110,7 +86,7 @@ export function FileBar(properties: {
         />
       ) : (
         <ClickAwayListener onClickAway={closeMenus}>
-          <DesktopMenuWrapper>
+          <div className="file-bar-desktop-menu">
             <FileMenu
               newModel={properties.newModel}
               newModelFromTemplate={properties.newModelFromTemplate}
@@ -130,10 +106,10 @@ export function FileBar(properties: {
               onClose={closeMenus}
               onHover={() => openMenu && setOpenMenu("help")}
             />
-          </DesktopMenuWrapper>
+          </div>
         </ClickAwayListener>
       )}
-      <WorkbookTitleWrapper>
+      <div className="file-bar-title-wrapper">
         <WorkbookTitle
           name={properties.model.getName()}
           onNameChange={(name) => {
@@ -143,54 +119,11 @@ export function FileBar(properties: {
           }}
           maxWidth={maxTitleWidth}
         />
-      </WorkbookTitleWrapper>
-      <Spacer ref={spacerRef} />
-      <RightSideWrapper>
-        <Tooltip
-          title={
-            <div
-              style={{ display: "flex", flexDirection: "column", gap: "4px" }}
-            >
-              <div>{cloudWarningText1}</div>
-              <div style={{ fontWeight: "bold" }}>{cloudWarningText2}</div>
-            </div>
-          }
-          placement="bottom-end"
-          enterTouchDelay={0}
-          enterDelay={500}
-          slotProps={{
-            popper: {
-              modifiers: [
-                {
-                  name: "offset",
-                  options: {
-                    offset: [0, -16],
-                  },
-                },
-              ],
-            },
-            tooltip: {
-              sx: {
-                maxWidth: "240px",
-                fontSize: "11px",
-                padding: "8px",
-                backgroundColor: "#fff",
-                color: "#333333",
-                borderRadius: "8px",
-                border: "1px solid #e0e0e0",
-                boxShadow: "0px 1px 3px 0px #0000001A",
-                fontFamily: "Inter",
-                fontWeight: "400",
-                lineHeight: "16px",
-              },
-            },
-          }}
-        >
-          <CloudButton>
-            <CloudOff />
-          </CloudButton>
-        </Tooltip>
-        <DialogContainer>
+      </div>
+      <div ref={spacerRef} className="file-bar-spacer" />
+      <div className="file-bar-right">
+        <StorageWarning />
+        <div className="file-bar-dialog-container">
           <ShareButton onClick={() => setIsDialogOpen(true)} />
           {isDialogOpen && (
             <ShareWorkbookDialog
@@ -198,99 +131,8 @@ export function FileBar(properties: {
               model={properties.model}
             />
           )}
-        </DialogContainer>
-      </RightSideWrapper>
-    </FileBarWrapper>
+        </div>
+      </div>
+    </div>
   );
 }
-
-// We want the workbook title to be exactly an the center of the page,
-// so we need an absolute position
-const WorkbookTitleWrapper = styled("div")`
-  position: absolute;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 6px;
-  left: 50%;
-  transform: translateX(-50%);
-`;
-
-const CloudButton = styled("div")`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: default;
-  background-color: transparent;
-  border-radius: 6px;
-  padding: 8px;
-  svg {
-    width: 16px;
-    height: 16px;
-    color: #bdbdbd;
-  }
-  &:hover {
-    svg {
-      color: #757575;
-    }
-  }
-`;
-
-// The "Spacer" component occupies as much space as possible between the menu and the share button
-const Spacer = styled("div")`
-  flex-grow: 1;
-`;
-
-// const DrawerButton = styled(IconButton)<{ $isDrawerOpen: boolean }>`
-// cursor: ${(props) => (props.$isDrawerOpen ? "w-resize" : "e-resize")};
-const DrawerButton = styled(IconButton)`
-  margin-left: 8px;
-  height: 32px;
-  width: 32px;
-  padding: 8px;
-  border-radius: 6px;
-
-  svg {
-    stroke-width: 2px;
-    stroke: #757575;
-    width: 16px;
-    height: 16px;
-  }
-  &:hover {
-    background-color: #f2f2f2;
-  }
-  &:active {
-    background-color: #e0e0e0;
-  }
-`;
-
-// The container must be relative positioned so we can position the title absolutely
-const FileBarWrapper = styled("div")`
-  position: relative;
-  height: 60px;
-  min-height: 60px;
-  width: 100%;
-  background: #fff;
-  display: flex;
-  gap: 2px;
-  align-items: center;
-  border-bottom: 1px solid #e0e0e0;
-  justify-content: space-between;
-`;
-
-const RightSideWrapper = styled("div")`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
-const DialogContainer = styled("div")`
-  position: relative;
-  display: inline-block;
-`;
-
-const DesktopMenuWrapper = styled("div")`
-  display: flex;
-  align-items: center;
-  gap: 2px;
-`;

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -63,7 +63,7 @@ export function FileBar(properties: {
   const isMobile = width < MIN_MAIN_CONTENT_WIDTH_FOR_MOBILE;
 
   return (
-    <div className="file-bar">
+    <div className="app-ic-file-bar">
       <Tooltip title={drawerLabel}>
         <IconButton
           icon={
@@ -71,7 +71,7 @@ export function FileBar(properties: {
           }
           aria-label={drawerLabel}
           size="md"
-          className="file-bar-drawer-button"
+          className="app-ic-file-bar-drawer-button"
           onClick={() => properties.setIsDrawerOpen(!properties.isDrawerOpen)}
         />
       </Tooltip>
@@ -86,7 +86,7 @@ export function FileBar(properties: {
         />
       ) : (
         <ClickAwayListener onClickAway={closeMenus}>
-          <div className="file-bar-desktop-menu">
+          <div className="app-ic-file-bar-desktop-menu">
             <FileMenu
               newModel={properties.newModel}
               newModelFromTemplate={properties.newModelFromTemplate}
@@ -109,7 +109,7 @@ export function FileBar(properties: {
           </div>
         </ClickAwayListener>
       )}
-      <div className="file-bar-title-wrapper">
+      <div className="app-ic-file-bar-title-wrapper">
         <WorkbookTitle
           name={properties.model.getName()}
           onNameChange={(name) => {
@@ -120,10 +120,10 @@ export function FileBar(properties: {
           maxWidth={maxTitleWidth}
         />
       </div>
-      <div ref={spacerRef} className="file-bar-spacer" />
-      <div className="file-bar-right">
+      <div ref={spacerRef} className="app-ic-file-bar-spacer" />
+      <div className="app-ic-file-bar-right">
         <StorageWarning />
-        <div className="file-bar-dialog-container">
+        <div className="app-ic-file-bar-dialog-container">
           <ShareButton onClick={() => setIsDialogOpen(true)} />
           {isDialogOpen && (
             <ShareWorkbookDialog

--- a/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/share-button.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/share-button.css
@@ -1,7 +1,3 @@
-.share-button {
-  margin-right: 10px;
-}
-
 @media (max-width: 600px) {
   .share-button__text {
     display: none;

--- a/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
@@ -1,14 +1,14 @@
-import { useTooltipPosition } from "@ironcalc/workbook";
 import { CloudOff } from "lucide-react";
 import { type RefObject, useId, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { usePopoverPosition } from "./usePopoverPosition";
 
 export function StorageWarning() {
   const { t } = useTranslation();
-  const tooltipId = useId();
+  const popoverId = useId();
   const [visible, setVisible] = useState(false);
-  const { triggerRef, tooltipRef, position } = useTooltipPosition(visible);
+  const { triggerRef, popoverRef, position } = usePopoverPosition(visible);
 
   return (
     <>
@@ -16,7 +16,7 @@ export function StorageWarning() {
         ref={triggerRef as unknown as RefObject<HTMLButtonElement>}
         type="button"
         className="app-ic-file-bar-cloud-button"
-        aria-describedby={visible ? tooltipId : undefined}
+        aria-describedby={visible ? popoverId : undefined}
         onMouseEnter={() => setVisible(true)}
         onMouseLeave={() => setVisible(false)}
         onFocus={() => setVisible(true)}
@@ -32,8 +32,8 @@ export function StorageWarning() {
       </button>
       {createPortal(
         <div
-          ref={tooltipRef}
-          id={tooltipId}
+          ref={popoverRef}
+          id={popoverId}
           role="tooltip"
           className="app-ic-file-bar-cloud-popover-content"
           data-visible={visible}

--- a/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
@@ -15,7 +15,7 @@ export function StorageWarning() {
       <button
         ref={triggerRef as unknown as RefObject<HTMLButtonElement>}
         type="button"
-        className="file-bar-cloud-button"
+        className="app-ic-file-bar-cloud-button"
         aria-describedby={visible ? tooltipId : undefined}
         onMouseEnter={() => setVisible(true)}
         onMouseLeave={() => setVisible(false)}
@@ -35,7 +35,7 @@ export function StorageWarning() {
           ref={tooltipRef}
           id={tooltipId}
           role="tooltip"
-          className="file-bar-cloud-popover-content"
+          className="app-ic-file-bar-cloud-popover-content"
           data-visible={visible}
           style={position}
         >

--- a/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
@@ -1,0 +1,38 @@
+import { useTooltipPosition } from "@ironcalc/workbook";
+import { CloudOff } from "lucide-react";
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+export function StorageWarning() {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+  const { triggerRef, tooltipRef, position } = useTooltipPosition(visible);
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        role="none"
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+      >
+        <div className="file-bar-cloud-button">
+          <CloudOff />
+        </div>
+      </span>
+      {createPortal(
+        <div
+          ref={tooltipRef}
+          className="file-bar-cloud-popover-content"
+          data-visible={visible}
+          style={position}
+        >
+          {t("file_bar.title_input.warning_text1")}
+          <strong>{t("file_bar.title_input.warning_text2")}</strong>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
@@ -1,29 +1,40 @@
 import { useTooltipPosition } from "@ironcalc/workbook";
 import { CloudOff } from "lucide-react";
-import { useState } from "react";
+import { type RefObject, useId, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 export function StorageWarning() {
   const { t } = useTranslation();
+  const tooltipId = useId();
   const [visible, setVisible] = useState(false);
   const { triggerRef, tooltipRef, position } = useTooltipPosition(visible);
 
   return (
     <>
-      <span
-        ref={triggerRef}
-        role="none"
+      <button
+        ref={triggerRef as unknown as RefObject<HTMLButtonElement>}
+        type="button"
+        className="file-bar-cloud-button"
+        aria-describedby={visible ? tooltipId : undefined}
         onMouseEnter={() => setVisible(true)}
         onMouseLeave={() => setVisible(false)}
+        onFocus={() => setVisible(true)}
+        onBlur={() => setVisible(false)}
+        onPointerDown={(e) => {
+          if (e.pointerType === "touch") {
+            e.preventDefault();
+            setVisible((v) => !v);
+          }
+        }}
       >
-        <div className="file-bar-cloud-button">
-          <CloudOff />
-        </div>
-      </span>
+        <CloudOff />
+      </button>
       {createPortal(
         <div
           ref={tooltipRef}
+          id={tooltipId}
+          role="tooltip"
           className="file-bar-cloud-popover-content"
           data-visible={visible}
           style={position}

--- a/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import {
   type ChangeEvent,
   useEffect,
@@ -7,8 +6,10 @@ import {
   useState,
 } from "react";
 
-// This element has a in situ editable text
-// We use a virtual element to compute the size of the input
+import "./workbook-title.css";
+
+// This element has an in situ editable text.
+// We use a virtual element to compute the size of the input.
 
 export function WorkbookTitle(properties: {
   name: string;
@@ -37,13 +38,12 @@ export function WorkbookTitle(properties: {
     }
   }, [name]);
 
+  const constrainedWidth = Math.min(width, properties.maxWidth);
+
   return (
-    <Container
-      style={{
-        width: Math.min(width, properties.maxWidth),
-      }}
-    >
-      <TitleInput
+    <div className="workbook-title" style={{ width: constrainedWidth }}>
+      <input
+        className="workbook-title-input"
         value={name}
         onChange={handleChange}
         onBlur={(event) => {
@@ -52,67 +52,21 @@ export function WorkbookTitle(properties: {
         onKeyDown={(event) => {
           switch (event.key) {
             case "Enter": {
-              // If we hit "Enter" finish editing
               event.currentTarget.blur();
               break;
             }
             case "Escape": {
-              // revert changes
               setName(properties.name);
               break;
             }
           }
         }}
-        style={{ width: Math.min(width, properties.maxWidth) }}
-        spellCheck="false"
+        style={{ width: constrainedWidth }}
+        spellCheck={false}
       />
-      <MirrorDiv ref={mirrorDivRef}>{name}</MirrorDiv>
-    </Container>
+      <div ref={mirrorDivRef} className="workbook-title-mirror">
+        {name}
+      </div>
+    </div>
   );
 }
-
-const Container = styled("div")`
-  text-align: left;
-  padding: 6px 4px;
-  font-size: 14px;
-  font-weight: 600;
-  font-family: Inter;
-`;
-
-const MirrorDiv = styled("div")`
-  position: absolute;
-  top: -9999px;
-  left: -9999px;
-  white-space: pre-wrap;
-  text-wrap: nowrap;
-  visibility: hidden;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  padding: inherit;
-  border: inherit;
-`;
-
-const TitleInput = styled("input")`
-  vertical-align: middle;
-  text-align: center;
-  height: 20px;
-  line-height: 20px;
-  border-radius: 6px;
-  padding: inherit;
-  outline: none;
-  resize: none;
-  text-wrap: nowrap;
-  border: none;
-  &:hover {
-    background-color: #f2f2f2;
-  }
-  &:focus {
-    outline: 1px solid grey;
-  }
-  font-weight: inherit;
-  font-family: inherit;
-  font-size: inherit;
-  overflow: ellipsis;
-  white-space: nowrap;
-`;

--- a/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WorkbookTitle.tsx
@@ -41,9 +41,9 @@ export function WorkbookTitle(properties: {
   const constrainedWidth = Math.min(width, properties.maxWidth);
 
   return (
-    <div className="workbook-title" style={{ width: constrainedWidth }}>
+    <div className="app-ic-workbook-title" style={{ width: constrainedWidth }}>
       <input
-        className="workbook-title-input"
+        className="app-ic-workbook-title-input"
         value={name}
         onChange={handleChange}
         onBlur={(event) => {
@@ -64,7 +64,7 @@ export function WorkbookTitle(properties: {
         style={{ width: constrainedWidth }}
         spellCheck={false}
       />
-      <div ref={mirrorDivRef} className="workbook-title-mirror">
+      <div ref={mirrorDivRef} className="app-ic-workbook-title-mirror">
         {name}
       </div>
     </div>

--- a/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
@@ -1,4 +1,4 @@
-.file-bar {
+.app-ic-file-bar {
   position: relative;
   height: 52px;
   min-height: 52px;
@@ -11,7 +11,7 @@
   border-bottom: 1px solid var(--palette-grey-300);
 }
 
-.file-bar-title-wrapper {
+.app-ic-file-bar-title-wrapper {
   position: absolute;
   display: flex;
   align-items: center;
@@ -20,27 +20,27 @@
   transform: translateX(-50%);
 }
 
-.file-bar-desktop-menu {
+.app-ic-file-bar-desktop-menu {
   display: flex;
   align-items: center;
   gap: 2px;
 }
 
-.file-bar-spacer {
+.app-ic-file-bar-spacer {
   flex-grow: 1;
 }
 
-.file-bar-right {
+.app-ic-file-bar-right {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.file-bar-drawer-button svg {
+.app-ic-file-bar-drawer-button svg {
   stroke: var(--palette-grey-600);
 }
 
-.file-bar-cloud-popover-content {
+.app-ic-file-bar-cloud-popover-content {
   position: fixed;
   display: flex;
   flex-direction: column;
@@ -62,7 +62,7 @@
     visibility 0s linear 150ms;
 }
 
-.file-bar-cloud-popover-content[data-visible="true"] {
+.app-ic-file-bar-cloud-popover-content[data-visible="true"] {
   opacity: 1;
   visibility: visible;
   transition:
@@ -70,7 +70,7 @@
     visibility 0s;
 }
 
-.file-bar-cloud-button {
+.app-ic-file-bar-cloud-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -81,21 +81,21 @@
   padding: 8px;
 }
 
-.file-bar-cloud-button svg {
+.app-ic-file-bar-cloud-button svg {
   width: 16px;
   height: 16px;
   color: var(--palette-grey-400);
 }
 
-.file-bar-cloud-button:hover {
+.app-ic-file-bar-cloud-button:hover {
   background-color: var(--palette-grey-100);
 }
 
-.file-bar-cloud-button:hover svg {
+.app-ic-file-bar-cloud-button:hover svg {
   color: var(--palette-grey-600);
 }
 
-.file-bar-dialog-container {
+.app-ic-file-bar-dialog-container {
   position: relative;
   display: inline-block;
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
@@ -1,0 +1,99 @@
+.file-bar {
+  position: relative;
+  height: 52px;
+  min-height: 52px;
+  padding: 0 8px;
+  background: var(--palette-common-white);
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--palette-grey-300);
+}
+
+.file-bar-title-wrapper {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.file-bar-desktop-menu {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.file-bar-spacer {
+  flex-grow: 1;
+}
+
+.file-bar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.file-bar-drawer-button svg {
+  stroke: var(--palette-grey-600);
+}
+
+.file-bar-cloud-popover-content {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 240px;
+  background-color: var(--palette-common-white);
+  border: 1px solid var(--palette-grey-300);
+  border-radius: 8px;
+  box-shadow: var(--shadow-sm);
+  padding: 8px;
+  font-family: var(--typography-font-family);
+  font-size: calc(var(--typography-font-size) - 1px);
+  color: var(--palette-grey-900);
+  line-height: 128%;
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 150ms ease-out,
+    visibility 0s linear 150ms;
+}
+
+.file-bar-cloud-popover-content[data-visible="true"] {
+  opacity: 1;
+  visibility: visible;
+  transition:
+    opacity 150ms ease-out,
+    visibility 0s;
+}
+
+.file-bar-cloud-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.file-bar-cloud-button svg {
+  width: 16px;
+  height: 16px;
+  color: var(--palette-grey-400);
+}
+
+.file-bar-cloud-button:hover {
+  background-color: var(--palette-grey-100);
+}
+
+.file-bar-cloud-button:hover svg {
+  color: var(--palette-grey-600);
+}
+
+.file-bar-dialog-container {
+  position: relative;
+  display: inline-block;
+}

--- a/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
@@ -71,10 +71,12 @@
 }
 
 .file-bar-cloud-button {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: default;
+  border: none;
+  background: transparent;
   border-radius: 6px;
   padding: 8px;
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/usePopoverPosition.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/usePopoverPosition.ts
@@ -1,0 +1,62 @@
+import { type CSSProperties, useLayoutEffect, useRef, useState } from "react";
+
+function getPopoverPosition(trigger: HTMLElement, popover: HTMLElement) {
+  const triggerRect = trigger.getBoundingClientRect();
+  const popoverWidth = popover.offsetWidth;
+  const popoverHeight = popover.offsetHeight;
+  const viewportWidth = window.innerWidth;
+
+  const offset = 6;
+  const margin = 8;
+
+  let left = triggerRect.left + triggerRect.width / 2 - popoverWidth / 2;
+
+  let top = triggerRect.top - popoverHeight - offset;
+  if (top < margin) {
+    top = triggerRect.bottom + offset;
+  }
+
+  if (left + popoverWidth > viewportWidth - margin) {
+    left = viewportWidth - popoverWidth - margin;
+  }
+  if (left < margin) {
+    left = margin;
+  }
+
+  return { top, left };
+}
+
+export function usePopoverPosition(visible: boolean) {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<CSSProperties>({});
+
+  useLayoutEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    function updatePosition() {
+      const trigger = triggerRef.current;
+      const popover = popoverRef.current;
+      if (!trigger || !popover) {
+        return;
+      }
+
+      const { top, left } = getPopoverPosition(trigger, popover);
+      setPosition({ top, left });
+    }
+
+    updatePosition();
+
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [visible]);
+
+  return { triggerRef, popoverRef, position };
+}

--- a/webapp/app.ironcalc.com/frontend/src/components/useWindowWidth.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/useWindowWidth.ts
@@ -1,0 +1,14 @@
+import { useLayoutEffect, useState } from "react";
+
+export function useWindowWidth(): number {
+  const [width, setWidth] = useState(0);
+  useLayoutEffect(() => {
+    function updateWidth() {
+      setWidth(window.innerWidth);
+    }
+    window.addEventListener("resize", updateWidth);
+    updateWidth();
+    return () => window.removeEventListener("resize", updateWidth);
+  }, []);
+  return width;
+}

--- a/webapp/app.ironcalc.com/frontend/src/components/workbook-title.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/workbook-title.css
@@ -1,0 +1,43 @@
+.workbook-title {
+  padding: 6px 4px;
+  font-size: calc(var(--typography-font-size) + 2px);
+  font-weight: 600;
+  font-family: var(--typography-font-family);
+}
+
+.workbook-title-input {
+  text-align: center;
+  height: 20px;
+  line-height: 20px;
+  border-radius: 6px;
+  padding: inherit;
+  border: none;
+  outline: none;
+  white-space: nowrap;
+  font-weight: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  background: transparent;
+}
+
+.workbook-title-input:hover {
+  background-color: var(--palette-grey-100);
+}
+
+.workbook-title-input:focus {
+  outline: 1px solid var(--palette-grey-500);
+}
+
+.workbook-title-mirror {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+  white-space: pre-wrap;
+  text-wrap: nowrap;
+  visibility: hidden;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  padding: inherit;
+  border: inherit;
+}

--- a/webapp/app.ironcalc.com/frontend/src/components/workbook-title.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/workbook-title.css
@@ -1,11 +1,11 @@
-.workbook-title {
+.app-ic-workbook-title {
   padding: 6px 4px;
   font-size: calc(var(--typography-font-size) + 2px);
   font-weight: 600;
   font-family: var(--typography-font-family);
 }
 
-.workbook-title-input {
+.app-ic-workbook-title-input {
   text-align: center;
   height: 20px;
   line-height: 20px;
@@ -20,15 +20,15 @@
   background: transparent;
 }
 
-.workbook-title-input:hover {
+.app-ic-workbook-title-input:hover {
   background-color: var(--palette-grey-100);
 }
 
-.workbook-title-input:focus {
+.app-ic-workbook-title-input:focus {
   outline: 1px solid var(--palette-grey-500);
 }
 
-.workbook-title-mirror {
+.app-ic-workbook-title-mirror {
   position: absolute;
   top: -9999px;
   left: -9999px;


### PR DESCRIPTION
This PR gets rid of MUI elements and styled in the FileBar:

<img width="1166" height="55" alt="image" src="https://github.com/user-attachments/assets/08fdbcd3-43d0-4acf-b30e-cd03fb148b78" />

---

Changes:

- Refactored `FileBar.tsx` to use React+CSS
- Refactored the `WorkbookTitle.tsx` component as well
- Isolated the Storage Warning tooltip in its own file
- Moved the `isWindowWidth.ts` hook to its own file
- Removed a class in ShareButton, as we handle margin in the parent now
- Added needed imports (Tooltip, IconButton) to `index.ts`

> Note: we are still using `ClickAwayListener` from MUI, as that's used in the File and Help menu elements. I will refactor these next as I prefer to do so in a separate PR.
