### PR TITLE
fix: overlapping chevrons in toolbar

### DIFF
--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -143,18 +143,6 @@ function Toolbar(properties: ToolbarProperties) {
 
   return (
     <div className="ic-toolbar-wrapper">
-      {showLeftArrow && (
-        <Tooltip title={t("toolbar.scroll_left")}>
-          {/** biome-ignore lint/a11y/noStaticElementInteractions: we need this */}
-          {/** biome-ignore lint/a11y/useKeyWithClickEvents: TODO! */}
-          <div
-            className="ic-toolbar-scroll-arrow ic-toolbar-scroll-arrow--left"
-            onClick={scrollLeft}
-          >
-            <ChevronLeft />
-          </div>
-        </Tooltip>
-      )}
       <div className="ic-toolbar-container" ref={toolbarRef}>
         {/* History/Edit Group */}
         <div className="ic-toolbar-button-group">
@@ -544,6 +532,20 @@ function Toolbar(properties: ToolbarProperties) {
           open={borderPickerOpen}
         />
       </div>
+
+      {showLeftArrow && (
+        <Tooltip title={t("toolbar.scroll_left")}>
+          {/** biome-ignore lint/a11y/noStaticElementInteractions: we need this */}
+          {/** biome-ignore lint/a11y/useKeyWithClickEvents: TODO! */}
+          <div
+            className="ic-toolbar-scroll-arrow ic-toolbar-scroll-arrow--left"
+            onClick={scrollLeft}
+          >
+            <ChevronLeft />
+          </div>
+        </Tooltip>
+      )}
+
       {showRightArrow && (
         <Tooltip title={t("toolbar.scroll_right")}>
           {/** biome-ignore lint/a11y/noStaticElementInteractions: we need this */}

--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -534,29 +534,29 @@ function Toolbar(properties: ToolbarProperties) {
       </div>
 
       {showLeftArrow && (
-        <Tooltip title={t("toolbar.scroll_left")}>
-          {/** biome-ignore lint/a11y/noStaticElementInteractions: we need this */}
-          {/** biome-ignore lint/a11y/useKeyWithClickEvents: TODO! */}
-          <div
-            className="ic-toolbar-scroll-arrow ic-toolbar-scroll-arrow--left"
-            onClick={scrollLeft}
-          >
+        // biome-ignore lint/a11y/noStaticElementInteractions: we need this
+        // biome-ignore lint/a11y/useKeyWithClickEvents: TODO!
+        <div
+          className="ic-toolbar-scroll-arrow ic-toolbar-scroll-arrow--left"
+          onClick={scrollLeft}
+        >
+          <Tooltip title={t("toolbar.scroll_left")}>
             <ChevronLeft />
-          </div>
-        </Tooltip>
+          </Tooltip>
+        </div>
       )}
 
       {showRightArrow && (
-        <Tooltip title={t("toolbar.scroll_right")}>
-          {/** biome-ignore lint/a11y/noStaticElementInteractions: we need this */}
-          {/** biome-ignore lint/a11y/useKeyWithClickEvents: TODO! */}
-          <div
-            className="ic-toolbar-scroll-arrow ic-toolbar-scroll-arrow--right"
-            onClick={scrollRight}
-          >
+        // biome-ignore lint/a11y/noStaticElementInteractions: we need this
+        // biome-ignore lint/a11y/useKeyWithClickEvents: TODO!
+        <div
+          className="ic-toolbar-scroll-arrow ic-toolbar-scroll-arrow--right"
+          onClick={scrollRight}
+        >
+          <Tooltip title={t("toolbar.scroll_right")}>
             <ChevronRight />
-          </div>
-        </Tooltip>
+          </Tooltip>
+        </div>
       )}
     </div>
   );

--- a/webapp/IronCalc/src/components/Toolbar/toolbar.css
+++ b/webapp/IronCalc/src/components/Toolbar/toolbar.css
@@ -1,7 +1,6 @@
 /* Toolbar wrapper */
 .ic-toolbar-wrapper {
   position: relative;
-  isolation: isolate;
   display: flex;
   align-items: center;
   background: var(--palette-common-white);
@@ -71,7 +70,6 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  z-index: 10;
   width: 24px;
   height: 100%;
   display: flex;

--- a/webapp/IronCalc/src/components/Toolbar/toolbar.css
+++ b/webapp/IronCalc/src/components/Toolbar/toolbar.css
@@ -1,6 +1,7 @@
 /* Toolbar wrapper */
 .ic-toolbar-wrapper {
   position: relative;
+  isolation: isolate;
   display: flex;
   align-items: center;
   background: var(--palette-common-white);

--- a/webapp/IronCalc/src/components/Toolbar/toolbar.css
+++ b/webapp/IronCalc/src/components/Toolbar/toolbar.css
@@ -101,3 +101,10 @@
   width: 16px;
   height: 16px;
 }
+
+.ic-toolbar-scroll-arrow .ic-tooltip-trigger {
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
This PR fixes an annoying bug that was making the toolbar chevron buttons overlap unrelated elements, like dialogs and drawers. These buttons appear on narrow displays and help users reach all buttons in the toolbar.

<img width="auto" height="400" alt="IMG_6567" src="https://github.com/user-attachments/assets/f6d5d87a-8447-4e23-b655-cd7d56397ad3" /> <img width="auto" height="400" alt="IMG_6568" src="https://github.com/user-attachments/assets/29658d2a-cf5f-4ef9-93f1-c01755457c4f" />

We may want to revisit the chevron button solution in the future, but for now this just makes sure it's not in the way of other elements.