### PR TITLE
docs: fix some typos, styles and broken links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ lint:
 	cargo clippy --all-targets --all-features -- -W clippy::unwrap_used -W clippy::expect_used -W clippy::panic -D warnings
 	cd webapp/IronCalc/ && npm install && npm run check
 	cd webapp/app.ironcalc.com/frontend/ && npm install && npm run check
+	cd docs/ && npm install && npm run build
 
 .PHONY: format
 format:
@@ -23,7 +24,7 @@ test-rust:
 
 .PHONY: test-js
 test-js:
-	# Regretabbly we need to build the wasm twice, once for the nodejs tests
+	# Regrettably we need to build the wasm twice, once for the nodejs tests
 	# and a second one for the vitest.
 	cd bindings/wasm/ && wasm-pack build --target nodejs && node tests/test.mjs && make
 	cd webapp/IronCalc/ && npm install && npm run test

--- a/docs/src/contributing/function-documentation-guide.md
+++ b/docs/src/contributing/function-documentation-guide.md
@@ -201,7 +201,7 @@ List all error scenarios the function may encounter:
 - Add the include directive at the end if using the error details snippet:
 
 ```markdown
-<!--@include: ../markdown-snippets/error-type-details.txt-->
+<!--@include: ../functions/markdown-snippets/error-type-details.txt-->
 ```
 
 ### 5. Details (Optional but Recommended)
