### PR TITLE
Fix build_criteria for date comparisons in COUNTIF / SUMIF / AVERAGEIF functions

### DIFF
--- a/base/src/formatter/format.rs
+++ b/base/src/formatter/format.rs
@@ -745,7 +745,7 @@ fn parse_year(year_str: &str) -> Result<(i32, String), String> {
 // NOTE 1: The separator has to be the same
 // NOTE 2: In some engines "2/3" is implemented ad "2/March of the present year"
 // NOTE 3: I did not implement the "short date"
-fn parse_date(value: &str, locale: &Locale) -> Result<(i32, String), String> {
+pub(crate) fn parse_date(value: &str, locale: &Locale) -> Result<(i32, String), String> {
     let separator = if value.contains('/') {
         '/'
     } else if value.contains('-') {

--- a/base/src/functions/statistical/if_ifs.rs
+++ b/base/src/functions/statistical/if_ifs.rs
@@ -70,7 +70,7 @@ impl<'a> Model<'a> {
             }
         }
         for criterion in criteria.iter() {
-            fn_criteria.push(build_criteria(criterion));
+            fn_criteria.push(build_criteria(criterion, self.locale));
         }
 
         let mut total = 0.0;
@@ -221,7 +221,7 @@ impl<'a> Model<'a> {
             }
         }
         for criterion in criteria.iter() {
-            fn_criteria.push(build_criteria(criterion));
+            fn_criteria.push(build_criteria(criterion, self.locale));
         }
 
         let left_row = sum_range.left.row;

--- a/base/src/functions/util.rs
+++ b/base/src/functions/util.rs
@@ -4,8 +4,24 @@ use regex_lite as regex;
 use crate::{
     calc_result::CalcResult,
     expressions::token::{is_english_error_string, Error},
+    formatter::format::parse_date,
+    locale::Locale,
     number_format::to_excel_precision,
 };
+
+/// If `s` looks like a date literal in the given locale, return its Excel
+/// serial number as `f64`. Pure numeric strings are rejected here because the
+/// numeric branch in `build_criteria` handles them already, and date parsing
+/// must not shadow the simpler number path.
+fn parse_date_criterion(s: &str, locale: &Locale) -> Option<f64> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() || trimmed.parse::<f64>().is_ok() {
+        return None;
+    }
+    parse_date(trimmed, locale)
+        .ok()
+        .map(|(serial, _)| serial as f64)
+}
 
 fn error_sort_rank(e: &Error) -> u8 {
     match e {
@@ -345,7 +361,17 @@ fn result_is_equal_to_empty(calc_result: &CalcResult) -> bool {
 /// This returns a function (closure) of signature fn(&CalcResult) -> bool
 /// It is Boxed because it returns different closures, so the size cannot be known at compile time
 /// The lifetime (a) of value has to be longer or equal to the lifetime of the returned closure
-pub(crate) fn build_criteria<'a>(value: &'a CalcResult) -> Box<dyn Fn(&CalcResult) -> bool + 'a> {
+///
+/// `locale` is used to recognise date literals in the criterion string (e.g.
+/// "<7/31/2023" or "<31/7/2023" depending on the locale's short date format).
+/// When the post-operator string is not parseable as a number, we try to parse
+/// it as a date and, on success, fall back to numeric comparison against the
+/// resulting Excel serial. This is what lets COUNTIF/SUMIF/AVERAGEIF (and the
+/// *IFS variants) match date-serial cells with date-string criteria.
+pub(crate) fn build_criteria<'a>(
+    value: &'a CalcResult,
+    locale: &'a Locale,
+) -> Box<dyn Fn(&CalcResult) -> bool + 'a> {
     match value {
         CalcResult::String(s) => {
             if let Some(v) = s.strip_prefix("<=") {
@@ -354,6 +380,8 @@ pub(crate) fn build_criteria<'a>(value: &'a CalcResult) -> Box<dyn Fn(&CalcResul
                     Box::new(move |x| result_is_less_or_equal_than_number(x, f))
                 } else if v.is_empty() {
                     Box::new(move |_x| false)
+                } else if let Some(f) = parse_date_criterion(v, locale) {
+                    Box::new(move |x| result_is_less_or_equal_than_number(x, f))
                 } else {
                     Box::new(move |x| result_is_less_or_equal_than_string(x, &v.to_lowercase()))
                 }
@@ -363,6 +391,8 @@ pub(crate) fn build_criteria<'a>(value: &'a CalcResult) -> Box<dyn Fn(&CalcResul
                     Box::new(move |x| result_is_greater_or_equal_than_number(x, f))
                 } else if v.is_empty() {
                     Box::new(move |_x| false)
+                } else if let Some(f) = parse_date_criterion(v, locale) {
+                    Box::new(move |x| result_is_greater_or_equal_than_number(x, f))
                 } else {
                     Box::new(move |x| result_is_greater_or_equal_than_string(x, &v.to_lowercase()))
                 }
@@ -381,6 +411,8 @@ pub(crate) fn build_criteria<'a>(value: &'a CalcResult) -> Box<dyn Fn(&CalcResul
                     }
                 } else if v.is_empty() {
                     Box::new(result_is_not_equal_to_empty)
+                } else if let Some(f) = parse_date_criterion(v, locale) {
+                    Box::new(move |x| result_is_not_equal_to_number(x, f))
                 } else {
                     Box::new(move |x| result_is_not_equal_to_string(x, &v.to_lowercase()))
                 }
@@ -390,6 +422,8 @@ pub(crate) fn build_criteria<'a>(value: &'a CalcResult) -> Box<dyn Fn(&CalcResul
                     Box::new(move |x| result_is_less_than_number(x, f))
                 } else if v.is_empty() {
                     Box::new(move |_x| false)
+                } else if let Some(f) = parse_date_criterion(v, locale) {
+                    Box::new(move |x| result_is_less_than_number(x, f))
                 } else {
                     Box::new(move |x| result_is_less_than_string(x, &v.to_lowercase()))
                 }
