### PR TITLE
update: add unit testing for FACT, FACTDOUBLE and mark some functions as available in the docs

### DIFF
--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -13,6 +13,7 @@ mod test_datedif_leap_month_end;
 mod test_days360_month_end;
 mod test_degrees_radians;
 mod test_error_propagation;
+mod test_fact_factdouble;
 mod test_fn_average;
 mod test_fn_averageifs;
 mod test_fn_choose;

--- a/base/src/test/test_fact_factdouble.rs
+++ b/base/src/test/test_fact_factdouble.rs
@@ -1,0 +1,23 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+#[test]
+fn arguments() {
+    let mut model = new_empty_model();
+    model._set("A1", "=FACT()");
+    model._set("A2", "=FACTDOUBLE()");
+    model._set("A3", "=FACT(3)");
+    model._set("A4", "=FACTDOUBLE(3)");
+    model._set("A5", "=FACT(1, 2)");
+    model._set("A6", "=FACTDOUBLE(1, 2)");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"#ERROR!");
+    assert_eq!(model._get_text("A2"), *"#ERROR!");
+    assert_eq!(model._get_text("A3"), *"6");
+    assert_eq!(model._get_text("A4"), *"3");
+    assert_eq!(model._get_text("A5"), *"#ERROR!");
+    assert_eq!(model._get_text("A6"), *"#ERROR!");
+}

--- a/docs/src/functions/logical/bycol.md
+++ b/docs/src/functions/logical/bycol.md
@@ -7,6 +7,5 @@ lang: en-US
 # BYCOL
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/logical/byrow.md
+++ b/docs/src/functions/logical/byrow.md
@@ -7,6 +7,5 @@ lang: en-US
 # BYROW
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/logical/lambda.md
+++ b/docs/src/functions/logical/lambda.md
@@ -7,6 +7,5 @@ lang: en-US
 # LAMBDA
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/logical/let.md
+++ b/docs/src/functions/logical/let.md
@@ -7,6 +7,5 @@ lang: en-US
 # LET
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/logical/map.md
+++ b/docs/src/functions/logical/map.md
@@ -7,6 +7,5 @@ lang: en-US
 # MAP
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/logical/reduce.md
+++ b/docs/src/functions/logical/reduce.md
@@ -7,6 +7,5 @@ lang: en-US
 # REDUCE
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/logical/scan.md
+++ b/docs/src/functions/logical/scan.md
@@ -7,6 +7,5 @@ lang: en-US
 # SCAN
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/lookup_and_reference/filter.md
+++ b/docs/src/functions/lookup_and_reference/filter.md
@@ -7,6 +7,5 @@ lang: en-US
 # FILTER
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/lookup_and_reference/sort.md
+++ b/docs/src/functions/lookup_and_reference/sort.md
@@ -7,6 +7,5 @@ lang: en-US
 # SORT
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/lookup_and_reference/sortby.md
+++ b/docs/src/functions/lookup_and_reference/sortby.md
@@ -7,6 +7,5 @@ lang: en-US
 # SORTBY
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/lookup_and_reference/unique.md
+++ b/docs/src/functions/lookup_and_reference/unique.md
@@ -7,6 +7,5 @@ lang: en-US
 # UNIQUE
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/math_and_trigonometry/fact.md
+++ b/docs/src/functions/math_and_trigonometry/fact.md
@@ -7,6 +7,5 @@ lang: en-US
 # FACT
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/math_and_trigonometry/factdouble.md
+++ b/docs/src/functions/math_and_trigonometry/factdouble.md
@@ -7,6 +7,5 @@ lang: en-US
 # FACTDOUBLE
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/math_and_trigonometry/gcd.md
+++ b/docs/src/functions/math_and_trigonometry/gcd.md
@@ -7,6 +7,5 @@ lang: en-US
 # GCD
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/math_and_trigonometry/lcm.md
+++ b/docs/src/functions/math_and_trigonometry/lcm.md
@@ -7,6 +7,5 @@ lang: en-US
 # LCM
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/math_and_trigonometry/randarray.md
+++ b/docs/src/functions/math_and_trigonometry/randarray.md
@@ -7,6 +7,5 @@ lang: en-US
 # RANDARRAY
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/math_and_trigonometry/sequence.md
+++ b/docs/src/functions/math_and_trigonometry/sequence.md
@@ -7,6 +7,5 @@ lang: en-US
 # SEQUENCE
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/text/concat.md
+++ b/docs/src/functions/text/concat.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# CONCAT
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/concatenate.md
+++ b/docs/src/functions/text/concatenate.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# CONCATENATE
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/exact.md
+++ b/docs/src/functions/text/exact.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# EXACT
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/find.md
+++ b/docs/src/functions/text/find.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# FIND
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/left.md
+++ b/docs/src/functions/text/left.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# LEFT
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/len.md
+++ b/docs/src/functions/text/len.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# LEN
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/lower.md
+++ b/docs/src/functions/text/lower.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# LOWER
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/textsplit.md
+++ b/docs/src/functions/text/textsplit.md
@@ -7,6 +7,5 @@ lang: en-US
 # TEXTSPLIT
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::


### PR DESCRIPTION
This PR adds unit testing in Rust to check the number of arguments taken by FACT and FACTDOUBLE functions. Also marks them as implemented in their respective documentation pages. 

While doing this, other implemented functions were found with the wrong description in their pages. Some functions in the following categories were fixed:
- Logical
- Mathematical and trigonometry
- Information
- Lookup and reference
- Dynamic array
- Text (some functions here did not even have their own page)