### PR TITLE
update[app]: remove MUI from `WelcomeDialog.tsx` and `TemplatesDialog.tsx`

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/App.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/App.tsx
@@ -4,7 +4,6 @@ import type { IronCalcHandle } from "@ironcalc/workbook";
 // From IronCalc
 import { IronCalc, IronCalcIcon, init, Model } from "@ironcalc/workbook";
 import "@ironcalc/workbook/style.css";
-import { Modal } from "@mui/material";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FileBar } from "./components/FileBar";
@@ -245,25 +244,19 @@ function App() {
           }}
         />
       )}
-      <Modal
+      <TemplatesDialog
         open={isTemplatesDialogOpen}
         onClose={() => setTemplatesDialogOpen(false)}
-        aria-labelledby="templates-dialog-title"
-        aria-describedby="templates-dialog-description"
-      >
-        <TemplatesDialog
-          onClose={() => setTemplatesDialogOpen(false)}
-          onSelectTemplate={async (fileName) => {
-            const model_bytes = await get_documentation_model(fileName);
-            const locale = loadDefaultLocaleFromStorage();
-            const languageId = getLanguageFromLocale(locale);
-            const importedModel = Model.from_bytes(model_bytes, languageId);
-            saveModelToStorage(importedModel);
-            setModel(importedModel);
-            setTemplatesDialogOpen(false);
-          }}
-        />
-      </Modal>
+        onSelectTemplate={async (fileName) => {
+          const model_bytes = await get_documentation_model(fileName);
+          const locale = loadDefaultLocaleFromStorage();
+          const languageId = getLanguageFromLocale(locale);
+          const importedModel = Model.from_bytes(model_bytes, languageId);
+          saveModelToStorage(importedModel);
+          setModel(importedModel);
+          setTemplatesDialogOpen(false);
+        }}
+      />
     </Wrapper>
   );
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesDialog.tsx
@@ -1,84 +1,84 @@
-import { Dialog, styled } from "@mui/material";
+import { Button, IconButton } from "@ironcalc/workbook";
 import { X } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import TemplatesList, {
-  Cross,
-  DialogContent,
-  DialogFooter,
-  DialogFooterButton,
-} from "./TemplatesList";
+import TemplatesList from "./TemplatesList";
+import { useDialogFocus } from "./useDialogFocus";
+import { useDialogKeyDown } from "./useDialogKeyDown";
+import "./welcome-dialog.css";
 