@@ -399,6 +433,8 @@ pub(crate) fn build_criteria<'a>(value: &'a CalcResult) -> Box<dyn Fn(&CalcResul
                     Box::new(move |x| result_is_greater_than_number(x, f))
                 } else if v.is_empty() {
                     Box::new(move |_x| false)
+                } else if let Some(f) = parse_date_criterion(v, locale) {
+                    Box::new(move |x| result_is_greater_than_number(x, f))
                 } else {
                     Box::new(move |x| result_is_greater_than_string(x, &v.to_lowercase()))
                 }
@@ -420,6 +456,8 @@ pub(crate) fn build_criteria<'a>(value: &'a CalcResult) -> Box<dyn Fn(&CalcResul
                     } else {
                         Box::new(move |_| false)
                     }
+                } else if let Some(f) = parse_date_criterion(v, locale) {
+                    Box::new(move |x| result_is_equal_to_number(x, f))
                 } else {
                     Box::new(move |x| result_is_equal_to_string(x, &v.to_lowercase()))
                 }

--- a/base/src/test/test_criteria.rs
+++ b/base/src/test/test_criteria.rs
@@ -1,5 +1,12 @@
+#![allow(clippy::unwrap_used)]
+
 use crate::calc_result::CalcResult;
 use crate::functions::util::build_criteria;
+use crate::locale::{get_locale, Locale};
+
+fn en_locale() -> &'static Locale {
+    get_locale("en").unwrap()
+}
 
 // Tests for build_criteria
 // ------------------------
