### PR TITLE
update[app]: remove MUI from `DeleteWorkbookDialog.tsx`

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/DeleteWorkbookDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/DeleteWorkbookDialog.tsx
@@ -1,188 +1,44 @@
-import styled from "@emotion/styled";
-import { Trash2 } from "lucide-react";
-import { useEffect, useRef } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { Confirm } from "@ironcalc/workbook";
+import { useTranslation } from "react-i18next";
 
 interface DeleteWorkbookDialogProperties {
+  open: boolean;
   onClose: () => void;
   onConfirm: () => void;
   workbookName: string;
-  titleId?: string;
-  descriptionId?: string;
 }
 
-function DeleteWorkbookDialog(properties: DeleteWorkbookDialogProperties) {
+function DeleteWorkbookDialog({
+  open,
+  onClose,
+  onConfirm,
+  workbookName,
+}: DeleteWorkbookDialogProperties) {
   const { t } = useTranslation();
-  const deleteButtonRef = useRef<HTMLButtonElement>(null);
-  const titleId = properties.titleId ?? "delete-dialog-title";
-  const descriptionId = properties.descriptionId ?? "delete-dialog-description";
-
-  useEffect(() => {
-    if (deleteButtonRef.current) {
-      deleteButtonRef.current.focus();
-    }
-  }, []);
 
   return (
-    <DialogWrapper
-      tabIndex={-1}
-      onKeyDown={(event) => {
-        if (event.code === "Escape") {
-          properties.onClose();
-        }
-      }}
-      aria-labelledby={titleId}
-      aria-describedby={descriptionId}
-    >
-      <IconWrapper>
-        <Trash2 />
-      </IconWrapper>
-      <ContentWrapper>
-        <Title id={titleId}>
-          {t("file_bar.file_menu.delete_workbook.title")}
-        </Title>
-        <Body id={descriptionId}>
-          <Trans
-            i18nKey="file_bar.file_menu.delete_workbook.subtitle"
-            components={{ bold: <strong /> }}
-            values={{
-              workbookName: properties.workbookName,
-            }}
-          />
-        </Body>
-        <ButtonGroup>
-          <DeleteButton
-            onClick={() => {
-              properties.onConfirm();
-              properties.onClose();
-            }}
-            ref={deleteButtonRef}
-          >
-            {t("file_bar.file_menu.delete_workbook.confirm_button")}
-          </DeleteButton>
-          <CancelButton onClick={properties.onClose}>
-            {t("file_bar.file_menu.delete_workbook.cancel_button")}
-          </CancelButton>
-        </ButtonGroup>
-      </ContentWrapper>
-    </DialogWrapper>
+    <Confirm
+      open={open}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title={t("file_bar.file_menu.delete_workbook.title")}
+      message={
+        <>
+          <p>
+            {t("file_bar.file_menu.delete_workbook.subtitle", { workbookName })}
+          </p>
+          <p>
+            <strong>{t("file_bar.file_menu.delete_workbook.warning")}</strong>
+          </p>
+        </>
+      }
+      confirmLabel={t("file_bar.file_menu.delete_workbook.confirm_button")}
+      cancelLabel={t("file_bar.file_menu.delete_workbook.cancel_button")}
+      variant="destructive"
+    />
   );
 }
 
 DeleteWorkbookDialog.displayName = "DeleteWorkbookDialog";
-
-// some colors taken from the IronCalc palette
-const COMMON_WHITE = "#FFF";
-
-const ERROR_MAIN = "#EB5757";
-const ERROR_DARK = "#CB4C4C";
-
-const GREY_200 = "#EEEEEE";
-const GREY_300 = "#E0E0E0";
-const GREY_700 = "#616161";
-const GREY_900 = "#333333";
-
-const PRIMARY_MAIN = "#F2994A";
-const PRIMARY_DARK = "#D68742";
-
-const DialogWrapper = styled.div`
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: white;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 12px;
-  border-radius: 8px;
-  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.15);
-  width: 280px;
-  max-width: calc(100% - 40px);
-  z-index: 50;
-  font-family: "Inter", sans-serif;
-`;
-
-const IconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 4px;
-  background-color: ${ERROR_MAIN}1A;
-  margin: 12px auto 0 auto;
-  color: ${ERROR_MAIN};
-  svg {
-    width: 16px;
-    height: 16px;
-  }
-`;
-
-const ContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  word-break: break-word;
-`;
-
-const Title = styled.h2`
-  margin: 0;
-  font-weight: 600;
-  font-size: inherit;
-  color: ${GREY_900};
-`;
-
-const Body = styled.p`
-  margin: 0;
-  text-align: center;
-  color: ${GREY_900};
-  font-size: 12px;
-`;
-
-const ButtonGroup = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 8px;
-  width: 100%;
-`;
-
-const Button = styled.button`
-  cursor: pointer;
-  color: ${COMMON_WHITE};
-  background-color: ${PRIMARY_MAIN};
-  padding: 0px 10px;
-  height: 36px;
-  border-radius: 4px;
-  border: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 14px;
-  text-overflow: ellipsis;
-  transition: background-color 150ms;
-  &:hover {
-    background-color: ${PRIMARY_DARK};
-  }
-`;
-
-const DeleteButton = styled(Button)`
-  background-color: ${ERROR_MAIN};
-  color: ${COMMON_WHITE};
-  &:hover {
-    background-color: ${ERROR_DARK};
-  }
-`;
-
-const CancelButton = styled(Button)`
-  background-color: ${GREY_200};
-  color: ${GREY_700};
-  &:hover {
-    background-color: ${GREY_300};
-  }
-`;
 
 export default DeleteWorkbookDialog;

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Menu, MenuItem, Modal } from "@mui/material";
+import { Menu, MenuItem } from "@mui/material";
 import {
   Copy,
   EllipsisVertical,
@@ -330,20 +330,14 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
         </DeleteButton>
       </StyledMenu>
 
-      <Modal
+      <DeleteWorkbookDialog
         open={isDeleteDialogOpen}
         onClose={handleDeleteCancel}
-        aria-labelledby="delete-dialog-title"
-        aria-describedby="delete-dialog-description"
-      >
-        <DeleteWorkbookDialog
-          onClose={handleDeleteCancel}
-          onConfirm={handleDeleteConfirm}
-          workbookName={
-            workbookToDelete ? modelsMetadata[workbookToDelete].name : ""
-          }
-        />
-      </Modal>
+        onConfirm={handleDeleteConfirm}
+        workbookName={
+          workbookToDelete ? modelsMetadata[workbookToDelete].name : ""
+        }
+      />
     </>
   );
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/Navigation/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/Navigation/FileMenu.tsx
@@ -9,7 +9,6 @@ import {
   Trash2,
 } from "lucide-react";
 import { type ComponentProps, forwardRef, useEffect, useState } from "react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import DeleteWorkbookDialog from "../DeleteWorkbookDialog";
 import { getModelsMetadata, getSelectedUuid } from "../storage";
@@ -179,15 +178,12 @@ export function FileMenu(props: {
         />
       )}
 
-      {isDeleteDialogOpen &&
-        createPortal(
-          <DeleteWorkbookDialog
-            onClose={() => setDeleteDialogOpen(false)}
-            onConfirm={props.onDelete}
-            workbookName={models[selectedUuid ?? ""]?.name ?? ""}
-          />,
-          document.body,
-        )}
+      <DeleteWorkbookDialog
+        open={isDeleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        onConfirm={props.onDelete}
+        workbookName={models[selectedUuid ?? ""]?.name ?? ""}
+      />
     </>
   );
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/Navigation/MobileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/Navigation/MobileMenu.tsx
@@ -12,7 +12,6 @@ import {
   Trash2,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import DeleteWorkbookDialog from "../DeleteWorkbookDialog";
 import { getModelsMetadata, getSelectedUuid } from "../storage";
@@ -211,15 +210,12 @@ export function MobileMenu(props: MobileMenuProps) {
         />
       )}
 
-      {isDeleteDialogOpen &&
-        createPortal(
-          <DeleteWorkbookDialog
-            onClose={() => setDeleteDialogOpen(false)}
-            onConfirm={props.onDelete}
-            workbookName={(selectedUuid && models[selectedUuid]?.name) || ""}
-          />,
-          document.body,
-        )}
+      <DeleteWorkbookDialog
+        open={isDeleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        onConfirm={props.onDelete}
+        workbookName={(selectedUuid && models[selectedUuid]?.name) || ""}
+      />
     </>
   );
 }

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -69,8 +69,9 @@
       "delete_workbook": {
         "button": "Arbeitsmappe löschen",
         "title": "Sind Sie sicher?",
-        "subtitle": "Die Arbeitsmappe <bold>'{{workbookName}}'</bold> wird dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
-        "confirm_button": "Ja, Arbeitsmappe löschen",
+        "subtitle": "Die Arbeitsmappe '{{workbookName}}' wird dauerhaft gelöscht.",
+        "warning": "Diese Aktion kann nicht rückgängig gemacht werden.",
+        "confirm_button": "Ja, löschen",
         "cancel_button": "Abbrechen"
       },
       "default_language": "Standardsprache"

--- a/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
@@ -69,8 +69,9 @@
       "delete_workbook": {
         "button": "Delete workbook",
         "title": "Are you sure?",
-        "subtitle": "The workbook <bold>'{{workbookName}}'</bold> will be permanently deleted. This action cannot be undone.",
-        "confirm_button": "Yes, delete workbook",
+        "subtitle": "The workbook '{{workbookName}}' will be permanently deleted.",
+        "warning": "This action cannot be undone.",
+        "confirm_button": "Yes, delete",
         "cancel_button": "Cancel"
       },
       "default_language": "Default language"

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -69,8 +69,9 @@
       "delete_workbook": {
         "button": "Eliminar libro",
         "title": "¿Estás seguro?",
-        "subtitle": "El libro <bold>'{{workbookName}}'</bold> será eliminado permanentemente. Esta acción no se puede deshacer.",
-        "confirm_button": "Sí, eliminar libro",
+        "subtitle": "El libro '{{workbookName}}' será eliminado permanentemente.",
+        "warning": "Esta acción no se puede deshacer.",
+        "confirm_button": "Sí, eliminar",
         "cancel_button": "Cancelar"
       },
       "default_language": "Idioma predeterminado"

--- a/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
@@ -69,8 +69,9 @@
       "delete_workbook": {
         "button": "Supprimer le classeur",
         "title": "Êtes-vous sûr ?",
-        "subtitle": "Le classeur <bold>'{{workbookName}}'</bold> sera définitivement supprimé. Cette action ne peut pas être annulée.",
-        "confirm_button": "Oui, supprimer le classeur",
+        "subtitle": "Le classeur '{{workbookName}}' sera définitivement supprimé.",
+        "warning": "Cette action ne peut pas être annulée.",
+        "confirm_button": "Oui, supprimer",
         "cancel_button": "Annuler"
       },
       "default_language": "Langue par défaut"

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -69,8 +69,9 @@
       "delete_workbook": {
         "button": "Elimina cartella di lavoro",
         "title": "Sei sicuro?",
-        "subtitle": "La cartella di lavoro <bold>'{{workbookName}}'</bold> verrà eliminata definitivamente. Questa azione non può essere annullata.",
-        "confirm_button": "Sì, elimina cartella di lavoro",
+        "subtitle": "La cartella di lavoro '{{workbookName}}' verrà eliminata definitivamente.",
+        "warning": "Questa azione non può essere annullata.",
+        "confirm_button": "Sì, elimina",
         "cancel_button": "Annulla"
       },
       "default_language": "Lingua predefinita"


### PR DESCRIPTION
Changes:

- Remove `styled` from `DeleteWorkbookDialog.tsx`
- Update these files using it (`FileMenu.tsx`, `WorkbookList.tsx`, `MobileMenu.tsx`)
- Update all translation files
  - Copy in the confirmation button is shorter now ("Yes, delete workbook" -> "Yes, delete")
  - Text is split in 2 lines to improve readability 