-function TemplatesDialog(properties: {
+interface TemplatesDialogProperties {
+  open: boolean;
   onClose: () => void;
   onSelectTemplate: (templateId: string) => void;
-}) {
-  const { t } = useTranslation();
-  const [selectedTemplate, setSelectedTemplate] = useState<string>("");
-
-  const handleClose = () => {
-    properties.onClose();
-  };
-
-  const handleTemplateSelect = (templateId: string) => {
-    setSelectedTemplate(templateId);
-  };
-
-  return (
-    <DialogWrapper open={true} onClose={() => {}}>
-      <DialogTemplateHeader>
-        <span style={{ flexGrow: 2, marginLeft: 12 }}>
-          {t("welcome_dialog.templates.choose_template")}
-        </span>
-        <Cross
-          style={{ marginRight: 12 }}
-          onClick={handleClose}
-          title={t("welcome_dialog.close_dialog")}
-          tabIndex={0}
-          onKeyDown={(event) => event.key === "Enter" && properties.onClose()}
-        >
-          <X />
-        </Cross>
-      </DialogTemplateHeader>
-      <DialogContent>
-        <TemplatesList
-          selectedTemplate={selectedTemplate}
-          handleTemplateSelect={handleTemplateSelect}
-        />
-      </DialogContent>
-      <DialogFooter>
-        <DialogFooterButton
-          onClick={() => properties.onSelectTemplate(selectedTemplate)}
-        >
-          {t("welcome_dialog.create_workbook")}
-        </DialogFooterButton>
-      </DialogFooter>
-    </DialogWrapper>
-  );
 }
 
-export const DialogWrapper = styled(Dialog)`
-  font-family: Inter;
-  .MuiDialog-paper {
-    width: 440px;
-    border-radius: 8px;
-    margin: 16px;
-    border: 1px solid #e0e0e0;
-    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.15);
-  }
-  .MuiBackdrop-root {
-    background-color: rgba(0, 0, 0, 0.4);
-  }
-`;
+function TemplatesDialog({
+  open,
+  onClose,
+  onSelectTemplate,
+}: TemplatesDialogProperties) {
+  const { t } = useTranslation();
+  const [selectedTemplate, setSelectedTemplate] = useState<string>("");
+  const { dialogRef, restoreFocus } = useDialogFocus(open);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
-const DialogTemplateHeader = styled("div")`
-  display: flex;
-  align-items: center;
-  border-bottom: 1px solid #e0e0e0;
-  height: 44px;
-  font-size: 14px;
-  font-weight: 500;
-  font-family: Inter;
-`;
+  const handleClose = () => {
+    onClose();
+    restoreFocus();
+  };
+
+  const { onKeyDown } = useDialogKeyDown({
+    focusableElements: [closeButtonRef, confirmButtonRef],
+    onClose: handleClose,
+  });
+
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="app-ic-wd-backdrop" onClick={handleClose} role="none">
+      <div
+        ref={dialogRef}
+        className="app-ic-wd-paper"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+      >
+        <div className="app-ic-wd-template-header">
+          <span className="app-ic-wd-template-header-title">
+            {t("welcome_dialog.templates.choose_template")}
+          </span>
+          <IconButton
+            ref={closeButtonRef}
+            icon={<X />}
+            aria-label={t("welcome_dialog.close_dialog")}
+            onClick={handleClose}
+          />
+        </div>
+        <div className="app-ic-wd-content">
+          <TemplatesList
+            selectedTemplate={selectedTemplate}
+            handleTemplateSelect={setSelectedTemplate}
+          />
+        </div>
+        <div className="app-ic-wd-footer">
+          <Button
+            ref={confirmButtonRef}
+            onClick={() => onSelectTemplate(selectedTemplate)}
+          >
+            {t("welcome_dialog.create_workbook")}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
 
 export default TemplatesDialog;

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesDialog.tsx
@@ -1,6 +1,6 @@
 import { Button, IconButton } from "@ironcalc/workbook";
 import { X } from "lucide-react";
-import { useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import TemplatesList from "./TemplatesList";
@@ -20,14 +20,16 @@ function TemplatesDialog({
   onSelectTemplate,
 }: TemplatesDialogProperties) {
   const { t } = useTranslation();
-  const [selectedTemplate, setSelectedTemplate] = useState<string>("");
-  const { dialogRef, restoreFocus } = useDialogFocus(open);
+  const titleId = useId();
+  const [selectedTemplate, setSelectedTemplate] = useState(
+    "mortgage_calculator",
+  );
+  const { dialogRef } = useDialogFocus(open);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleClose = () => {
     onClose();
-    restoreFocus();
   };
 
   const { onKeyDown } = useDialogKeyDown({
@@ -48,10 +50,11 @@ function TemplatesDialog({
         onKeyDown={onKeyDown}
         role="dialog"
         aria-modal="true"
+        aria-labelledby={titleId}
         tabIndex={-1}
       >
         <div className="app-ic-wd-template-header">
-          <span className="app-ic-wd-template-header-title">
+          <span id={titleId} className="app-ic-wd-template-header-title">
             {t("welcome_dialog.templates.choose_template")}
           </span>
           <IconButton

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesDialog.tsx
@@ -24,7 +24,7 @@ function TemplatesDialog({
   const [selectedTemplate, setSelectedTemplate] = useState(
     "mortgage_calculator",
   );
-  const { dialogRef } = useDialogFocus(open);
+  const dialogRef = useDialogFocus(open);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesList.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesList.tsx
@@ -1,7 +1,7 @@
-import { Dialog, styled } from "@mui/material";
 import { House, TicketsPlane } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import TemplatesListItem from "./TemplatesListItem";
+import "./welcome-dialog.css";
 
 function TemplatesList(props: {
   selectedTemplate: string;
@@ -10,7 +10,7 @@ function TemplatesList(props: {
   const { selectedTemplate, handleTemplateSelect } = props;
   const { t } = useTranslation();
   return (
-    <TemplatesListWrapper>
+    <div className="app-ic-wd-templates-list">
       <TemplatesListItem
         title={t("welcome_dialog.templates.mortgage_calculator")}
         description={t(
@@ -31,80 +31,8 @@ function TemplatesList(props: {
         active={selectedTemplate === "travel_expenses_tracker"}
         onClick={() => handleTemplateSelect("travel_expenses_tracker")}
       />
-    </TemplatesListWrapper>
+    </div>
   );
 }
 
-export const DialogWrapper = styled(Dialog)`
-  font-family: Inter;
-  .MuiDialog-paper {
-    width: 440px;
-    border-radius: 8px;
-    margin: 16px;
-    border: 1px solid #e0e0e0;
-    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.15);
-  }
-  .MuiBackdrop-root {
-    background-color: rgba(0, 0, 0, 0.4);
-  }
-`;
-
-export const Cross = styled("div")`
-  &:hover {
-    background-color: #f5f5f5;
-  }
-  display: flex;
-  border-radius: 4px;
-  min-height: 24px;
-  min-width: 24px;
-  cursor: pointer;
-  align-items: center;
-  justify-content: center;
-  svg {
-    width: 16px;
-    height: 16px;
-    stroke-width: 1.5;
-  }
-`;
-
-export const DialogContent = styled("div")`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  max-height: 300px;
-  overflow: hidden;
-  overflow-y: auto;
-`;
-
-export const TemplatesListWrapper = styled("div")`
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-`;
-
-export const DialogFooter = styled("div")`
-  border-top: 1px solid #e0e0e0;
-  padding: 16px;
-`;
-
-export const DialogFooterButton = styled("button")`
-  background-color: #f2994a;
-  border: none;
-  color: #fff;
-  padding: 12px;
-  border-radius: 4px;
-  cursor: pointer;
-  width: 100%;
-  font-size: 12px;
-  font-family: Inter;
-  &:hover {
-    background-color: #d68742;
-  }
-  &:active {
-    background-color: #d68742;
-  }
-`;
-
-// export default TemplatesDialog;
 export default TemplatesList;

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesListItem.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesListItem.tsx
@@ -1,5 +1,5 @@
-import { styled } from "@mui/material";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import "./welcome-dialog.css";
 
 interface TemplatesListItemProps {
   title: string;
@@ -19,89 +19,30 @@ function TemplatesListItem({
   onClick,
 }: TemplatesListItemProps) {
   return (
-    <ListItemWrapper active={active} iconColor={iconColor} onClick={onClick}>
-      <StyledIcon iconColor={iconColor}>{icon}</StyledIcon>
-      <TemplatesListItemTitle>
-        <Title>{title}</Title>
-        <Subtitle>{description}</Subtitle>
-      </TemplatesListItemTitle>
-      <RadioButton active={active}>
-        <RadioButtonDot />
-      </RadioButton>
-    </ListItemWrapper>
+    <button
+      type="button"
+      className={`app-ic-wd-list-item${active ? " app-ic-wd-list-item--active" : ""}`}
+      style={
+        {
+          "--item-color": iconColor,
+          "--item-color-alpha": `${iconColor}24`,
+        } as CSSProperties
+      }
+      aria-pressed={active}
+      onClick={onClick}
+    >
+      <div className="app-ic-wd-list-item-icon">{icon}</div>
+      <div className="app-ic-wd-list-item-body">
+        <div className="app-ic-wd-list-item-title">{title}</div>
+        <div className="app-ic-wd-list-item-description">{description}</div>
+      </div>
+      <div
+        className={`app-ic-wd-radio${active ? " app-ic-wd-radio--active" : ""}`}
+      >
+        <div className="app-ic-wd-radio-dot" />
+      </div>
+    </button>
   );
 }
-
-const ListItemWrapper = styled("div")<{ active?: boolean; iconColor?: string }>`
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 8px;
-  font-size: 12px;
-  color: #424242;
-  border: 1px solid ${(props) => (props.active ? props.iconColor || "#424242" : "rgba(224, 224, 224, 0.60)")};
-  background-color: #FFFFFF;
-  padding: 16px;
-  border-radius: 8px;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
-  cursor: pointer;
-  outline: ${(props) => (props.active ? `4px solid ${props.iconColor || "#424242"}24` : "none")};
-  transition: border 0.1s ease-in-out;
-  user-select: none;
-  &:hover {
-    border: 1px solid ${(props) => props.iconColor};
-    transition: border 0.1s ease-in-out;
-  }
-`;
-
-const TemplatesListItemTitle = styled("div")`
-  display: flex;
-  flex-direction: column;
-  color: #424242;
-  width: 100%;
-  gap: 2px;
-`;
-
-const Title = styled("div")`
-  font-weight: 600;
-  color: #424242;
-  line-height: 16px;
-`;
-
-const Subtitle = styled("div")`
-  color: #757575;
-`;
-
-const StyledIcon = styled("div")<{ iconColor?: string }>`
-  display: flex;
-  align-items: center;
-  margin-top: -1px;
-  svg {
-    width: 18px;
-    height: 100%;
-    color: ${(props) => props.iconColor || "#424242"};
-  }
-`;
-
-const RadioButton = styled("div")<{ active?: boolean }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  min-width: 16px;
-  height: 16px;
-  border-radius: 16px;
-  margin-top: -4px;
-  margin-right: -4px;
-  background-color: ${(props) => (props.active ? "#F2994A" : "#FFFFFF")};
-  border: ${(props) => (props.active ? "none" : "1px solid #E0E0E0")};
-`;
-
-const RadioButtonDot = styled("div")`
-  width: 6px;
-  height: 6px;
-  border-radius: 6px;
-  background-color: #FFF;
-`;
 
 export default TemplatesListItem;

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/WelcomeDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/WelcomeDialog.tsx
@@ -38,7 +38,7 @@ function WelcomeDialog({
   const { t } = useTranslation();
   const titleId = useId();
   const [selectedTemplate, setSelectedTemplate] = useState<string>("blank");
-  const { dialogRef } = useDialogFocus(true);
+  const dialogRef = useDialogFocus(true);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/WelcomeDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/WelcomeDialog.tsx
@@ -1,138 +1,118 @@
-import { IronCalcIconWhite as IronCalcIcon } from "@ironcalc/workbook";
-import { styled } from "@mui/material";
+import {
+  Button,
+  IconButton,
+  IronCalcIconWhite as IronCalcIcon,
+} from "@ironcalc/workbook";
 import { Table, X } from "lucide-react";
-import { useState } from "react";
+import type { ReactNode } from "react";
+import { useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import TemplatesList, {
-  Cross,
-  DialogContent,
-  DialogFooter,
-  DialogFooterButton,
-  DialogWrapper,
-  TemplatesListWrapper,
-} from "./TemplatesList";
+import TemplatesList from "./TemplatesList";
 import TemplatesListItem from "./TemplatesListItem";
+import { useDialogFocus } from "./useDialogFocus";
+import { useDialogKeyDown } from "./useDialogKeyDown";
+import "./welcome-dialog.css";
 
-function WelcomeDialog(properties: {
+export function DialogHeaderLogoWrapper({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={`app-ic-wd-header-logo${className ? ` ${className}` : ""}`}>
+      {children}
+    </div>
+  );
+}
+
+function WelcomeDialog({
+  onClose,
+  onSelectTemplate,
+}: {
   onClose: () => void;
   onSelectTemplate: (templateId: string) => void;
 }) {
   const { t } = useTranslation();
   const [selectedTemplate, setSelectedTemplate] = useState<string>("blank");
+  const { dialogRef, restoreFocus } = useDialogFocus(true);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleClose = () => {
-    properties.onClose();
+    onClose();
+    restoreFocus();
   };
 
-  const handleTemplateSelect = (templateId: string) => {
-    setSelectedTemplate(templateId);
-  };
+  const { onKeyDown } = useDialogKeyDown({
+    focusableElements: [closeButtonRef, confirmButtonRef],
+    onClose: handleClose,
+  });
 
-  return (
-    <DialogWrapper open={true} onClose={() => {}}>
-      <DialogWelcomeHeader>
-        <DialogHeaderTitleWrapper>
-          <DialogHeaderLogoWrapper>
-            <IronCalcIcon />
-          </DialogHeaderLogoWrapper>
-          <DialogHeaderTitle>{t("welcome_dialog.title")}</DialogHeaderTitle>
-          <DialogHeaderTitleSubtitle>
-            {t("welcome_dialog.subtitle")}
-          </DialogHeaderTitleSubtitle>
-        </DialogHeaderTitleWrapper>
-        <Cross
-          onClick={handleClose}
-          title={t("welcome_dialog.close_dialog")}
-          tabIndex={0}
-          onKeyDown={(event) => event.key === "Enter" && properties.onClose()}
-        >
-          <X />
-        </Cross>
-      </DialogWelcomeHeader>
-      <DialogContent>
-        <ListTitle>{t("welcome_dialog.new")}</ListTitle>
-        <TemplatesListWrapper>
-          <TemplatesListItem
-            title={t("welcome_dialog.blank_workbook")}
-            description={t("welcome_dialog.blank_workbook_description")}
-            icon={<Table />}
-            iconColor="#F2994A"
-            active={selectedTemplate === "blank"}
-            onClick={() => handleTemplateSelect("blank")}
+  return createPortal(
+    <div className="app-ic-wd-backdrop" onClick={handleClose} role="none">
+      <div
+        ref={dialogRef}
+        className="app-ic-wd-paper"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+      >
+        <div className="app-ic-wd-welcome-header">
+          <div className="app-ic-wd-header-body">
+            <DialogHeaderLogoWrapper>
+              <IronCalcIcon />
+            </DialogHeaderLogoWrapper>
+            <span className="app-ic-wd-header-title">
+              {t("welcome_dialog.title")}
+            </span>
+            <span className="app-ic-wd-header-subtitle">
+              {t("welcome_dialog.subtitle")}
+            </span>
+          </div>
+          <IconButton
+            ref={closeButtonRef}
+            icon={<X />}
+            aria-label={t("welcome_dialog.close_dialog")}
+            onClick={handleClose}
           />
-        </TemplatesListWrapper>
-        <ListTitle>{t("welcome_dialog.templates.templates")}</ListTitle>
-        <TemplatesList
-          selectedTemplate={selectedTemplate}
-          handleTemplateSelect={handleTemplateSelect}
-        />
-      </DialogContent>
-      <DialogFooter>
-        <DialogFooterButton
-          onClick={() => properties.onSelectTemplate(selectedTemplate)}
-        >
-          {t("welcome_dialog.create_workbook")}
-        </DialogFooterButton>
-      </DialogFooter>
-    </DialogWrapper>
+        </div>
+        <div className="app-ic-wd-content">
+          <div className="app-ic-wd-list-title">{t("welcome_dialog.new")}</div>
+          <div className="app-ic-wd-templates-list">
+            <TemplatesListItem
+              title={t("welcome_dialog.blank_workbook")}
+              description={t("welcome_dialog.blank_workbook_description")}
+              icon={<Table />}
+              iconColor="#F2994A"
+              active={selectedTemplate === "blank"}
+              onClick={() => setSelectedTemplate("blank")}
+            />
+          </div>
+          <div className="app-ic-wd-list-title">
+            {t("welcome_dialog.templates.templates")}
+          </div>
+          <TemplatesList
+            selectedTemplate={selectedTemplate}
+            handleTemplateSelect={setSelectedTemplate}
+          />
+        </div>
+        <div className="app-ic-wd-footer">
+          <Button
+            ref={confirmButtonRef}
+            onClick={() => onSelectTemplate(selectedTemplate)}
+          >
+            {t("welcome_dialog.create_workbook")}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
   );
 }
-
-const DialogWelcomeHeader = styled("div")`
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  border-bottom: 1px solid #e0e0e0;
-  padding: 16px;
-  font-family: Inter;
-`;
-
-const DialogHeaderTitleWrapper = styled("span")`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  font-size: 14px;
-  font-weight: 500;
-  padding: 4px 0px;
-  gap: 4px;
-  width: 100%;
-`;
-
-const DialogHeaderTitle = styled("span")`
-  font-weight: 700;
-`;
-
-const DialogHeaderTitleSubtitle = styled("span")`
-  font-size: 12px;
-  color: #757575;
-`;
-
-export const DialogHeaderLogoWrapper = styled("div")`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  max-width: 20px;
-  max-height: 20px;
-  background-color: #f2994a;
-  padding: 10px;
-  margin-bottom: 12px;
-  border-radius: 6px;
-  border: 1px solid rgba(0, 0, 0, 0.04);
-  box-shadow: rgba(0, 0, 0, 0.07) 0px 1px 2px;
-  transform: rotate(-8deg);
-  user-select: none;
-
-  svg {
-    width: 18px;
-    height: 18px;
-  }
-`;
-
-const ListTitle = styled("div")`
-  font-size: 12px;
-  font-weight: 600;
-  color: #424242;
-`;
 
 export default WelcomeDialog;

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/WelcomeDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/WelcomeDialog.tsx
@@ -5,7 +5,7 @@ import {
 } from "@ironcalc/workbook";
 import { Table, X } from "lucide-react";
 import type { ReactNode } from "react";
-import { useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import TemplatesList from "./TemplatesList";
@@ -36,14 +36,14 @@ function WelcomeDialog({
   onSelectTemplate: (templateId: string) => void;
 }) {
   const { t } = useTranslation();
+  const titleId = useId();
   const [selectedTemplate, setSelectedTemplate] = useState<string>("blank");
-  const { dialogRef, restoreFocus } = useDialogFocus(true);
+  const { dialogRef } = useDialogFocus(true);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleClose = () => {
     onClose();
-    restoreFocus();
   };
 
   const { onKeyDown } = useDialogKeyDown({
@@ -60,6 +60,7 @@ function WelcomeDialog({
         onKeyDown={onKeyDown}
         role="dialog"
         aria-modal="true"
+        aria-labelledby={titleId}
         tabIndex={-1}
       >
         <div className="app-ic-wd-welcome-header">
@@ -67,7 +68,7 @@ function WelcomeDialog({
             <DialogHeaderLogoWrapper>
               <IronCalcIcon />
             </DialogHeaderLogoWrapper>
-            <span className="app-ic-wd-header-title">
+            <span id={titleId} className="app-ic-wd-header-title">
               {t("welcome_dialog.title")}
             </span>
             <span className="app-ic-wd-header-subtitle">

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/useDialogFocus.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/useDialogFocus.ts
@@ -19,5 +19,5 @@ export function useDialogFocus(open: boolean) {
     };
   }, [open]);
 
-  return { dialogRef };
+  return dialogRef;
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/useDialogFocus.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/useDialogFocus.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+
+export function useDialogFocus(open: boolean) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    requestAnimationFrame(() => {
+      if (!dialogRef.current?.contains(document.activeElement)) {
+        dialogRef.current?.focus();
+      }
+    });
+  }, [open]);
+
+  function restoreFocus(): void {
+    previousFocusRef.current?.focus();
+  }
+
+  return { dialogRef, restoreFocus };
+}

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/useDialogFocus.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/useDialogFocus.ts
@@ -14,11 +14,10 @@ export function useDialogFocus(open: boolean) {
         dialogRef.current?.focus();
       }
     });
+    return () => {
+      previousFocusRef.current?.focus();
+    };
   }, [open]);
 
-  function restoreFocus(): void {
-    previousFocusRef.current?.focus();
-  }
-
-  return { dialogRef, restoreFocus };
+  return { dialogRef };
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/useDialogKeyDown.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/useDialogKeyDown.ts
@@ -1,0 +1,39 @@
+import { type KeyboardEvent, type RefObject, useCallback } from "react";
+
+interface Options {
+  focusableElements: RefObject<HTMLElement | null>[];
+  onClose: () => void;
+}
+
+export function useDialogKeyDown({ focusableElements, onClose }: Options) {
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (event.key === "Tab") {
+        const firstEl = focusableElements[0]?.current;
+        const lastEl = focusableElements[focusableElements.length - 1]?.current;
+        if (!firstEl || !lastEl) {
+          return;
+        }
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstEl) {
+            event.preventDefault();
+            lastEl.focus();
+          }
+        } else if (document.activeElement === lastEl) {
+          event.preventDefault();
+          firstEl.focus();
+        }
+      }
+    },
+    [focusableElements, onClose],
+  );
+
+  return { onKeyDown };
+}

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/welcome-dialog.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/welcome-dialog.css
@@ -1,0 +1,223 @@
+/* Shared dialog shell */
+
+.app-ic-wd-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: color-mix(in srgb, black 40%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.app-ic-wd-paper {
+  width: 440px;
+  max-width: calc(100% - 32px);
+  max-height: calc(100vh - 32px);
+  display: flex;
+  flex-direction: column;
+  border-radius: 8px;
+  border: 1px solid var(--palette-grey-300);
+  box-shadow: var(--shadow-sm);
+  background: var(--palette-common-white);
+  font-family: var(--typography-font-family);
+  font-size: var(--typography-font-size);
+}
+
+/* Scrollable content */
+
+.app-ic-wd-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 4px 12px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+/* Footer */
+
+.app-ic-wd-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px 12px;
+}
+
+@media (max-width: 600px) {
+  .app-ic-wd-footer button {
+    width: 100%;
+  }
+}
+
+/* Templates list */
+
+.app-ic-wd-templates-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.app-ic-wd-list-title {
+  font-size: var(--typography-font-size);
+  font-weight: 600;
+  color: var(--palette-grey-800);
+}
+
+/* List item — uses --item-color and --item-color-alpha for dynamic per-item colors */
+
+.app-ic-wd-list-item {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  text-align: left;
+  background: none;
+  gap: 8px;
+  font-size: var(--typography-font-size);
+  color: var(--palette-grey-800);
+  border: 1px solid rgba(224, 224, 224, 0.6);
+  background-color: var(--palette-common-white);
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  outline: none;
+  transition: border 0.1s ease-in-out;
+  user-select: none;
+}
+
+.app-ic-wd-list-item:focus-visible {
+  outline: 2px solid var(--palette-primary-main);
+  outline-offset: 2px;
+}
+
+.app-ic-wd-list-item:hover {
+  border-color: var(--item-color);
+}
+
+.app-ic-wd-list-item--active {
+  border-color: var(--item-color);
+  outline: 4px solid var(--item-color-alpha);
+}
+
+.app-ic-wd-list-item-icon {
+  display: flex;
+  align-items: center;
+  margin-top: -1px;
+}
+
+.app-ic-wd-list-item-icon svg {
+  width: 18px;
+  height: 100%;
+  color: var(--item-color);
+}
+
+.app-ic-wd-list-item-body {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 2px;
+}
+
+.app-ic-wd-list-item-title {
+  font-weight: 600;
+  line-height: 16px;
+}
+
+.app-ic-wd-list-item-description {
+  color: var(--palette-grey-600);
+}
+
+/* Radio indicator */
+
+.app-ic-wd-radio {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  margin-top: -4px;
+  margin-right: -4px;
+  background-color: var(--palette-common-white);
+  border: 1px solid var(--palette-grey-300);
+}
+
+.app-ic-wd-radio--active {
+  background-color: var(--palette-primary-main);
+  border: none;
+}
+
+.app-ic-wd-radio-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--palette-common-white);
+}
+
+/* TemplatesDialog header */
+
+.app-ic-wd-template-header {
+  display: flex;
+  align-items: center;
+  height: 44px;
+  padding: 0 12px;
+  gap: 8px;
+}
+
+.app-ic-wd-template-header-title {
+  flex: 1;
+}
+
+/* WelcomeDialog header */
+
+.app-ic-wd-welcome-header {
+  display: flex;
+  align-items: flex-start;
+  padding: 12px;
+}
+
+.app-ic-wd-header-body {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 4px 0;
+  gap: 4px;
+  width: 100%;
+}
+
+.app-ic-wd-header-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 20px;
+  max-height: 20px;
+  background-color: var(--palette-primary-main);
+  padding: 10px;
+  margin-bottom: 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  box-shadow: rgba(0, 0, 0, 0.07) 0px 1px 2px;
+  transform: rotate(-8deg);
+  user-select: none;
+}
+
+.app-ic-wd-header-logo svg {
+  width: 18px;
+  height: 18px;
+}
+
+.app-ic-wd-template-header-title,
+.app-ic-wd-header-title {
+  min-width: 0;
+  font-size: calc(var(--typography-font-size) + 1px);
+  font-weight: 600;
+  color: var(--palette-grey-900);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-ic-wd-header-subtitle {
+  font-size: var(--typography-font-size);
+  color: var(--palette-grey-600);
+}


### PR DESCRIPTION
In this PR we have:
- Removed MUI from `WelcomeDialog.tsx` and `TemplatesDialog.tsx`
- Also from `TemplatesList.tsx` and `TemplatesListItem.tsx`, used in both dialogs
- Added all css in `welcome-dialog.css` (shared for all files)
- Isolated hooks on `useDialogFocus` and `useDialogKeyDown`
- Made all items focusable
- Updated `App.tsx` with the new files