@@ -28,14 +35,14 @@ use crate::functions::util::build_criteria;
 #[test]
 fn test_build_criteria_is_number() {
     let c = CalcResult::Number(42.0);
-    let fn_criteria = build_criteria(&c);
+    let fn_criteria = build_criteria(&c, en_locale());
     assert!(fn_criteria(&CalcResult::Number(42.0)));
     assert!(fn_criteria(&CalcResult::String("42".to_string())));
     assert!(fn_criteria(&CalcResult::String("42.00".to_string())));
     assert!(!fn_criteria(&CalcResult::Number(2.0)));
 
     let c = CalcResult::String("=42".to_string());
-    let fn_criteria = build_criteria(&c);
+    let fn_criteria = build_criteria(&c, en_locale());
     assert!(fn_criteria(&CalcResult::Number(42.0)));
     assert!(fn_criteria(&CalcResult::String("42".to_string())));
     assert!(fn_criteria(&CalcResult::String("42.00".to_string())));
@@ -45,13 +52,13 @@ fn test_build_criteria_is_number() {
 #[test]
 fn test_build_criteria_is_bool() {
     let c = CalcResult::Boolean(true);
-    let fn_criteria = build_criteria(&c);
+    let fn_criteria = build_criteria(&c, en_locale());
     assert!(fn_criteria(&CalcResult::Boolean(true)));
     assert!(!fn_criteria(&CalcResult::String("true".to_string())));
     assert!(!fn_criteria(&CalcResult::Number(1.0)));
 
     let c = CalcResult::String("=True".to_string());
-    let fn_criteria = build_criteria(&c);
+    let fn_criteria = build_criteria(&c, en_locale());
     assert!(fn_criteria(&CalcResult::Boolean(true)));
     assert!(!fn_criteria(&CalcResult::String("true".to_string())));
     assert!(!fn_criteria(&CalcResult::Number(1.0)));
@@ -60,7 +67,7 @@ fn test_build_criteria_is_bool() {
 #[test]
 fn test_build_criteria_is_less_than() {
     let c = CalcResult::String("<100".to_string());
-    let fn_criteria = build_criteria(&c);
+    let fn_criteria = build_criteria(&c, en_locale());
     assert!(!fn_criteria(&CalcResult::Boolean(true)));
     assert!(!fn_criteria(&CalcResult::String("23".to_string())));
     assert!(fn_criteria(&CalcResult::Number(1.0)));
@@ -70,7 +77,7 @@ fn test_build_criteria_is_less_than() {
 #[test]
 fn test_build_criteria_is_less_wildcard() {
     let c = CalcResult::String("=D* G*".to_string());
-    let fn_criteria = build_criteria(&c);
+    let fn_criteria = build_criteria(&c, en_locale());
     assert!(fn_criteria(&CalcResult::String(
         "Diarmuid Glynn".to_string()
     )));
@@ -83,4 +90,74 @@ fn test_build_criteria_is_less_wildcard() {
     assert!(!fn_criteria(&CalcResult::String(
         " Daniel Gonzalez".to_string()
     )));
+}
+
+// Date-string criteria. Excel parses literals like "7/31/2023" into a serial
+// (45138 in this case) and applies the comparison numerically against
+// date-serial cells. These tests cover all six branches of build_criteria.
+//
+// The neighbouring serials used below:
+//   45137 = 7/30/2023
+//   45138 = 7/31/2023  (the criterion target)
+//   45139 = 8/1/2023
+
+#[test]
+fn test_build_criteria_date_less_than() {
+    let c = CalcResult::String("<7/31/2023".to_string());
+    let fn_criteria = build_criteria(&c, en_locale());
+    assert!(fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45138.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45139.0)));
+}
+
+#[test]
+fn test_build_criteria_date_less_or_equal() {
+    let c = CalcResult::String("<=7/31/2023".to_string());
+    let fn_criteria = build_criteria(&c, en_locale());
+    assert!(fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(fn_criteria(&CalcResult::Number(45138.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45139.0)));
+}
+
+#[test]
+fn test_build_criteria_date_greater_than() {
+    let c = CalcResult::String(">7/31/2023".to_string());
+    let fn_criteria = build_criteria(&c, en_locale());
+    assert!(!fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45138.0)));
+    assert!(fn_criteria(&CalcResult::Number(45139.0)));
+}
+
+#[test]
+fn test_build_criteria_date_greater_or_equal() {
+    let c = CalcResult::String(">=7/31/2023".to_string());
+    let fn_criteria = build_criteria(&c, en_locale());
+    assert!(!fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(fn_criteria(&CalcResult::Number(45138.0)));
+    assert!(fn_criteria(&CalcResult::Number(45139.0)));
+}
+
+#[test]
+fn test_build_criteria_date_not_equal() {
+    let c = CalcResult::String("<>7/31/2023".to_string());
+    let fn_criteria = build_criteria(&c, en_locale());
+    assert!(fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45138.0)));
+    assert!(fn_criteria(&CalcResult::Number(45139.0)));
+}
+
+#[test]
+fn test_build_criteria_date_equal() {
+    let c = CalcResult::String("7/31/2023".to_string());
+    let fn_criteria = build_criteria(&c, en_locale());
+    assert!(!fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(fn_criteria(&CalcResult::Number(45138.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45139.0)));
+
+    // Same with a leading "=" prefix.
+    let c = CalcResult::String("=7/31/2023".to_string());
+    let fn_criteria = build_criteria(&c, en_locale());
+    assert!(!fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(fn_criteria(&CalcResult::Number(45138.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45139.0)));
 }

--- a/base/src/test/test_criteria.rs
+++ b/base/src/test/test_criteria.rs
@@ -161,3 +161,122 @@ fn test_build_criteria_date_equal() {
     assert!(fn_criteria(&CalcResult::Number(45138.0)));
     assert!(!fn_criteria(&CalcResult::Number(45139.0)));
 }
+
+// Locale coverage for the date-parse fallback.
+//
+// `parse_date` decides D/M/Y vs M/D/Y by inspecting the locale's
+// `date_formats.short`. The tests below pick locales whose short formats are
+// known: `en` -> "m/d/yy", `en-GB` -> "dd/mm/yyyy", `es` -> "d/m/yy",
+// `de` -> "dd.mm.yy". They guard against three regression classes:
+//   1. The locale parameter being dropped or hard-coded to "en".
+//   2. The `.` separator path (used by `de`) being broken.
+//   3. ISO dates becoming locale-dependent.
+//
+// Serial numbers used (Excel 1900 system, anchored on 45108 = 2023-07-01):
+//   44941 = 2023-01-15
+//   44992 = 2023-03-07
+//   45110 = 2023-07-03
+//   45138 = 2023-07-31
+
+#[test]
+fn test_build_criteria_date_dmy_locale_en_gb() {
+    // "31/7/2023" is unambiguously a date under en-GB (D/M/Y), but under en
+    // (M/D/Y) the would-be month is 31 and the parse must fail.
+    let en_gb = get_locale("en-GB").unwrap();
+    let c = CalcResult::String("<31/7/2023".to_string());
+    let fn_criteria = build_criteria(&c, en_gb);
+    assert!(fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45138.0)));
+
+    // Under en, the same string is not a parseable date so it falls through to
+    // string comparison; numeric cells must never match.
+    let fn_criteria_en = build_criteria(&c, en_locale());
+    assert!(!fn_criteria_en(&CalcResult::Number(45137.0)));
+    assert!(!fn_criteria_en(&CalcResult::Number(45138.0)));
+}
+
+#[test]
+fn test_build_criteria_date_dmy_locale_es() {
+    // Spanish is also D/M/Y. Cover equality and >= to exercise different
+    // branches than the en-GB test above.
+    let es = get_locale("es").unwrap();
+    let c = CalcResult::String("31/7/2023".to_string());
+    let fn_criteria = build_criteria(&c, es);
+    assert!(fn_criteria(&CalcResult::Number(45138.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45137.0)));
+
+    let c = CalcResult::String(">=31/7/2023".to_string());
+    let fn_criteria = build_criteria(&c, es);
+    assert!(!fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(fn_criteria(&CalcResult::Number(45138.0)));
+}
+
+#[test]
+fn test_build_criteria_date_dot_separator_locale_de() {
+    // German short format is "dd.mm.yy" — the `.` separator is a third path
+    // through parse_date, separate from `/` and `-`.
+    let de = get_locale("de").unwrap();
+    let c = CalcResult::String("<=31.7.2023".to_string());
+    let fn_criteria = build_criteria(&c, de);
+    assert!(fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(fn_criteria(&CalcResult::Number(45138.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45139.0)));
+
+    let c = CalcResult::String("<>31.7.2023".to_string());
+    let fn_criteria = build_criteria(&c, de);
+    assert!(fn_criteria(&CalcResult::Number(45137.0)));
+    assert!(!fn_criteria(&CalcResult::Number(45138.0)));
+}
+
+#[test]
+fn test_build_criteria_date_iso_is_locale_independent() {
+    // ISO yyyy-mm-dd must parse the same way under every locale. Without this
+    // guard, a regression that wrongly applied the D/M/Y swap to ISO dates
+    // would slip through.
+    let iso = CalcResult::String("2023-07-31".to_string());
+    for id in ["en", "en-GB", "es", "de", "fr", "it"] {
+        let loc = get_locale(id).unwrap();
+        let fn_criteria = build_criteria(&iso, loc);
+        assert!(
+            fn_criteria(&CalcResult::Number(45138.0)),
+            "ISO date should match 45138 under locale {id}"
+        );
+        assert!(
+            !fn_criteria(&CalcResult::Number(45137.0)),
+            "ISO date should not match 45137 under locale {id}"
+        );
+    }
+}
+
+#[test]
+fn test_build_criteria_date_locale_disambiguation() {
+    // "3/7/2023" is ambiguous: en reads March 7 (44992), es reads July 3 (45110).
+    // Pin both interpretations to make sure the locale is actually consulted
+    // rather than silently defaulted.
+    let c = CalcResult::String("3/7/2023".to_string());
+
+    let fn_en = build_criteria(&c, en_locale());
+    assert!(fn_en(&CalcResult::Number(44992.0))); // March 7
+    assert!(!fn_en(&CalcResult::Number(45110.0))); // July 3
+
+    let es = get_locale("es").unwrap();
+    let fn_es = build_criteria(&c, es);
+    assert!(!fn_es(&CalcResult::Number(44992.0)));
+    assert!(fn_es(&CalcResult::Number(45110.0)));
+}
+
+#[test]
+fn test_build_criteria_date_localized_month_name() {
+    // Spanish abbreviates January as "ene". parse_month consults the locale's
+    // months_short list, so this only matches under the matching locale.
+    let es = get_locale("es").unwrap();
+    let c = CalcResult::String("=15-ene-2023".to_string());
+    let fn_es = build_criteria(&c, es);
+    assert!(fn_es(&CalcResult::Number(44941.0))); // 2023-01-15
+    assert!(!fn_es(&CalcResult::Number(44942.0)));
+
+    // Under en, "ene" is not a known month — parse fails and the criterion
+    // falls back to string equality, so no Number cell should match.
+    let fn_en = build_criteria(&c, en_locale());
+    assert!(!fn_en(&CalcResult::Number(44941.0)));
+}

--- a/base/src/test/test_fn_count.rs
+++ b/base/src/test/test_fn_count.rs
@@ -18,6 +18,37 @@ fn test_fn_count_arguments() {
 }
 
 #[test]
+fn test_fn_countif_date_string_criterion() {
+    // 45131..=45137 -> 7/24/2023..7/30/2023 (seven dates strictly before 7/31)
+    // 45138         -> 7/31/2023
+    // 45139, 45200  -> after 7/31/2023
+    let mut model = new_empty_model();
+    for (idx, serial) in (45131..=45137).enumerate() {
+        let cell = format!("B{}", idx + 2);
+        model._set(&cell, &serial.to_string());
+    }
+    model._set("B9", "45138");
+    model._set("B10", "45139");
+    model._set("B11", "45200");
+
+    model._set("A1", "=COUNTIF(B2:B11, \"<7/31/2023\")");
+    model._set("A2", "=COUNTIF(B2:B11, \"<=7/31/2023\")");
+    model._set("A3", "=COUNTIF(B2:B11, \"7/31/2023\")");
+    model._set("A4", "=COUNTIF(B2:B11, \">7/31/2023\")");
+    model._set("A5", "=COUNTIF(B2:B11, \">=7/31/2023\")");
+    model._set("A6", "=COUNTIF(B2:B11, \"<>7/31/2023\")");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"7");
+    assert_eq!(model._get_text("A2"), *"8");
+    assert_eq!(model._get_text("A3"), *"1");
+    assert_eq!(model._get_text("A4"), *"2");
+    assert_eq!(model._get_text("A5"), *"3");
+    assert_eq!(model._get_text("A6"), *"9");
+}
+
+#[test]
 fn test_fn_count_minimal() {
     let mut model = new_empty_model();
     model._set("B1", "3.1415926");

--- a/base/src/test/test_fn_sumifs.rs
+++ b/base/src/test/test_fn_sumifs.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
+use crate::model::Model;
 use crate::test::util::new_empty_model;
 
 #[test]
@@ -37,4 +38,92 @@ fn test_fn_sumifs_arguments() {
 
     // Correct
     assert_eq!(model._get_text("A5"), *"20");
+}
+
+// Date-string criteria reach build_criteria via two distinct paths:
+//   * fn_countifs has its own criteria loop (covered by test_fn_count.rs)
+//   * apply_ifs is the shared path behind SUMIF, SUMIFS, AVERAGEIF,
+//     AVERAGEIFS, MAXIFS, MINIFS — exercised here.
+//
+// Layout:
+//   B2..B8  = 45131..45137 (2023-07-24 .. 2023-07-30, all "<7/31/2023")
+//   B9      = 45138        (2023-07-31, the criterion target)
+//   B10..B11= 45139, 45200 (after 7/31/2023)
+//   C2..C8  = 1..7         (matches "<7/31/2023")
+//   C9      = 100          (matches "7/31/2023")
+//   C10..C11= 99, 50       (matches ">7/31/2023")
+fn populate_date_apply_ifs_data(model: &mut Model) {
+    let date_serials = [45131, 45132, 45133, 45134, 45135, 45136, 45137];
+    let values = [1, 2, 3, 4, 5, 6, 7];
+    for (idx, (serial, value)) in date_serials.iter().zip(values.iter()).enumerate() {
+        let row = idx + 2;
+        model._set(&format!("B{row}"), &serial.to_string());
+        model._set(&format!("C{row}"), &value.to_string());
+    }
+    model._set("B9", "45138");
+    model._set("C9", "100");
+    model._set("B10", "45139");
+    model._set("C10", "99");
+    model._set("B11", "45200");
+    model._set("C11", "50");
+}
+
+#[test]
+fn test_apply_ifs_date_criterion_covers_all_consumers() {
+    // One worksheet, one criterion shape, every apply_ifs consumer probed.
+    // If a future change drops the locale at the apply_ifs call site, every
+    // assertion below collapses to 0 / DIV-by-0 and the test fails loudly.
+    let mut model = new_empty_model();
+    populate_date_apply_ifs_data(&mut model);
+
+    // SUMIF / SUMIFS — sum of C where B "<7/31/2023" is 1+2+3+4+5+6+7 = 28
+    model._set("A1", "=SUMIF(B2:B11, \"<7/31/2023\", C2:C11)");
+    model._set("A2", "=SUMIFS(C2:C11, B2:B11, \"<7/31/2023\")");
+    // AVERAGEIF / AVERAGEIFS — 28 / 7 = 4
+    model._set("A3", "=AVERAGEIF(B2:B11, \"<7/31/2023\", C2:C11)");
+    model._set("A4", "=AVERAGEIFS(C2:C11, B2:B11, \"<7/31/2023\")");
+    // MAXIFS / MINIFS over the same range
+    model._set("A5", "=MAXIFS(C2:C11, B2:B11, \"<7/31/2023\")");
+    model._set("A6", "=MINIFS(C2:C11, B2:B11, \"<7/31/2023\")");
+
+    // Use a different operator (>=) on SUMIFS / MAXIFS / MINIFS to exercise
+    // a second branch of build_criteria through the apply_ifs path.
+    // C cells where B >= 7/31/2023 are C9=100, C10=99, C11=50 -> sum 249
+    model._set("A7", "=SUMIFS(C2:C11, B2:B11, \">=7/31/2023\")");
+    model._set("A8", "=MAXIFS(C2:C11, B2:B11, \">=7/31/2023\")");
+    model._set("A9", "=MINIFS(C2:C11, B2:B11, \">=7/31/2023\")");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"28");
+    assert_eq!(model._get_text("A2"), *"28");
+    assert_eq!(model._get_text("A3"), *"4");
+    assert_eq!(model._get_text("A4"), *"4");
+    assert_eq!(model._get_text("A5"), *"7");
+    assert_eq!(model._get_text("A6"), *"1");
+    assert_eq!(model._get_text("A7"), *"249");
+    assert_eq!(model._get_text("A8"), *"100");
+    assert_eq!(model._get_text("A9"), *"50");
+}
+
+#[test]
+fn test_apply_ifs_date_criterion_respects_locale() {
+    // Build the same workbook under en-GB (D/M/Y). "31/7/2023" is only a
+    // valid date under a D/M/Y locale; if apply_ifs ever stops forwarding
+    // self.locale to build_criteria, en's M/D/Y rules would reject this
+    // string and SUMIFS would collapse to 0.
+    let mut model = Model::new_empty("model", "en-GB", "UTC", "en").unwrap();
+    populate_date_apply_ifs_data(&mut model);
+
+    model._set("A1", "=SUMIFS(C2:C11, B2:B11, \"<31/7/2023\")");
+    model._set("A2", "=AVERAGEIFS(C2:C11, B2:B11, \"<31/7/2023\")");
+    model._set("A3", "=MAXIFS(C2:C11, B2:B11, \"<31/7/2023\")");
+    model._set("A4", "=MINIFS(C2:C11, B2:B11, \"<31/7/2023\")");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"28");
+    assert_eq!(model._get_text("A2"), *"4");
+    assert_eq!(model._get_text("A3"), *"7");
+    assert_eq!(model._get_text("A4"), *"1");
 }


### PR DESCRIPTION
## Summary

Fix build_criteria (base/src/functions/util.rs) so date-string criteria like "<7/31/2023" match numeric date-serial cells in COUNTIF / SUMIF / AVERAGEIF and the *IFS variants. Previously the post-operator string was only tried as f64; on failure it fell through to string comparison and never matched CalcResult::Number, so =COUNTIF(B2:B66, "<7/31/2023") returned 0 instead of Excel's 7.

## Changes

- build_criteria now takes &Locale and, in all six branches (<=, >=, <>, <, >, equality), tries a date parse between the existing f64 attempt and the string fallback. On success it routes to the numeric predicate against the Excel serial.
- The <> and equality branches keep their existing wildcard / boolean / error checks ahead of the date attempt.
- Reuses the locale-aware parse_date in formatter/format.rs (visibility bumped to pub(crate)), so D/M/Y locales work — "<31/7/2023" parses correctly under e.g. es-ES.
- Callers in statistical/if_ifs.rs pass self.locale. No public API change.
