### PR TITLE
update: remove custom `LineStyle` icon and use Lucide's

### DIFF
--- a/webapp/IronCalc/src/components/BorderPicker/BorderPicker.tsx
+++ b/webapp/IronCalc/src/components/BorderPicker/BorderPicker.tsx
@@ -2,6 +2,7 @@ import { type BorderOptions, BorderStyle, BorderType } from "@ironcalc/wasm";
 import {
   Grid2X2 as BorderAllIcon,
   ChevronRight,
+  LineStyle,
   PencilLine,
 } from "lucide-react";
 import type React from "react";
@@ -16,7 +17,6 @@ import {
   BorderNoneIcon,
   BorderOuterIcon,
   BorderRightIcon,
-  BorderStyleIcon,
   BorderTopIcon,
 } from "../../icons";
 import { IconButton } from "../Button/IconButton";
@@ -326,7 +326,7 @@ export default function BorderPicker({
           onMouseLeave={() => setStylePickerOpen(false)}
         >
           <button type="button" className="ic-border-picker__button">
-            <BorderStyleIcon />
+            <LineStyle />
             <span>{t("toolbar.borders.style")}</span>
             <ChevronRight />
           </button>

--- a/webapp/IronCalc/src/icons/border-style.svg
+++ b/webapp/IronCalc/src/icons/border-style.svg
@@ -1,3 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M3 8H2M14 8H13M7 8H5M11 8H9M14 4H2M2.01 12H2M4.01 12H4M6.01 12H6M8.01 12H8M10.01 12H10M12.01 12H12M14.01 12H14" stroke="#333333" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/webapp/IronCalc/src/icons/index.ts
+++ b/webapp/IronCalc/src/icons/index.ts
@@ -7,7 +7,6 @@ import BorderLeftIcon from "./border-left.svg?react";
 import BorderNoneIcon from "./border-none.svg?react";
 import BorderOuterIcon from "./border-outer.svg?react";
 import BorderRightIcon from "./border-right.svg?react";
-import BorderStyleIcon from "./border-style.svg?react";
 import BorderTopIcon from "./border-top.svg?react";
 import DeleteColumnIcon from "./delete-column.svg?react";
 import DeleteRowIcon from "./delete-row.svg?react";
@@ -30,7 +29,6 @@ export {
   BorderNoneIcon,
   BorderOuterIcon,
   BorderRightIcon,
-  BorderStyleIcon,
   BorderTopIcon,
   DeleteColumnIcon,
   DeleteRowIcon,


### PR DESCRIPTION
We were finally able to include [one of our icons](https://lucide.dev/icons/line-style), `line-style`, in Lucide's library! This PR removes the current custom-made svg and uses the one from the official library.