@@ -367,7 +367,7 @@ FUNCTION_NAME returns a [type](/features/value-types#type) representing [descrip
 - Specific error condition with [`#ERROR!`](/features/error-types.md#error) link.
 - Another error condition.
 
-<!--@include: ../markdown-snippets/error-type-details.txt-->
+<!--@include: ../functions/markdown-snippets/error-type-details.txt-->
 
 ## Details
 

--- a/docs/src/functions/date_and_time/now.md
+++ b/docs/src/functions/date_and_time/now.md
@@ -18,7 +18,7 @@ The optional `timezone` argument is an IronCalc extension. Excel, Google Sheets,
 
 ### Syntax
 
-**NOW([[<span title="Text" style="color:#E53935">timezone</span>]]) => <span title="Number" style="color:#1E88E5">serial_number</span>**
+**NOW([<span title="Text" style="color:#E53935">timezone</span>]) => <span title="Number" style="color:#1E88E5">serial_number</span>**
 
 ### Argument descriptions
 

--- a/docs/src/functions/information/cell.md
+++ b/docs/src/functions/information/cell.md
@@ -8,10 +8,10 @@ lang: en-US
 
 ## Overview
 
-CELL returns information about the formatting, location, or contents of a cell. The type of information to return is specified by the `info_type` argument.
+CELL returns information about the formatting, location, or contents of a cell. The type of information to return is specified by the *info_type* argument.
 
 ::: tip Language note
-The `info_type` argument is **always in English**, regardless of the workbook's locale or the user's display language. See [Regional Settings](/features/regional-settings.md) for more details.
+The *info_type* argument is **always in English**, regardless of the workbook's locale or the user's display language. See [Regional Settings](/features/regional-settings.md) for more details.
 :::
 
 ## Usage
@@ -25,9 +25,9 @@ The `info_type` argument is **always in English**, regardless of the workbook's 
 - *info_type* ([text](/features/value-types#text), required). A string specifying which type of cell information to return. Always written in English. See the table of supported values below.
 - *reference* ([reference](/features/value-types#references), optional). The cell to get information about. If omitted, CELL uses the cell containing the formula.
 
-### Supported `info_type` values
+### Supported *info_type* values
 
-| `info_type` | Returns |
+| *info_type* | Returns |
 |---|---|
 | `"address"` | The absolute reference of the first cell as text (e.g. `$A$1`). |
 | `"col"` | The column number of the cell. |
@@ -35,23 +35,23 @@ The `info_type` argument is **always in English**, regardless of the workbook's 
 | `"row"` | The row number of the cell. |
 | `"type"` | The type of data in the cell: `"b"` for blank, `"l"` for label (text), or `"v"` for value (number, boolean, or error). |
 
-The following `info_type` values are recognized but **not yet implemented** and return a [`#VALUE!`](/features/error-types.md#value) error: `"color"`, `"filename"`, `"format"`, `"parentheses"`, `"prefix"`, `"protect"`, `"width"`.
+The following *info_type* values are recognized but **not yet implemented** and return a [`#VALUE!`](/features/error-types.md#value) error: `"color"`, `"filename"`, `"format"`, `"parentheses"`, `"prefix"`, `"protect"`, `"width"`.
 
-::: info Case-insensitive
-The `info_type` argument is case-insensitive. `"address"`, `"ADDRESS"`, and `"Address"` all work the same way.
+::: tip Case-insensitive
+The *info_type* argument is case-insensitive. `"address"`, `"ADDRESS"`, and `"Address"` all work the same way.
 :::
 
 ### Returned value
 
-The return type depends on the `info_type` argument. It may be a number or text string.
+The return type depends on the *info_type* argument. It may be a number or text string.
 
 ### Error conditions
 
 - If no argument or more than two arguments are supplied, CELL returns the [`#ERROR!`](/features/error-types.md#error) error.
-- If `info_type` is not a recognized string, CELL returns the [`#VALUE!`](/features/error-types.md#value) error.
-- If the `reference` argument is not a cell reference, CELL returns the [`#VALUE!`](/features/error-types.md#value) error.
-- If `info_type` is `"address"` and `reference` is on a different sheet than the formula cell, CELL returns the [`#N/IMPL!`](/features/error-types.md#nimpl) error (cross-sheet address not yet implemented).
-- If `info_type` is one of the unimplemented values (`"color"`, `"filename"`, etc.), CELL returns the [`#VALUE!`](/features/error-types.md#value) error.
+- If *info_type* is not a recognized string, CELL returns the [`#VALUE!`](/features/error-types.md#value) error.
+- If the *reference* argument is not a cell reference, CELL returns the [`#VALUE!`](/features/error-types.md#value) error.
+- If *info_type* is `"address"` and *reference* is on a different sheet than the formula cell, CELL returns the [`#N/IMPL!`](/features/error-types.md#nimpl) error (cross-sheet address not yet implemented).
+- If *info_type* is one of the unimplemented values (`"color"`, `"filename"`, etc.), CELL returns the [`#VALUE!`](/features/error-types.md#value) error.
 
 ## Examples
 
@@ -67,4 +67,4 @@ The return type depends on the `info_type` argument. It may be a number or text 
 ## Links
 
 - Visit Microsoft Excel's [CELL function](https://support.microsoft.com/en-us/office/cell-function-51bd39a5-f338-4dbe-a33f-955d67c2b2cf) page.
-- [Google Sheets](https://support.google.com/docs/answer/3093266) and [LibreOffice Calc](https://wiki.documentfoundation.org/Documentation/Calc_Functions/CELL) also provide versions of the CELL function.
+- [Google Sheets](https://support.google.com/docs/answer/3267071) and [LibreOffice Calc](https://wiki.documentfoundation.org/Documentation/Calc_Functions/CELL) also provide versions of the CELL function.

--- a/docs/src/functions/information/cell.md
+++ b/docs/src/functions/information/cell.md
@@ -32,10 +32,11 @@ The *info_type* argument is **always in English**, regardless of the workbook's 
 | `"address"` | The absolute reference of the first cell as text (e.g. `$A$1`). |
 | `"col"` | The column number of the cell. |
 | `"contents"` | The value of the upper-left cell in the reference. |
+| `"filename"` | The name of the file as a string like `[workbook.xlsx]SheetName`. |
 | `"row"` | The row number of the cell. |
 | `"type"` | The type of data in the cell: `"b"` for blank, `"l"` for label (text), or `"v"` for value (number, boolean, or error). |
 
-The following *info_type* values are recognized but **not yet implemented** and return a [`#VALUE!`](/features/error-types.md#value) error: `"color"`, `"filename"`, `"format"`, `"parentheses"`, `"prefix"`, `"protect"`, `"width"`.
+The following *info_type* values are recognized but **not yet implemented** and return a [`#VALUE!`](/features/error-types.md#value) error: `"color"`, `"format"`, `"parentheses"`, `"prefix"`, `"protect"`, `"width"`.
 
 ::: tip Case-insensitive
 The *info_type* argument is case-insensitive. `"address"`, `"ADDRESS"`, and `"Address"` all work the same way.

--- a/docs/src/functions/information/info.md
+++ b/docs/src/functions/information/info.md
@@ -11,7 +11,7 @@ lang: en-US
 INFO returns information about the current operating environment and the workbook.
 
 ::: tip Language note
-The `type_text` argument is **always in English**, regardless of the workbook's locale or the user's display language. See [Regional Settings](/features/regional-settings.md) for more details.
+The *type_text* argument is **always in English**, regardless of the workbook's locale or the user's display language. See [Regional Settings](/features/regional-settings.md) for more details.
 :::
 
 ## Usage
@@ -24,30 +24,30 @@ The `type_text` argument is **always in English**, regardless of the workbook's 
 
 - *type_text* ([text](/features/value-types#text), required). A string specifying which type of environment information to return. Always written in English. See the table of supported values below.
 
-### Supported `type_text` values
+### Supported *type_text* values
 
-| `type_text` | Returns |
+| *type_text* | Returns |
 |---|---|
 | `"numfile"` | The number of worksheets in the current workbook. |
 | `"recalc"` | The current recalculation mode. IronCalc always returns `"Automatic"`. |
 | `"release"` | The version of IronCalc as a text string. |
 | `"system"` | The name of the operating environment: `"browser"` in the web app, or the OS name (e.g. `"linux"`, `"windows"`, `"macos"`) in other contexts. |
 
-The following `type_text` values are recognized but **not yet implemented** and return a [`#NIMPL!`](/features/error-types.md#nimpl) error: `"directory"`, `"origin"`, `"osversion"`.
+The following *type_text* values are recognized but **not yet implemented** and return a [`#N/IMPL!`](/features/error-types.md#nimpl) error: `"directory"`, `"origin"`, `"osversion"`.
 
-::: info Case-insensitive
-The `type_text` argument is case-insensitive. `"release"`, `"RELEASE"`, and `"Release"` all work the same way.
+::: tip Case-insensitive
+The *type_text* argument is case-insensitive. `"release"`, `"RELEASE"`, and `"Release"` all work the same way.
 :::
 
 ### Returned value
 
-INFO returns a [text](/features/value-types#text) string, or a number for `"numfile"`.
+INFO returns a [text](/features/value-types#text) string, or a [number](/features/value-types#numbers) for `"numfile"`.
 
 ### Error conditions
 
 - If the wrong number of arguments is supplied, INFO returns the [`#ERROR!`](/features/error-types.md#error) error.
-- If `type_text` is not a recognized string, INFO returns the [`#VALUE!`](/features/error-types.md#value) error.
-- If `type_text` is one of the unimplemented values (`"directory"`, `"origin"`, `"osversion"`), INFO returns the [`#N/IMPL!`](/features/error-types.md#nimpl) error.
+- If *type_text* is not a recognized string, INFO returns the [`#VALUE!`](/features/error-types.md#value) error.
+- If *type_text* is one of the unimplemented values (`"directory"`, `"origin"`, `"osversion"`), INFO returns the [`#N/IMPL!`](/features/error-types.md#nimpl) error.
 
 ## Examples
 
@@ -61,4 +61,4 @@ INFO returns a [text](/features/value-types#text) string, or a number for `"numf
 ## Links
 
 - Visit Microsoft Excel's [INFO function](https://support.microsoft.com/en-us/office/info-function-725f259a-0e4b-49b3-8b52-58815c69acae) page.
-- [Google Sheets](https://support.google.com/docs/answer/3093180) and [LibreOffice Calc](https://wiki.documentfoundation.org/Documentation/Calc_Functions/INFO) also provide versions of the INFO function.
+- [LibreOffice Calc](https://wiki.documentfoundation.org/Documentation/Calc_Functions/INFO) also provides a version of the INFO function.


### PR DESCRIPTION
This PR includes some styling fixes for the recently added NOW, CELL and INFO pages. 

Changes include:
- Highlighted text in an unified style using `tip` 
- Function argument names in italics
- Broken links are now fixed: INFO is not implemented in Google Sheets, markdown snippets link