### PR TITLE
update[app]: allow bulk deletion of workbooks

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerContent.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerContent.tsx
@@ -31,7 +31,9 @@ function DrawerContent({
           onCheckboxClick={onCheckboxClick}
         />
       </div>
-      <div className="app-ic-drawer-alert-wrapper">
+      <div
+        className={`app-ic-drawer-alert-wrapper${checkedUuids.size > 0 ? " app-ic-drawer-alert-wrapper--selection" : ""}`}
+      >
         <LocalStorageAlert />
       </div>
     </>

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerContent.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerContent.tsx
@@ -1,4 +1,3 @@
-import type React from "react";
 import LocalStorageAlert from "./LocalStorageAlert";
 import WorkbookList from "./WorkbookList";
 
@@ -7,7 +6,11 @@ interface DrawerContentProps {
   onDelete: (uuid: string) => void;
   searchQuery: string;
   checkedUuids: Set<string>;
-  setCheckedUuids: React.Dispatch<React.SetStateAction<Set<string>>>;
+  onCheckboxClick: (
+    uuid: string,
+    shiftKey: boolean,
+    orderedUuids: string[],
+  ) => void;
 }
 
 function DrawerContent({
@@ -15,7 +18,7 @@ function DrawerContent({
   onDelete,
   searchQuery,
   checkedUuids,
-  setCheckedUuids,
+  onCheckboxClick,
 }: DrawerContentProps) {
   return (
     <>
@@ -25,7 +28,7 @@ function DrawerContent({
           onDelete={onDelete}
           searchQuery={searchQuery}
           checkedUuids={checkedUuids}
-          setCheckedUuids={setCheckedUuids}
+          onCheckboxClick={onCheckboxClick}
         />
       </div>
       <div className="app-ic-drawer-alert-wrapper">

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerContent.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerContent.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import LocalStorageAlert from "./LocalStorageAlert";
 import WorkbookList from "./WorkbookList";
 
@@ -5,12 +6,16 @@ interface DrawerContentProps {
   setModel: (key: string) => void;
   onDelete: (uuid: string) => void;
   searchQuery: string;
+  checkedUuids: Set<string>;
+  setCheckedUuids: React.Dispatch<React.SetStateAction<Set<string>>>;
 }
 
 function DrawerContent({
   setModel,
   onDelete,
   searchQuery,
+  checkedUuids,
+  setCheckedUuids,
 }: DrawerContentProps) {
   return (
     <>
@@ -19,6 +24,8 @@ function DrawerContent({
           setModel={setModel}
           onDelete={onDelete}
           searchQuery={searchQuery}
+          checkedUuids={checkedUuids}
+          setCheckedUuids={setCheckedUuids}
         />
       </div>
       <div className="app-ic-drawer-alert-wrapper">

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerFooter.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerFooter.tsx
@@ -1,8 +1,7 @@
-import { Confirm } from "@ironcalc/workbook";
+import { Button, Confirm } from "@ironcalc/workbook";
 import { BookOpen, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button } from "../../../../../IronCalc/src/components/Button/Button";
 
 interface DrawerFooterProps {
   checkedCount: number;

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerFooter.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerFooter.tsx
@@ -1,8 +1,62 @@
-import { BookOpen } from "lucide-react";
+import { Confirm } from "@ironcalc/workbook";
+import { BookOpen, Trash2 } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Button } from "../../../../../IronCalc/src/components/Button/Button";
 
-function DrawerFooter() {
+interface DrawerFooterProps {
+  checkedCount: number;
+  onDeleteChecked: () => void;
+  onCancelChecked: () => void;
+}
+
+function DrawerFooter({
+  checkedCount,
+  onDeleteChecked,
+  onCancelChecked,
+}: DrawerFooterProps) {
   const { t } = useTranslation();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  if (checkedCount > 0) {
+    return (
+      <>
+        <div className="app-ic-drawer-footer app-ic-drawer-footer--selection">
+          <Button
+            variant="destructive"
+            startIcon={<Trash2 />}
+            style={{ width: "100%" }}
+            onClick={() => setIsDeleteDialogOpen(true)}
+          >
+            {t("left_drawer.delete_workbooks", { count: checkedCount })}
+          </Button>
+          <Button
+            variant="secondary"
+            style={{ width: "100%" }}
+            onClick={onCancelChecked}
+          >
+            {t("left_drawer.cancel")}
+          </Button>
+        </div>
+        <Confirm
+          open={isDeleteDialogOpen}
+          onClose={() => setIsDeleteDialogOpen(false)}
+          onConfirm={() => {
+            setIsDeleteDialogOpen(false);
+            onDeleteChecked();
+          }}
+          title={t("file_bar.file_menu.delete_workbook.title")}
+          message={t("left_drawer.bulk_delete_message", {
+            count: checkedCount,
+          })}
+          confirmLabel={t("file_bar.file_menu.delete_workbook.confirm_button")}
+          cancelLabel={t("file_bar.file_menu.delete_workbook.cancel_button")}
+          variant="destructive"
+        />
+      </>
+    );
+  }
+
   return (
     <div className="app-ic-drawer-footer">
       <a

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerFooter.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/DrawerFooter.tsx
@@ -25,16 +25,11 @@ function DrawerFooter({
           <Button
             variant="destructive"
             startIcon={<Trash2 />}
-            style={{ width: "100%" }}
             onClick={() => setIsDeleteDialogOpen(true)}
           >
             {t("left_drawer.delete_workbooks", { count: checkedCount })}
           </Button>
-          <Button
-            variant="secondary"
-            style={{ width: "100%" }}
-            onClick={onCancelChecked}
-          >
+          <Button variant="secondary" onClick={onCancelChecked}>
             {t("left_drawer.cancel")}
           </Button>
         </div>

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/LeftDrawer.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import DrawerContent from "./DrawerContent";
 import DrawerFooter from "./DrawerFooter";
 import DrawerHeader from "./DrawerHeader";
+import { useWorkbookSelection } from "./useWorkbookSelection";
 import "./left-drawer.css";
 
 interface LeftDrawerProps {
@@ -14,18 +15,12 @@ interface LeftDrawerProps {
 
 function LeftDrawer({ open, newModel, setModel, onDelete }: LeftDrawerProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [checkedUuids, setCheckedUuids] = useState<Set<string>>(new Set());
-
-  const handleDeleteChecked = () => {
-    for (const uuid of checkedUuids) {
-      onDelete(uuid);
-    }
-    setCheckedUuids(new Set());
-  };
-
-  const handleCancelChecked = () => {
-    setCheckedUuids(new Set());
-  };
+  const {
+    checkedUuids,
+    handleCheckboxClick,
+    handleDeleteChecked,
+    handleCancelChecked,
+  } = useWorkbookSelection({ onDelete });
 
   return (
     <div className={`app-ic-drawer${open ? " app-ic-drawer--open" : ""}`}>
@@ -40,7 +35,7 @@ function LeftDrawer({ open, newModel, setModel, onDelete }: LeftDrawerProps) {
           onDelete={onDelete}
           searchQuery={searchQuery}
           checkedUuids={checkedUuids}
-          setCheckedUuids={setCheckedUuids}
+          onCheckboxClick={handleCheckboxClick}
         />
         <DrawerFooter
           checkedCount={checkedUuids.size}

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/LeftDrawer.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/LeftDrawer.tsx
@@ -14,6 +14,18 @@ interface LeftDrawerProps {
 
 function LeftDrawer({ open, newModel, setModel, onDelete }: LeftDrawerProps) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [checkedUuids, setCheckedUuids] = useState<Set<string>>(new Set());
+
+  const handleDeleteChecked = () => {
+    for (const uuid of checkedUuids) {
+      onDelete(uuid);
+    }
+    setCheckedUuids(new Set());
+  };
+
+  const handleCancelChecked = () => {
+    setCheckedUuids(new Set());
+  };
 
   return (
     <div className={`app-ic-drawer${open ? " app-ic-drawer--open" : ""}`}>
@@ -27,8 +39,14 @@ function LeftDrawer({ open, newModel, setModel, onDelete }: LeftDrawerProps) {
           setModel={setModel}
           onDelete={onDelete}
           searchQuery={searchQuery}
+          checkedUuids={checkedUuids}
+          setCheckedUuids={setCheckedUuids}
         />
-        <DrawerFooter />
+        <DrawerFooter
+          checkedCount={checkedUuids.size}
+          onDeleteChecked={handleDeleteChecked}
+          onCancelChecked={handleCancelChecked}
+        />
       </div>
     </div>
   );

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
@@ -102,30 +102,33 @@ function WorkbookList({
         key={uuid}
         className={`app-ic-drawer-workbook-item${uuid === selectedUuid ? " app-ic-drawer-workbook-item--selected" : ""}`}
       >
+        <span className="app-ic-drawer-workbook-icon">
+          <span className="app-ic-drawer-workbook-icon--default">
+            <Table2 />
+          </span>
+          <span className="app-ic-drawer-workbook-icon--checkbox-wrapper">
+            <input
+              type="checkbox"
+              className="app-ic-drawer-workbook-icon--checkbox"
+              aria-label={t("left_drawer.select_workbook", {
+                name: modelsMetadata[uuid].name,
+              })}
+              checked={checkedUuids.has(uuid)}
+              onChange={(e) => {
+                const isShift =
+                  e.nativeEvent instanceof MouseEvent && e.nativeEvent.shiftKey;
+                onCheckboxClick(uuid, isShift, getOrderedUuids());
+              }}
+              onClick={(e) => e.stopPropagation()}
+            />
+          </span>
+        </span>
         <button
           type="button"
           className="app-ic-drawer-workbook-select"
           disabled={isMenuOpen}
           onClick={() => setModel(uuid)}
         >
-          <span className="app-ic-drawer-workbook-icon">
-            <span className="app-ic-drawer-workbook-icon--default">
-              <Table2 />
-            </span>
-            <span className="app-ic-drawer-workbook-icon--checkbox-wrapper">
-              <input
-                type="checkbox"
-                className="app-ic-drawer-workbook-icon--checkbox"
-                tabIndex={-1}
-                checked={checkedUuids.has(uuid)}
-                onChange={() => {}}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCheckboxClick(uuid, e.shiftKey, getOrderedUuids());
-                }}
-              />
-            </span>
-          </span>
           <span className="app-ic-drawer-workbook-name">
             {modelsMetadata[uuid].name}
           </span>

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
@@ -14,9 +14,17 @@ interface WorkbookListProps {
   setModel: (key: string) => void;
   onDelete: (uuid: string) => void;
   searchQuery: string;
+  checkedUuids: Set<string>;
+  setCheckedUuids: React.Dispatch<React.SetStateAction<Set<string>>>;
 }
 
-function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
+function WorkbookList({
+  setModel,
+  onDelete,
+  searchQuery,
+  checkedUuids,
+  setCheckedUuids,
+}: WorkbookListProps) {
   const { t } = useTranslation();
   const {
     menuAnchorEl,
@@ -34,6 +42,8 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
     handlePinToggle,
     handleDuplicate,
   } = useWorkbookMenu({ setModel, onDelete });
+
+  const hasAnyChecked = checkedUuids.size > 0;
 
   const selectedUuid = getSelectedUuid();
   const modelsMetadata = getModelsMetadata();
@@ -81,7 +91,26 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
           onClick={() => setModel(uuid)}
         >
           <span className="app-ic-drawer-workbook-icon">
-            <Table2 />
+            <span className="app-ic-drawer-workbook-icon--default">
+              <Table2 />
+            </span>
+            <span className="app-ic-drawer-workbook-icon--checkbox-wrapper">
+              <input
+                type="checkbox"
+                className="app-ic-drawer-workbook-icon--checkbox"
+                tabIndex={-1}
+                checked={checkedUuids.has(uuid)}
+                onChange={() =>
+                  setCheckedUuids((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(uuid)) next.delete(uuid);
+                    else next.add(uuid);
+                    return next;
+                  })
+                }
+                onClick={(e) => e.stopPropagation()}
+              />
+            </span>
           </span>
           <span className="app-ic-drawer-workbook-name">
             {modelsMetadata[uuid].name}
@@ -141,7 +170,13 @@ function WorkbookList({ setModel, onDelete, searchQuery }: WorkbookListProps) {
 
   return (
     <>
-      {content}
+      <div
+        className={
+          hasAnyChecked ? "app-ic-drawer-workbook-list--has-checked" : undefined
+        }
+      >
+        {content}
+      </div>
 
       {menuAnchorEl && selectedWorkbookUuid && (
         <WorkbookMenu

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/WorkbookList.tsx
@@ -15,7 +15,11 @@ interface WorkbookListProps {
   onDelete: (uuid: string) => void;
   searchQuery: string;
   checkedUuids: Set<string>;
-  setCheckedUuids: React.Dispatch<React.SetStateAction<Set<string>>>;
+  onCheckboxClick: (
+    uuid: string,
+    shiftKey: boolean,
+    orderedUuids: string[],
+  ) => void;
 }
 
 function WorkbookList({
@@ -23,7 +27,7 @@ function WorkbookList({
   onDelete,
   searchQuery,
   checkedUuids,
-  setCheckedUuids,
+  onCheckboxClick,
 }: WorkbookListProps) {
   const { t } = useTranslation();
   const {
@@ -77,6 +81,20 @@ function WorkbookList({
     };
   };
 
+  const getOrderedUuids = (): string[] => {
+    if (isSearchMode) {
+      return Object.keys(modelsMetadata)
+        .sort(
+          (a, b) => modelsMetadata[b].createdAt - modelsMetadata[a].createdAt,
+        )
+        .filter((id) =>
+          modelsMetadata[id].name.toLowerCase().includes(normalizedQuery),
+        );
+    }
+    const { pinned, today, thisMonth, older } = groupWorkbooks(modelsMetadata);
+    return [...pinned, ...today, ...thisMonth, ...older];
+  };
+
   const renderWorkbookItem = (uuid: string) => {
     const isThisMenuOpen = isMenuOpen && selectedWorkbookUuid === uuid;
     return (
@@ -100,15 +118,11 @@ function WorkbookList({
                 className="app-ic-drawer-workbook-icon--checkbox"
                 tabIndex={-1}
                 checked={checkedUuids.has(uuid)}
-                onChange={() =>
-                  setCheckedUuids((prev) => {
-                    const next = new Set(prev);
-                    if (next.has(uuid)) next.delete(uuid);
-                    else next.add(uuid);
-                    return next;
-                  })
-                }
-                onClick={(e) => e.stopPropagation()}
+                onChange={() => {}}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCheckboxClick(uuid, e.shiftKey, getOrderedUuids());
+                }}
               />
             </span>
           </span>

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
@@ -120,6 +120,7 @@
 .app-ic-drawer-footer--selection {
   flex-direction: column;
   gap: 4px;
+  align-items: stretch;
 }
 
 .app-ic-drawer-footer-link svg {
@@ -246,6 +247,11 @@
   left: 0;
   right: 0;
   padding: 12px;
+  transition: bottom 0.2s ease;
+}
+
+.app-ic-drawer-alert-wrapper--selection {
+  bottom: 84px;
 }
 
 /* Workbook list */
@@ -339,6 +345,12 @@
   background: transparent;
   flex-shrink: 0;
   position: relative;
+}
+
+.app-ic-drawer-workbook-icon--checkbox:focus {
+  outline: 1px solid
+    color-mix(in srgb, var(--palette-common-black) 8%, transparent);
+  outline-offset: 1px;
 }
 
 .app-ic-drawer-workbook-icon--checkbox:checked {

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
@@ -117,6 +117,11 @@
   background-color: var(--palette-grey-300);
 }
 
+.app-ic-drawer-footer--selection {
+  flex-direction: column;
+  gap: 4px;
+}
+
 .app-ic-drawer-footer-link svg {
   width: 16px;
   height: 16px;
@@ -308,6 +313,71 @@
   height: 16px;
 }
 
+.app-ic-drawer-workbook-icon--default {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.app-ic-drawer-workbook-icon--checkbox-wrapper {
+  display: none;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.app-ic-drawer-workbook-icon--checkbox {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  cursor: pointer;
+  border: 1.5px solid var(--palette-grey-500);
+  border-radius: 4px;
+  background: transparent;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.app-ic-drawer-workbook-icon--checkbox:checked {
+  background: var(--palette-common-black);
+  border-color: var(--palette-common-black);
+}
+
+.app-ic-drawer-workbook-icon--checkbox:checked::after {
+  content: "";
+  position: absolute;
+  left: 3px;
+  top: 1px;
+  width: 3px;
+  height: 6px;
+  border: 2px solid var(--palette-common-white);
+  border-top: none;
+  border-left: none;
+  transform: rotate(45deg);
+}
+
+.app-ic-drawer-workbook-icon:hover .app-ic-drawer-workbook-icon--default {
+  display: none;
+}
+
+.app-ic-drawer-workbook-icon:hover
+  .app-ic-drawer-workbook-icon--checkbox-wrapper {
+  display: flex;
+}
+
+.app-ic-drawer-workbook-list--has-checked
+  .app-ic-drawer-workbook-icon--default {
+  display: none;
+}
+
+.app-ic-drawer-workbook-list--has-checked
+  .app-ic-drawer-workbook-icon--checkbox-wrapper {
+  display: flex;
+}
+
 .app-ic-drawer-workbook-name {
   flex: 1;
   overflow: hidden;
@@ -335,7 +405,7 @@
 }
 
 .app-ic-drawer-workbook-item:hover .app-ic-drawer-workbook-ellipsis,
-.app-ic-drawer-workbook-item:focus-within .app-ic-drawer-workbook-ellipsis {
+.app-ic-drawer-workbook-ellipsis:focus {
   width: 24px;
   opacity: 1;
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
@@ -117,6 +117,16 @@
   background-color: var(--palette-grey-300);
 }
 
+.app-ic-drawer-footer-link:focus {
+  outline: none;
+}
+
+.app-ic-drawer-footer-link:focus-visible {
+  outline: 2px solid var(--palette-primary-main);
+  border-radius: 6px;
+  outline-offset: -2px;
+}
+
 .app-ic-drawer-footer--selection {
   flex-direction: column;
   gap: 4px;
@@ -291,7 +301,6 @@
 .app-ic-drawer-workbook-select {
   display: flex;
   align-items: center;
-  gap: 8px;
   flex: 1;
   min-width: 0;
   height: 100%;
@@ -299,7 +308,14 @@
   border: none;
   background: transparent;
   cursor: pointer;
+  outline: none;
   text-align: left;
+}
+
+.app-ic-drawer-workbook-select:focus-visible {
+  outline: 2px solid var(--palette-primary-main);
+  border-radius: 6px;
+  outline-offset: -2px;
 }
 
 .app-ic-drawer-workbook-item:hover,
@@ -311,6 +327,7 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
+  padding-left: 8px;
   color: var(--palette-grey-500);
 }
 
@@ -348,9 +365,12 @@
 }
 
 .app-ic-drawer-workbook-icon--checkbox:focus {
-  outline: 1px solid
-    color-mix(in srgb, var(--palette-common-black) 8%, transparent);
-  outline-offset: 1px;
+  outline: none;
+}
+
+.app-ic-drawer-workbook-icon--checkbox:focus-visible {
+  outline: 2px solid var(--palette-primary-main);
+  outline-offset: 2px;
 }
 
 .app-ic-drawer-workbook-icon--checkbox:checked {
@@ -371,11 +391,15 @@
   transform: rotate(45deg);
 }
 
-.app-ic-drawer-workbook-icon:hover .app-ic-drawer-workbook-icon--default {
+.app-ic-drawer-workbook-icon:hover .app-ic-drawer-workbook-icon--default,
+.app-ic-drawer-workbook-icon:focus-within
+  .app-ic-drawer-workbook-icon--default {
   display: none;
 }
 
 .app-ic-drawer-workbook-icon:hover
+  .app-ic-drawer-workbook-icon--checkbox-wrapper,
+.app-ic-drawer-workbook-icon:focus-within
   .app-ic-drawer-workbook-icon--checkbox-wrapper {
   display: flex;
 }
@@ -412,6 +436,7 @@
   cursor: pointer;
   opacity: 0;
   overflow: hidden;
+  outline: none;
   color: var(--palette-grey-900);
   flex-shrink: 0;
 }
@@ -420,6 +445,11 @@
 .app-ic-drawer-workbook-ellipsis:focus {
   width: 24px;
   opacity: 1;
+}
+
+.app-ic-drawer-workbook-ellipsis:focus-visible {
+  outline: 2px solid var(--palette-primary-main);
+  outline-offset: 2px;
 }
 
 .app-ic-drawer-workbook-ellipsis--open {

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/useWorkbookSelection.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/useWorkbookSelection.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+interface Options {
+  onDelete: (uuid: string) => void;
+}
+
+export function useWorkbookSelection({ onDelete }: Options) {
+  const [checkedUuids, setCheckedUuids] = useState<Set<string>>(new Set());
+  const [lastCheckedUuid, setLastCheckedUuid] = useState<string | null>(null);
+
+  const hasAnyChecked = checkedUuids.size > 0;
+
+  useEffect(() => {
+    if (checkedUuids.size === 0) setLastCheckedUuid(null);
+  }, [checkedUuids.size]);
+
+  const handleCheckboxClick = (
+    uuid: string,
+    shiftKey: boolean,
+    orderedUuids: string[],
+  ) => {
+    if (shiftKey && lastCheckedUuid) {
+      const fromIdx = orderedUuids.indexOf(lastCheckedUuid);
+      const toIdx = orderedUuids.indexOf(uuid);
+      if (fromIdx !== -1 && toIdx !== -1) {
+        const [start, end] =
+          fromIdx < toIdx ? [fromIdx, toIdx] : [toIdx, fromIdx];
+        setCheckedUuids((prev) => {
+          const next = new Set(prev);
+          for (const id of orderedUuids.slice(start, end + 1)) next.add(id);
+          return next;
+        });
+        return;
+      }
+    }
+    setCheckedUuids((prev) => {
+      const next = new Set(prev);
+      if (next.has(uuid)) next.delete(uuid);
+      else next.add(uuid);
+      return next;
+    });
+    setLastCheckedUuid(uuid);
+  };
+
+  const handleDeleteChecked = () => {
+    for (const uuid of checkedUuids) {
+      onDelete(uuid);
+    }
+    setCheckedUuids(new Set());
+  };
+
+  const handleCancelChecked = () => {
+    setCheckedUuids(new Set());
+  };
+
+  return {
+    checkedUuids,
+    hasAnyChecked,
+    handleCheckboxClick,
+    handleDeleteChecked,
+    handleCancelChecked,
+  };
+}

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -52,7 +52,8 @@
     "delete_workbooks_one": "{{count}} Arbeitsmappe löschen",
     "delete_workbooks_other": "{{count}} Arbeitsmappen löschen",
     "bulk_delete_message_one": "Diese Arbeitsmappe wird dauerhaft gelöscht.",
-    "bulk_delete_message_other": "{{count}} Arbeitsmappen werden dauerhaft gelöscht."
+    "bulk_delete_message_other": "{{count}} Arbeitsmappen werden dauerhaft gelöscht.",
+    "select_workbook": "{{name}} auswählen"
   },
   "file_bar": {
     "open_sidebar": "Seitenleiste öffnen",

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -47,7 +47,12 @@
       "subtitle2": "<bold>Laden Sie Ihre XLSX regelmäßig herunter</bold> – zukünftige Versionen können aktuelle Arbeitsmappen möglicherweise nicht öffnen, auch wenn sie geteilt wurden.",
       "close": "Schließen"
     },
-    "documentation": "Dokumentation"
+    "documentation": "Dokumentation",
+    "cancel": "Abbrechen",
+    "delete_workbooks_one": "{{count}} Arbeitsmappe löschen",
+    "delete_workbooks_other": "{{count}} Arbeitsmappen löschen",
+    "bulk_delete_message_one": "Diese Arbeitsmappe wird dauerhaft gelöscht.",
+    "bulk_delete_message_other": "{{count}} Arbeitsmappen werden dauerhaft gelöscht."
   },
   "file_bar": {
     "open_sidebar": "Seitenleiste öffnen",

--- a/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
@@ -47,7 +47,12 @@
       "subtitle2": "<bold>Download your XLSX often</bold> – future versions may not open current workbooks, even if shared.",
       "close": "Close"
     },
-    "documentation": "Documentation"
+    "documentation": "Documentation",
+    "cancel": "Cancel",
+    "delete_workbooks_one": "Delete {{count}} workbook",
+    "delete_workbooks_other": "Delete {{count}} workbooks",
+    "bulk_delete_message_one": "This workbook will be permanently deleted.",
+    "bulk_delete_message_other": "{{count}} workbooks will be permanently deleted."
   },
   "file_bar": {
     "open_sidebar": "Open sidebar",

--- a/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
@@ -52,7 +52,8 @@
     "delete_workbooks_one": "Delete {{count}} workbook",
     "delete_workbooks_other": "Delete {{count}} workbooks",
     "bulk_delete_message_one": "This workbook will be permanently deleted.",
-    "bulk_delete_message_other": "{{count}} workbooks will be permanently deleted."
+    "bulk_delete_message_other": "{{count}} workbooks will be permanently deleted.",
+    "select_workbook": "Select {{name}}"
   },
   "file_bar": {
     "open_sidebar": "Open sidebar",

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -47,7 +47,12 @@
       "subtitle2": "<bold>Descarga tu XLSX con frecuencia</bold> – las versiones futuras podrían no abrir los libros actuales, incluso si se comparten.",
       "close": "Cerrar"
     },
-    "documentation": "Documentación"
+    "documentation": "Documentación",
+    "cancel": "Cancelar",
+    "delete_workbooks_one": "Eliminar {{count}} libro",
+    "delete_workbooks_other": "Eliminar {{count}} libros",
+    "bulk_delete_message_one": "Este libro será eliminado permanentemente.",
+    "bulk_delete_message_other": "{{count}} libros serán eliminados permanentemente."
   },
   "file_bar": {
     "open_sidebar": "Abrir barra lateral",

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -52,7 +52,8 @@
     "delete_workbooks_one": "Eliminar {{count}} libro",
     "delete_workbooks_other": "Eliminar {{count}} libros",
     "bulk_delete_message_one": "Este libro será eliminado permanentemente.",
-    "bulk_delete_message_other": "{{count}} libros serán eliminados permanentemente."
+    "bulk_delete_message_other": "{{count}} libros serán eliminados permanentemente.",
+    "select_workbook": "Seleccionar {{name}}"
   },
   "file_bar": {
     "open_sidebar": "Abrir barra lateral",

--- a/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
@@ -52,7 +52,8 @@
     "delete_workbooks_one": "Supprimer {{count}} classeur",
     "delete_workbooks_other": "Supprimer {{count}} classeurs",
     "bulk_delete_message_one": "Ce classeur sera définitivement supprimé.",
-    "bulk_delete_message_other": "{{count}} classeurs seront définitivement supprimés."
+    "bulk_delete_message_other": "{{count}} classeurs seront définitivement supprimés.",
+    "select_workbook": "Sélectionner {{name}}"
   },
   "file_bar": {
     "open_sidebar": "Ouvrir la barre latérale",

--- a/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
@@ -47,7 +47,12 @@
       "subtitle2": "<bold>Téléchargez souvent votre XLSX</bold> – les versions futures pourraient ne pas ouvrir les classeurs actuels, même s'ils sont partagés.",
       "close": "Fermer"
     },
-    "documentation": "Documentation"
+    "documentation": "Documentation",
+    "cancel": "Annuler",
+    "delete_workbooks_one": "Supprimer {{count}} classeur",
+    "delete_workbooks_other": "Supprimer {{count}} classeurs",
+    "bulk_delete_message_one": "Ce classeur sera définitivement supprimé.",
+    "bulk_delete_message_other": "{{count}} classeurs seront définitivement supprimés."
   },
   "file_bar": {
     "open_sidebar": "Ouvrir la barre latérale",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -52,7 +52,8 @@
     "delete_workbooks_one": "Elimina {{count}} cartella",
     "delete_workbooks_other": "Elimina {{count}} cartelle",
     "bulk_delete_message_one": "Questa cartella di lavoro verrà eliminata definitivamente.",
-    "bulk_delete_message_other": "{{count}} cartelle di lavoro verranno eliminate definitivamente."
+    "bulk_delete_message_other": "{{count}} cartelle di lavoro verranno eliminate definitivamente.",
+    "select_workbook": "Seleziona {{name}}"
   },
   "file_bar": {
     "open_sidebar": "Apri barra laterale",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -47,7 +47,12 @@
       "subtitle2": "<bold>Scarica spesso il tuo XLSX</bold> – le versioni future potrebbero non aprire le cartelle di lavoro attuali, anche se condivise.",
       "close": "Chiudi"
     },
-    "documentation": "Documentazione"
+    "documentation": "Documentazione",
+    "cancel": "Annulla",
+    "delete_workbooks_one": "Elimina {{count}} cartella",
+    "delete_workbooks_other": "Elimina {{count}} cartelle",
+    "bulk_delete_message_one": "Questa cartella di lavoro verrà eliminata definitivamente.",
+    "bulk_delete_message_other": "{{count}} cartelle di lavoro verranno eliminate definitivamente."
   },
   "file_bar": {
     "open_sidebar": "Apri barra laterale",


### PR DESCRIPTION
As explained in #852, with this PR we'll allow users to easily delete multiple workbooks. See the video below for a demo:

https://github.com/user-attachments/assets/042feb1e-3e89-4f89-93d2-03119eacf2b3

---

### Changes:

- Added a checkbox to each workbook item in WorkbookList. The checkbox are shown when hovering the item.
- Once at least one workbook is checked, all checkboxes become permanently visible across the list
- Click a checkbox to toggle it; it becomes the anchor for range selection
- Shift-click another checkbox to select all items between the anchor and the target (inclusive)
  - This respecting the current sort/search order
- All selection logic is isolated in `useWorkbookSelection.ts`
- We still prompt a confirmation modal after hitting 'Delete {n} workbooks'

