### PR TITLE
Fix: Preserve original date case during autofill

### DIFF
--- a/base/src/test/user_model/test_autofill_columns.rs
+++ b/base/src/test/user_model/test_autofill_columns.rs
@@ -490,6 +490,93 @@ fn short_month_progression() {
 }
 
 #[test]
+fn short_month_progression_lowercase() {
+    let model = new_empty_model();
+    let mut model = UserModel::from_model(model);
+    model.set_user_input(0, 1, 1, "jan").unwrap(); // A1
+    model.set_user_input(0, 1, 2, "feb").unwrap(); // B1
+    model
+        .auto_fill_columns(
+            &Area {
+                sheet: 0,
+                row: 1,
+                column: 1,
+                width: 2,
+                height: 1,
+            },
+            4,
+        )
+        .unwrap();
+
+    assert_eq!(
+        model.get_cell_content(0, 1, 3), // C1
+        Ok("mar".to_string())
+    );
+    assert_eq!(
+        model.get_cell_content(0, 1, 4), // D1
+        Ok("apr".to_string())
+    );
+}
+
+#[test]
+fn short_month_progression_uppercase() {
+    let model = new_empty_model();
+    let mut model = UserModel::from_model(model);
+    model.set_user_input(0, 1, 1, "JAN").unwrap(); // A1
+    model.set_user_input(0, 1, 2, "FEB").unwrap(); // B1
+    model
+        .auto_fill_columns(
+            &Area {
+                sheet: 0,
+                row: 1,
+                column: 1,
+                width: 2,
+                height: 1,
+            },
+            4,
+        )
+        .unwrap();
+
+    assert_eq!(
+        model.get_cell_content(0, 1, 3), // C1
+        Ok("MAR".to_string())
+    );
+    assert_eq!(
+        model.get_cell_content(0, 1, 4), // D1
+        Ok("APR".to_string())
+    );
+}
+
+#[test]
+fn short_month_progression_left_uppercase() {
+    let model = new_empty_model();
+    let mut model = UserModel::from_model(model);
+    model.set_user_input(0, 1, 10, "JAN").unwrap(); // J1
+    model.set_user_input(0, 1, 11, "FEB").unwrap(); // K1
+    model
+        .auto_fill_columns(
+            &Area {
+                sheet: 0,
+                row: 1,
+                column: 10,
+                width: 2,
+                height: 1,
+            },
+            8,
+        )
+        .unwrap();
+
+    assert_eq!(
+        model.get_cell_content(0, 1, 9), // I1
+        Ok("DEC".to_string())
+    );
+    assert_eq!(
+        model.get_cell_content(0, 1, 8), // H1
+        Ok("NOV".to_string())
+    );
+}
+
+#[test]
 fn alpha_beta_gamma() {
     let model = new_empty_model();
     let mut model = UserModel::from_model(model);

--- a/base/src/test/user_model/test_autofill_rows.rs
+++ b/base/src/test/user_model/test_autofill_rows.rs
@@ -579,8 +579,8 @@ fn de_locale_month_progression_upwards_uppercase() {
     model.locale = get_locale("de").unwrap();
     let mut model = UserModel::from_model(model);
 
-    model.set_user_input(0, 10, 1, "JANUAR").unwrap(); // A10
-    model.set_user_input(0, 11, 1, "FEBRUAR").unwrap(); // A11
+    model.set_user_input(0, 10, 1, "MÄRZ").unwrap(); // A10
+    model.set_user_input(0, 11, 1, "april").unwrap(); // A11
     model
         .auto_fill_rows(
             &Area {
@@ -596,11 +596,11 @@ fn de_locale_month_progression_upwards_uppercase() {
 
     assert_eq!(
         model.get_cell_content(0, 9, 1), // A9
-        Ok("DEZEMBER".to_string())
+        Ok("FEBRUAR".to_string())
     );
     assert_eq!(
         model.get_cell_content(0, 8, 1), // A8
-        Ok("NOVEMBER".to_string())
+        Ok("JANUAR".to_string())
     );
 }
 

--- a/base/src/test/user_model/test_autofill_rows.rs
+++ b/base/src/test/user_model/test_autofill_rows.rs
@@ -458,7 +458,7 @@ fn de_locale_month_progression() {
 }
 
 #[test]
-fn short_month_progression() {
+fn short_month_progression_capitalized() {
     let model = new_empty_model();
     let mut model = UserModel::from_model(model);
     model.set_user_input(0, 1, 1, "Jan").unwrap(); // A1
@@ -483,6 +483,124 @@ fn short_month_progression() {
     assert_eq!(
         model.get_cell_content(0, 4, 1), // A4
         Ok("Apr".to_string())
+    );
+}
+
+#[test]
+fn short_month_progression_lowercase() {
+    let model = new_empty_model();
+    let mut model = UserModel::from_model(model);
+    model.set_user_input(0, 1, 1, "jan").unwrap(); // A1
+    model.set_user_input(0, 2, 1, "feb").unwrap(); // A2
+    model
+        .auto_fill_rows(
+            &Area {
+                sheet: 0,
+                row: 1,
+                column: 1,
+                width: 1,
+                height: 2,
+            },
+            4,
+        )
+        .unwrap();
+
+    assert_eq!(
+        model.get_cell_content(0, 3, 1), // A3
+        Ok("mar".to_string())
+    );
+    assert_eq!(
+        model.get_cell_content(0, 4, 1), // A4
+        Ok("apr".to_string())
+    );
+}
+
+#[test]
+fn short_month_progression_uppercase() {
+    let model = new_empty_model();
+    let mut model = UserModel::from_model(model);
+    model.set_user_input(0, 1, 1, "JAN").unwrap(); // A1
+    model.set_user_input(0, 2, 1, "FEB").unwrap(); // A2
+    model
+        .auto_fill_rows(
+            &Area {
+                sheet: 0,
+                row: 1,
+                column: 1,
+                width: 1,
+                height: 2,
+            },
+            4,
+        )
+        .unwrap();
+
+    assert_eq!(
+        model.get_cell_content(0, 3, 1), // A3
+        Ok("MAR".to_string())
+    );
+    assert_eq!(
+        model.get_cell_content(0, 4, 1), // A4
+        Ok("APR".to_string())
+    );
+}
+
+#[test]
+fn short_month_progression_upwards_lowercase() {
+    let model = new_empty_model();
+    let mut model = UserModel::from_model(model);
+    model.set_user_input(0, 10, 1, "jan").unwrap(); // A10
+    model.set_user_input(0, 11, 1, "feb").unwrap(); // A11
+    model
+        .auto_fill_rows(
+            &Area {
+                sheet: 0,
+                row: 10,
+                column: 1,
+                width: 1,
+                height: 2,
+            },
+            8,
+        )
+        .unwrap();
+
+    assert_eq!(
+        model.get_cell_content(0, 9, 1), // A9
+        Ok("dec".to_string())
+    );
+    assert_eq!(
+        model.get_cell_content(0, 8, 1), // A8
+        Ok("nov".to_string())
+    );
+}
+
+#[test]
+fn de_locale_month_progression_upwards_uppercase() {
+    let mut model = new_empty_model();
+    model.locale = get_locale("de").unwrap();
+    let mut model = UserModel::from_model(model);
+
+    model.set_user_input(0, 10, 1, "JANUAR").unwrap(); // A10
+    model.set_user_input(0, 11, 1, "FEBRUAR").unwrap(); // A11
+    model
+        .auto_fill_rows(
+            &Area {
+                sheet: 0,
+                row: 10,
+                column: 1,
+                width: 1,
+                height: 2,
+            },
+            8,
+        )
+        .unwrap();
+
+    assert_eq!(
+        model.get_cell_content(0, 9, 1), // A9
+        Ok("DEZEMBER".to_string())
+    );
+    assert_eq!(
+        model.get_cell_content(0, 8, 1), // A8
+        Ok("NOVEMBER".to_string())
     );
 }
 

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -1749,7 +1749,8 @@ impl<'a> UserModel<'a> {
                     .map(|row| self.get_cell_content(sheet, row, column))
                     .collect::<Result<Vec<_>, _>>()?
             };
-            let possible_progression = detect_progression(&values, locale);
+            let case_seed = self.get_cell_content(sheet, row1, column)?;
+            let possible_progression = detect_progression(&values, locale, &case_seed);
             for (range_idx, row_ref) in row_range.iter().enumerate() {
                 // Save value and style first
                 let row = *row_ref;
@@ -1876,7 +1877,8 @@ impl<'a> UserModel<'a> {
                     .map(|column| self.get_cell_content(sheet, row, column))
                     .collect::<Result<Vec<_>, _>>()?
             };
-            let possible_progression = detect_progression(&values, locale);
+            let case_seed = self.get_cell_content(sheet, row, column1)?;
+            let possible_progression = detect_progression(&values, locale, &case_seed);
             for (range_idx, column_ref) in column_range.iter().enumerate() {
                 let column = *column_ref;
                 // Save value and style first

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -1,5 +1,23 @@
+use std::collections::HashMap;
+
 use crate::locale::Locale;
 
+enum DateCaseStyle {
+    Uppercase,
+    Capitalized,
+    Lowercase,
+}
+impl DateCaseStyle {
+    fn new(case_seed: &str) -> Self {
+        if case_seed == case_seed.to_uppercase() {
+            Self::Uppercase
+        } else if case_seed.chars().next().is_some_and(|c| c.is_uppercase()) {
+            Self::Capitalized
+        } else {
+            Self::Lowercase
+        }
+    }
+}
 pub(crate) struct NumericProgression {
     last: f64,
     step: f64,
@@ -276,32 +294,41 @@ impl SequenceDetector for SuffixedNumberDetector<'_> {
 
 struct DateProgressionDetector<'a> {
     locale: &'a Locale,
+    case_style: DateCaseStyle,
 }
 
 impl<'a> DateProgressionDetector<'a> {
     fn find_progression(&self, values: &[String], dates: &[String]) -> Option<Progression> {
+        let date_indexes = dates
+            .iter()
+            .enumerate()
+            .map(|(idx, date)| (date.to_lowercase(), idx))
+            .collect::<HashMap<_, _>>();
+
         let indexes = values
             .iter()
             .map(|value| {
-                dates
-                    .iter()
-                    .position(|date| date.eq_ignore_ascii_case(value))
-                    .map(|idx| idx.to_string())
+                date_indexes
+                    .get(&value.to_lowercase())
+                    .map(|&idx| idx.to_string())
             })
-            .collect::<Option<Vec<_>>>();
+            .collect::<Option<Vec<_>>>()?;
 
-        if let Some(indices) = indexes {
-            if let Some(Progression::Numeric(numeric_progression)) = (NumericProgressionDetector {
-                locale: self.locale,
-            })
-            .detect(&indices)
-            {
-                let date_progression = DateProgression {
-                    numeric_progression,
-                    dates: dates.to_vec(),
-                };
-                return Some(Progression::Date(date_progression));
-            }
+        if let Some(Progression::Numeric(numeric_progression)) = (NumericProgressionDetector {
+            locale: self.locale,
+        })
+        .detect(&indexes)
+        {
+            let dates = match self.case_style {
+                DateCaseStyle::Uppercase => dates.iter().map(|date| date.to_uppercase()).collect(),
+                DateCaseStyle::Capitalized => dates.to_vec(),
+                DateCaseStyle::Lowercase => dates.iter().map(|date| date.to_lowercase()).collect(),
+            };
+            let date_progression = DateProgression {
+                numeric_progression,
+                dates: dates.to_vec(),
+            };
+            return Some(Progression::Date(date_progression));
         }
         None
     }
@@ -327,14 +354,20 @@ impl<'a> SequenceDetector for DateProgressionDetector<'a> {
     }
 }
 
-pub(crate) fn detect_progression(values: &[String], locale: &Locale) -> Option<Progression> {
+pub(crate) fn detect_progression(
+    values: &[String],
+    locale: &Locale,
+    case_seed: &str,
+) -> Option<Progression> {
     if let Some(progression) = (NumericProgressionDetector { locale }).detect(values) {
         return Some(progression);
     }
     if let Some(progression) = (SuffixedNumberDetector { locale }).detect(values) {
         return Some(progression);
     }
-    if let Some(progression) = (DateProgressionDetector { locale }).detect(values) {
+
+    let case_style = DateCaseStyle::new(case_seed);
+    if let Some(progression) = (DateProgressionDetector { locale, case_style }).detect(values) {
         return Some(progression);
     }
     None
@@ -550,7 +583,8 @@ mod tests {
     #[test]
     fn test_date_progression_detector_en() {
         let locale = get_locale("en").unwrap();
-        let detector = DateProgressionDetector { locale };
+        let case_style = DateCaseStyle::new("Monday");
+        let detector = DateProgressionDetector { locale, case_style };
 
         let values = vec!["Monday".to_string(), "Tuesday".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -577,16 +611,40 @@ mod tests {
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "Monday");
 
-        let values = vec!["saturday".to_string(), "SUNDAY".to_string()];
-        let progression = detector.detect(&values).unwrap();
-        assert_eq!(progression.next(0), "Monday");
-
         let values = vec!["Jan".to_string(), "Mar".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "May");
 
         let values = vec!["Jan".to_string(), "Feb".to_string(), "Apr".to_string()];
         assert!(detector.detect(&values).is_none());
+
+        let values = vec!["jan".to_string(), "feb".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "mar");
+
+        let values = vec!["saturday".to_string(), "SUNDAY".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "Monday");
+
+        let values = vec!["monday".to_string(), "tuesday".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "wednesday");
+
+        let values = vec!["january".to_string(), "february".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "march");
+
+        let values = vec!["MONDAY".to_string(), "TUESDAY".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "WEDNESDAY");
+
+        let values = vec!["JANUARY".to_string(), "FEBRUARY".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "MARCH");
+
+        let values = vec!["JAN".to_string(), "FEB".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "MAR");
     }
 
     #[test]
@@ -601,6 +659,14 @@ mod tests {
         let values = vec!["janvier".to_string(), "février".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "mars");
+
+        let values = vec!["LUNDI".to_string(), "MARDI".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "MERCREDI");
+
+        let values = vec!["JANVIER".to_string(), "FÉVRIER".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "MARS");
     }
 
     #[test]
@@ -615,6 +681,14 @@ mod tests {
         let values = vec!["enero".to_string(), "febrero".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "marzo");
+
+        let values = vec!["LUNES".to_string(), "MARTES".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "MIÉRCOLES");
+
+        let values = vec!["ENERO".to_string(), "FEBRERO".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "MARZO");
     }
 
     #[test]

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -22,7 +22,13 @@ impl DateCaseStyle {
     fn apply(&self, dates: &[String]) -> Vec<String> {
         match self {
             DateCaseStyle::Uppercase => dates.iter().map(|date| date.to_uppercase()).collect(),
-            DateCaseStyle::Capitalized => dates.to_vec(),
+            DateCaseStyle::Capitalized => dates
+                .iter()
+                .map(|date| {
+                    let mut chars = date.chars();
+                    chars.next().unwrap_or_default().to_uppercase().to_string() + chars.as_str()
+                })
+                .collect(),
             DateCaseStyle::Lowercase => dates.iter().map(|date| date.to_lowercase()).collect(),
         }
     }
@@ -312,7 +318,7 @@ impl<'a> DateProgressionDetector<'a> {
         let date_indexes = dates
             .iter()
             .enumerate()
-            .map(|(idx, date)| (date.to_lowercase(), idx))
+            .map(|(idx, date)| (date.trim_end_matches('.').to_lowercase(), idx))
             .collect::<HashMap<_, _>>();
 
         let indexes = values

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -314,18 +314,34 @@ struct DateProgressionDetector<'a> {
 }
 
 impl<'a> DateProgressionDetector<'a> {
+    fn normalize(s: &str) -> String {
+        let s = s.trim_matches(['.', ' ']);
+        let mut result = String::with_capacity(s.len());
+        for c in s.chars() {
+            for lc in c.to_lowercase() {
+                match lc {
+                    'á' | 'ä' => result.push('a'),
+                    'é' => result.push('e'),
+                    'ì' => result.push('i'),
+                    'û' => result.push('u'),
+                    _ => result.push(lc),
+                }
+            }
+        }
+        result
+    }
     fn find_progression(&self, values: &[String], dates: &[String]) -> Option<Progression> {
         let date_indexes = dates
             .iter()
             .enumerate()
-            .map(|(idx, date)| (date.trim_end_matches('.').to_lowercase(), idx))
+            .map(|(idx, date)| (Self::normalize(date), idx))
             .collect::<HashMap<_, _>>();
 
         let indexes = values
             .iter()
             .map(|value| {
                 date_indexes
-                    .get(&value.trim_matches(['.', ' ']).to_lowercase())
+                    .get(&Self::normalize(value))
                     .map(|&idx| idx.to_string())
             })
             .collect::<Option<Vec<_>>>()?;
@@ -689,6 +705,10 @@ mod tests {
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "mars");
 
+        let values = vec!["janv.".to_string(), "févr.".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "mars");
+
         let case_style = DateCaseStyle::new("LUNDI");
         let detector = DateProgressionDetector { locale, case_style };
 
@@ -706,10 +726,6 @@ mod tests {
         let values = vec!["Lundi".to_string(), "Mardi".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "Mercredi");
-
-        let values = vec!["janv".to_string(), "févr".to_string()];
-        let progression = detector.detect(&values).unwrap();
-        assert_eq!(progression.next(0), "mars.");
     }
 
     #[test]
@@ -723,7 +739,7 @@ mod tests {
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "März");
 
-        let values = vec!["So".to_string(), "Mo".to_string()];
+        let values = vec!["So.".to_string(), "Mo.".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "Di.");
     }

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -9,7 +9,7 @@ enum DateCaseStyle {
 }
 impl DateCaseStyle {
     fn new(case_seed: &str) -> Self {
-        if case_seed == case_seed.to_uppercase() {
+        if case_seed.chars().all(|c| c.is_uppercase()) {
             Self::Uppercase
         } else if case_seed.chars().next().is_some_and(|c| c.is_uppercase()) {
             Self::Capitalized
@@ -103,6 +103,10 @@ struct NumericProgressionDetector<'a> {
 }
 
 impl<'a> NumericProgressionDetector<'a> {
+    fn new(locale: &'a Locale) -> Self {
+        Self { locale }
+    }
+
     fn validate_group(part: &str, min_len: usize, max_len: usize) -> Result<(), ()> {
         let len = part.len();
         (!part.is_empty()
@@ -275,18 +279,22 @@ impl SequenceDetector for SuffixedNumberDetector<'_> {
         if !all_have_same_prefix {
             return None;
         }
+        // let Progression::Numeric(numeric_progression) =
+        //     NumericProgressionDetector::new(self.locale).detect(&indexes)?
+        // else {
+        //     return None;
+        // };
 
-        if let Some(Progression::Numeric(numeric_progression_from_suffixes)) =
-            (NumericProgressionDetector {
-                locale: self.locale,
-            })
-            .detect(&suffixes)
-        {
-            return Some(Progression::SuffixedNumber(SuffixedProgression {
-                numeric_progression: numeric_progression_from_suffixes,
-                prefix: prefix0.to_string(),
-            }));
-        }
+        let Progression::Numeric(numeric_progression_from_suffixes) =
+            NumericProgressionDetector::new(self.locale).detect(&suffixes)?
+        else {
+            return None;
+        };
+
+        return Some(Progression::SuffixedNumber(SuffixedProgression {
+            numeric_progression: numeric_progression_from_suffixes,
+            prefix: prefix0.to_string(),
+        }));
 
         None
     }
@@ -314,23 +322,22 @@ impl<'a> DateProgressionDetector<'a> {
             })
             .collect::<Option<Vec<_>>>()?;
 
-        if let Some(Progression::Numeric(numeric_progression)) = (NumericProgressionDetector {
-            locale: self.locale,
-        })
-        .detect(&indexes)
-        {
-            let dates = match self.case_style {
-                DateCaseStyle::Uppercase => dates.iter().map(|date| date.to_uppercase()).collect(),
-                DateCaseStyle::Capitalized => dates.to_vec(),
-                DateCaseStyle::Lowercase => dates.iter().map(|date| date.to_lowercase()).collect(),
-            };
-            let date_progression = DateProgression {
-                numeric_progression,
-                dates: dates.to_vec(),
-            };
-            return Some(Progression::Date(date_progression));
-        }
-        None
+        let Progression::Numeric(numeric_progression) =
+            NumericProgressionDetector::new(self.locale).detect(&indexes)?
+        else {
+            return None;
+        };
+
+        let dates = match self.case_style {
+            DateCaseStyle::Uppercase => dates.iter().map(|date| date.to_uppercase()).collect(),
+            DateCaseStyle::Capitalized => dates.to_vec(),
+            DateCaseStyle::Lowercase => dates.iter().map(|date| date.to_lowercase()).collect(),
+        };
+        let date_progression = DateProgression {
+            numeric_progression,
+            dates,
+        };
+        Some(Progression::Date(date_progression))
     }
 }
 
@@ -358,7 +365,7 @@ pub(crate) fn detect_progression(
     locale: &Locale,
     case_seed: &str,
 ) -> Option<Progression> {
-    if let Some(progression) = (NumericProgressionDetector { locale }).detect(values) {
+    if let Some(progression) = NumericProgressionDetector::new(locale).detect(values) {
         return Some(progression);
     }
     if let Some(progression) = (SuffixedNumberDetector { locale }).detect(values) {
@@ -382,7 +389,7 @@ mod tests {
     #[test]
     fn test_numeric_progression_detector() {
         let locale = get_locale("en").unwrap();
-        let detector = NumericProgressionDetector { locale };
+        let detector = NumericProgressionDetector::new(locale);
 
         let values = vec!["1".to_string(), "2".to_string(), "3".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -409,7 +416,7 @@ mod tests {
     #[test]
     fn test_numeric_float() {
         let locale = get_locale("en").unwrap();
-        let detector = NumericProgressionDetector { locale };
+        let detector = NumericProgressionDetector::new(locale);
 
         let values = vec!["1.5".to_string(), "2.0".to_string(), "2.5".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -460,7 +467,7 @@ mod tests {
     #[test]
     fn test_numeric_grouping_validation() {
         let locale = get_locale("en").unwrap();
-        let detector = NumericProgressionDetector { locale };
+        let detector = NumericProgressionDetector::new(locale);
 
         let values = vec!["1000000".to_string(), "2000000".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -504,7 +511,7 @@ mod tests {
     #[test]
     fn test_numeric_progression_detector_locale_de() {
         let locale = get_locale("de").unwrap();
-        let detector = NumericProgressionDetector { locale };
+        let detector = NumericProgressionDetector::new(locale);
 
         let values = vec!["1,5".to_string(), "2,0".to_string(), "2,5".to_string()];
         let progression = detector.detect(&values).unwrap();

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -17,6 +17,14 @@ impl DateCaseStyle {
             Self::Lowercase
         }
     }
+
+    fn apply(&self, dates: &[String]) -> Vec<String> {
+        match self {
+            DateCaseStyle::Uppercase => dates.iter().map(|date| date.to_uppercase()).collect(),
+            DateCaseStyle::Capitalized => dates.to_vec(),
+            DateCaseStyle::Lowercase => dates.iter().map(|date| date.to_lowercase()).collect(),
+        }
+    }
 }
 pub(crate) struct NumericProgression {
     last: f64,
@@ -279,11 +287,6 @@ impl SequenceDetector for SuffixedNumberDetector<'_> {
         if !all_have_same_prefix {
             return None;
         }
-        // let Progression::Numeric(numeric_progression) =
-        //     NumericProgressionDetector::new(self.locale).detect(&indexes)?
-        // else {
-        //     return None;
-        // };
 
         let Progression::Numeric(numeric_progression_from_suffixes) =
             NumericProgressionDetector::new(self.locale).detect(&suffixes)?
@@ -291,12 +294,10 @@ impl SequenceDetector for SuffixedNumberDetector<'_> {
             return None;
         };
 
-        return Some(Progression::SuffixedNumber(SuffixedProgression {
+        Some(Progression::SuffixedNumber(SuffixedProgression {
             numeric_progression: numeric_progression_from_suffixes,
             prefix: prefix0.to_string(),
-        }));
-
-        None
+        }))
     }
 }
 
@@ -328,16 +329,10 @@ impl<'a> DateProgressionDetector<'a> {
             return None;
         };
 
-        let dates = match self.case_style {
-            DateCaseStyle::Uppercase => dates.iter().map(|date| date.to_uppercase()).collect(),
-            DateCaseStyle::Capitalized => dates.to_vec(),
-            DateCaseStyle::Lowercase => dates.iter().map(|date| date.to_lowercase()).collect(),
-        };
-        let date_progression = DateProgression {
+        Some(Progression::Date(DateProgression {
             numeric_progression,
-            dates,
-        };
-        Some(Progression::Date(date_progression))
+            dates: self.case_style.apply(dates),
+        }))
     }
 }
 

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -339,11 +339,7 @@ impl<'a> DateProgressionDetector<'a> {
 
         let indexes = values
             .iter()
-            .map(|value| {
-                date_indexes
-                    .get(&Self::normalize(value))
-                    .map(|&idx| idx.to_string())
-            })
+            .map(|value| date_indexes.get(value).map(|&idx| idx.to_string()))
             .collect::<Option<Vec<_>>>()?;
 
         let Progression::Numeric(numeric_progression) =
@@ -364,6 +360,10 @@ impl<'a> SequenceDetector for DateProgressionDetector<'a> {
         if values.len() < 2 {
             return None;
         }
+        let normalized_values = values
+            .iter()
+            .map(|value| Self::normalize(value))
+            .collect::<Vec<_>>();
 
         let dates = &self.locale.dates;
 
@@ -374,7 +374,7 @@ impl<'a> SequenceDetector for DateProgressionDetector<'a> {
             &dates.months_short,
         ]
         .iter()
-        .find_map(|&names_vec| self.find_progression(values, names_vec))
+        .find_map(|&names_vec| self.find_progression(&normalized_values, names_vec))
     }
 }
 

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -347,7 +347,6 @@ impl<'a> SequenceDetector for DateProgressionDetector<'a> {
             &dates.day_names_short,
             &dates.months,
             &dates.months_short,
-            &dates.months_letter,
         ]
         .iter()
         .find_map(|&names_vec| self.find_progression(values, names_vec))
@@ -601,11 +600,6 @@ mod tests {
         let values = vec!["Jan".to_string(), "Feb".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "Mar");
-
-        let values = vec!["J".to_string(), "F".to_string(), "M".to_string()];
-        let progression = detector.detect(&values).unwrap();
-        assert_eq!(progression.next(0), "A");
-        assert_eq!(progression.next(1), "M");
 
         let values = vec!["Saturday".to_string(), "Sunday".to_string()];
         let progression = detector.detect(&values).unwrap();

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -9,6 +9,7 @@ enum DateCaseStyle {
 }
 impl DateCaseStyle {
     fn new(case_seed: &str) -> Self {
+        let case_seed = case_seed.trim_matches(['.', ' ']);
         if case_seed.chars().all(|c| c.is_uppercase()) {
             Self::Uppercase
         } else if case_seed.chars().next().is_some_and(|c| c.is_uppercase()) {
@@ -318,7 +319,7 @@ impl<'a> DateProgressionDetector<'a> {
             .iter()
             .map(|value| {
                 date_indexes
-                    .get(&value.to_lowercase())
+                    .get(&value.trim_matches(['.', ' ']).to_lowercase())
                     .map(|&idx| idx.to_string())
             })
             .collect::<Option<Vec<_>>>()?;
@@ -603,6 +604,14 @@ mod tests {
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "Mar");
 
+        let values = vec!["Jan.".to_string(), "Feb.".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "Mar");
+
+        let values = vec!["Jan ".to_string(), "Feb ".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "Mar");
+
         let values = vec!["Saturday".to_string(), "Sunday".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "Monday");
@@ -645,6 +654,13 @@ mod tests {
         assert_eq!(progression.next(0), "MARCH");
 
         let values = vec!["JAN".to_string(), "FEB".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "MAR");
+
+        let case_style = DateCaseStyle::new(" MONDAY ");
+        let detector = DateProgressionDetector { locale, case_style };
+
+        let values = vec!["JAN. ".to_string(), "FEB. ".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "MAR");
     }

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -618,13 +618,16 @@ mod tests {
         let values = vec!["Jan".to_string(), "Feb".to_string(), "Apr".to_string()];
         assert!(detector.detect(&values).is_none());
 
+        let case_style = DateCaseStyle::new("jan");
+        let detector = DateProgressionDetector { locale, case_style };
+
         let values = vec!["jan".to_string(), "feb".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "mar");
 
         let values = vec!["saturday".to_string(), "SUNDAY".to_string()];
         let progression = detector.detect(&values).unwrap();
-        assert_eq!(progression.next(0), "Monday");
+        assert_eq!(progression.next(0), "monday");
 
         let values = vec!["monday".to_string(), "tuesday".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -633,6 +636,9 @@ mod tests {
         let values = vec!["january".to_string(), "february".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "march");
+
+        let case_style = DateCaseStyle::new("MONDAY");
+        let detector = DateProgressionDetector { locale, case_style };
 
         let values = vec!["MONDAY".to_string(), "TUESDAY".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -650,7 +656,8 @@ mod tests {
     #[test]
     fn test_date_progression_detector_fr() {
         let locale = get_locale("fr").unwrap();
-        let detector = DateProgressionDetector { locale };
+        let case_style = DateCaseStyle::new("lundi");
+        let detector = DateProgressionDetector { locale, case_style };
 
         let values = vec!["lundi".to_string(), "mardi".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -659,6 +666,9 @@ mod tests {
         let values = vec!["janvier".to_string(), "février".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "mars");
+
+        let case_style = DateCaseStyle::new("LUNDI");
+        let detector = DateProgressionDetector { locale, case_style };
 
         let values = vec!["LUNDI".to_string(), "MARDI".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -672,7 +682,8 @@ mod tests {
     #[test]
     fn test_date_progression_detector_es() {
         let locale = get_locale("es").unwrap();
-        let detector = DateProgressionDetector { locale };
+        let case_style = DateCaseStyle::new("lunes");
+        let detector = DateProgressionDetector { locale, case_style };
 
         let values = vec!["lunes".to_string(), "martes".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -681,6 +692,9 @@ mod tests {
         let values = vec!["enero".to_string(), "febrero".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "marzo");
+
+        let case_style = DateCaseStyle::new("LUNES");
+        let detector = DateProgressionDetector { locale, case_style };
 
         let values = vec!["LUNES".to_string(), "MARTES".to_string()];
         let progression = detector.detect(&values).unwrap();
@@ -694,24 +708,25 @@ mod tests {
     #[test]
     fn test_detect_progression() {
         let locale = get_locale("en").unwrap();
+        let case_seed = "Mar";
 
         let values = vec!["1".to_string(), "3".to_string()];
-        let p = detect_progression(&values, locale).unwrap();
+        let p = detect_progression(&values, locale, case_seed).unwrap();
         assert_eq!(p.next(0), "5");
 
         let values = vec!["X10".to_string(), "X20".to_string()];
-        let p = detect_progression(&values, locale).unwrap();
+        let p = detect_progression(&values, locale, case_seed).unwrap();
         assert_eq!(p.next(0), "X30");
 
         let values = vec!["Mar".to_string(), "Apr".to_string()];
-        let p = detect_progression(&values, locale).unwrap();
+        let p = detect_progression(&values, locale, case_seed).unwrap();
         assert_eq!(p.next(0), "May");
 
         let values = vec!["1".to_string(), "A".to_string(), "foo".to_string()];
-        assert!(detect_progression(&values, locale).is_none());
+        assert!(detect_progression(&values, locale, case_seed).is_none());
 
         let values = vec!["1".to_string(), "2".to_string()];
-        let p = detect_progression(&values, locale).unwrap();
+        let p = detect_progression(&values, locale, case_seed).unwrap();
         assert!(matches!(p, Progression::Numeric(_)));
         assert_eq!(p.next(0), "3");
     }

--- a/base/src/user_model/sequence_detector.rs
+++ b/base/src/user_model/sequence_detector.rs
@@ -679,6 +679,10 @@ mod tests {
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "mars");
 
+        let values = vec!["janvier".to_string(), "fevrier".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "mars");
+
         let case_style = DateCaseStyle::new("LUNDI");
         let detector = DateProgressionDetector { locale, case_style };
 
@@ -689,6 +693,33 @@ mod tests {
         let values = vec!["JANVIER".to_string(), "FÉVRIER".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "MARS");
+
+        let case_style = DateCaseStyle::new("Lundi");
+        let detector = DateProgressionDetector { locale, case_style };
+
+        let values = vec!["Lundi".to_string(), "Mardi".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "Mercredi");
+
+        let values = vec!["janv".to_string(), "févr".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "mars.");
+    }
+
+    #[test]
+    fn test_date_progression_detector_de() {
+        let locale = get_locale("de").unwrap();
+
+        let case_style = DateCaseStyle::new("Jan");
+        let detector = DateProgressionDetector { locale, case_style };
+
+        let values = vec!["Jan".to_string(), "Feb".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "März");
+
+        let values = vec!["So".to_string(), "Mo".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "Di.");
     }
 
     #[test]
@@ -715,6 +746,13 @@ mod tests {
         let values = vec!["ENERO".to_string(), "FEBRERO".to_string()];
         let progression = detector.detect(&values).unwrap();
         assert_eq!(progression.next(0), "MARZO");
+
+        let case_style = DateCaseStyle::new("Lunes");
+        let detector = DateProgressionDetector { locale, case_style };
+
+        let values = vec!["Lunes".to_string(), "Martes".to_string()];
+        let progression = detector.detect(&values).unwrap();
+        assert_eq!(progression.next(0), "Miércoles");
     }
 
     #[test]


### PR DESCRIPTION
date autofill now preserves the users original letter case
  * jan, feb → mar, apr, ...
  * JANUAR, FEBRUAR → MÄRZ, APRIL, ...
  
month letters are no longer supported by autofill, aligning the behavior with Excel
added tests
refactoring

fix #902 
