### PR TITLE
update[app]: fix styling for focus state in WelcomeDialog

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/welcome-dialog.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/welcome-dialog.css
@@ -23,6 +23,11 @@
   font-size: var(--typography-font-size);
 }
 
+.app-ic-wd-paper:focus-visible {
+  outline: 3px solid
+    color-mix(in srgb, var(--palette-common-black) 8%, transparent);
+}
+
 /* Scrollable content */
 
 .app-ic-wd-content {


### PR DESCRIPTION
This PR adds a nicer styling to the focus-visible state of the WelcomeDialog. Until now we were showing a not-so-nice default blue outline.