### PR TITLE
update[app]: rename classes in `ShareWorkbook`

### DIFF
--- a/webapp/IronCalc/src/index.ts
+++ b/webapp/IronCalc/src/index.ts
@@ -13,7 +13,6 @@ export type { IconButtonProperties } from "./components/Button/IconButton";
 export { IconButton } from "./components/Button/IconButton";
 export type { InputProperties, InputSize } from "./components/Input/Input";
 export { Input } from "./components/Input/Input";
-export { useModalFocus } from "./components/Modal/useModalFocus";
 export type { TooltipProperties } from "./components/Tooltip/Tooltip";
 export { Tooltip } from "./components/Tooltip/Tooltip";
 export type { IronCalcHandle } from "./IronCalc";

--- a/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/ShareButton.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/ShareButton.tsx
@@ -2,7 +2,7 @@ import { Button } from "@ironcalc/workbook";
 import { Share2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
-import "./share-button.css";
+import "./share-workbook.css";
 
 export function ShareButton(properties: { onClick: () => void }) {
   const { onClick } = properties;
@@ -12,10 +12,10 @@ export function ShareButton(properties: { onClick: () => void }) {
       type="button"
       onClick={onClick}
       startIcon={<Share2 />}
-      className="share-button"
+      className="app-ic-share-button"
       aria-label={t("file_bar.share_popover.button")}
     >
-      <span className="share-button__text">
+      <span className="app-ic-share-button-text">
         {t("file_bar.share_popover.button")}
       </span>
     </Button>

--- a/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/ShareDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/ShareDialog.tsx
@@ -1,8 +1,9 @@
-import { Button, Input, type Model, useModalFocus } from "@ironcalc/workbook";
+import { Button, Input, type Model } from "@ironcalc/workbook";
 import { Check, Copy, GlobeLock } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { useModalFocus } from "./useModalFocus";
 import { useShareDialog } from "./useShareDialog";
 
 import "./share-dialog.css";

--- a/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/ShareDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/ShareDialog.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useModalFocus } from "./useModalFocus";
 import { useShareDialog } from "./useShareDialog";
 
-import "./share-dialog.css";
+import "./share-workbook.css";
 
 function ShareWorkbookDialog(properties: {
   onClose: () => void;
@@ -22,10 +22,14 @@ function ShareWorkbookDialog(properties: {
   };
 
   return createPortal(
-    <div className="share-dialog-backdrop" onClick={handleClose} role="none">
+    <div
+      className="app-ic-share-dialog-backdrop"
+      onClick={handleClose}
+      role="none"
+    >
       <div
         ref={modalRef}
-        className="share-dialog"
+        className="app-ic-share-dialog"
         role="dialog"
         aria-modal="true"
         onClick={(event) => event.stopPropagation()}
@@ -36,11 +40,11 @@ function ShareWorkbookDialog(properties: {
         }}
         tabIndex={-1}
       >
-        <div className="share-dialog-content">
-          <div className="share-dialog-qr-wrapper">
+        <div className="app-ic-share-dialog-content">
+          <div className="app-ic-share-dialog-qr-wrapper">
             <QRCodeSVG value={url} />
           </div>
-          <div className="share-dialog-url-wrapper">
+          <div className="app-ic-share-dialog-url-wrapper">
             <Input disabled value={url} />
             <Button
               type="button"
@@ -54,7 +58,7 @@ function ShareWorkbookDialog(properties: {
             </Button>
           </div>
         </div>
-        <div className="share-dialog-footer">
+        <div className="app-ic-share-dialog-footer">
           <GlobeLock />
           {t("file_bar.share_popover.info_text")}
         </div>

--- a/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/share-button.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/share-button.css
@@ -1,5 +1,0 @@
-@media (max-width: 600px) {
-  .share-button__text {
-    display: none;
-  }
-}

--- a/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/share-workbook.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/share-workbook.css
@@ -1,10 +1,10 @@
-.share-dialog-backdrop {
+.app-ic-share-dialog-backdrop {
   position: fixed;
   inset: 0;
   background-color: transparent;
 }
 
-.share-dialog {
+.app-ic-share-dialog {
   position: absolute;
   top: 54px;
   right: 10px;
@@ -18,14 +18,14 @@
   font-family: var(--typography-font-family);
 }
 
-.share-dialog-content {
+.app-ic-share-dialog-content {
   padding: 12px;
   display: flex;
   flex-direction: row;
   gap: 12px;
 }
 
-.share-dialog-url-wrapper {
+.app-ic-share-dialog-url-wrapper {
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -33,7 +33,7 @@
   align-items: stretch;
 }
 
-.share-dialog-qr-wrapper {
+.app-ic-share-dialog-qr-wrapper {
   height: auto;
   border-radius: 4px;
   display: flex;
@@ -41,12 +41,12 @@
   justify-content: center;
 }
 
-.share-dialog-qr-wrapper svg {
+.app-ic-share-dialog-qr-wrapper svg {
   width: 72px;
   height: auto;
 }
 
-.share-dialog-footer {
+.app-ic-share-dialog-footer {
   border-top: 1px solid var(--palette-grey-300);
   font-size: var(--typography-font-size);
   color: var(--palette-grey-600);
@@ -56,17 +56,21 @@
   padding: 12px;
 }
 
-.share-dialog-footer svg {
+.app-ic-share-dialog-footer svg {
   max-width: 16px;
   min-width: 16px;
 }
 
 @media (max-width: 600px) {
-  .share-dialog-qr-wrapper {
+  .app-ic-share-dialog-qr-wrapper {
     display: none;
   }
 
-  .share-dialog-url-wrapper {
+  .app-ic-share-dialog-url-wrapper {
     gap: 8px;
+  }
+
+  .app-ic-share-button-text {
+    display: none;
   }
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/useModalFocus.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/ShareWorkbook/useModalFocus.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from "react";
+
+export function useModalFocus(open: boolean) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+
+    requestAnimationFrame(() => {
+      if (!modalRef.current?.contains(document.activeElement)) {
+        modalRef.current?.focus();
+      }
+    });
+  }, [open]);
+
+  function restoreFocus(): void {
+    previousFocusRef.current?.focus();
+  }
+
+  return { modalRef, restoreFocus };
+}


### PR DESCRIPTION
As discussed, we'll be using the `app-ic-` prefix for all classes used in the app.

This PR:
- Renames classes in the recently merged `ShareWorkbook`
- Combines 2 css files in one
- Moves `useModalFocus` to its own file so we don't need to export it, and removes the export from `index.ts`