### PR TITLE
update: add a cell context menu

### DIFF
--- a/webapp/IronCalc/src/components/Menu/Menu.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.tsx
@@ -95,11 +95,7 @@ export function Menu(props: MenuProperties) {
       const insideAnyMenu =
         target instanceof Element &&
         target.closest(".ic-menu-wrapper") !== null;
-      if (
-        !triggerContains &&
-        !(menuRef.current?.contains(target) ?? false) &&
-        !insideAnyMenu
-      ) {
+      if (!triggerContains && !insideAnyMenu) {
         close();
       }
     }

--- a/webapp/IronCalc/src/components/Menu/Menu.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.tsx
@@ -108,7 +108,7 @@ export function Menu(props: MenuProperties) {
     return () => {
       document.removeEventListener("pointerdown", handlePointerDown, true);
     };
-  }, [open, close, isTriggerMode, triggerPosition.triggerRef, menuRef]);
+  }, [open, close, isTriggerMode, triggerPosition.triggerRef]);
 
   const { handleMenuKeyDown } = useMenuKeyDown(menuRef, close);
 

--- a/webapp/IronCalc/src/components/Menu/Menu.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.tsx
@@ -92,7 +92,6 @@ export function Menu(props: MenuProperties) {
       const triggerContains = isTriggerMode
         ? (triggerPosition.triggerRef.current?.contains(target) ?? false)
         : false;
-
       const insideAnyMenu =
         target instanceof Element &&
         target.closest(".ic-menu-wrapper") !== null;

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -174,7 +174,11 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         }
       }
       rootRef.current?.dispatchEvent(
-        new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }),
+        new ClipboardEvent("paste", {
+          clipboardData: dt,
+          bubbles: true,
+          cancelable: true,
+        }),
       );
     } catch {
       // fall back to text-only if clipboard.read() is unavailable
@@ -183,7 +187,11 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         const dt = new DataTransfer();
         dt.setData("text/plain", text);
         rootRef.current?.dispatchEvent(
-          new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }),
+          new ClipboardEvent("paste", {
+            clipboardData: dt,
+            bubbles: true,
+            cancelable: true,
+          }),
         );
       } catch {
         // clipboard access denied

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -770,6 +770,14 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
           }}
           ref={worksheetRef}
           canEdit={isArrayFormula}
+          onCut={(): void => {
+            focusWorkbook();
+            document.execCommand("cut");
+          }}
+          onCopy={(): void => {
+            focusWorkbook();
+            document.execCommand("copy");
+          }}
         />
 
         <SheetTabBar

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -43,6 +43,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
   const worksheetRef = useRef<{
     getCanvas: () => WorksheetCanvas | null;
   }>(null);
+  const lastClipboardJson = useRef<string | null>(null);
 
   // Calling `setRedrawId((id) => id + 1);` forces a redraw
   // This is needed because `model` or `workbookState` can change without React being aware of it
@@ -173,6 +174,9 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
           dt.setData(type, await (await item.getType(type)).text());
         }
       }
+      if (!dt.getData("application/json") && lastClipboardJson.current) {
+        dt.setData("application/json", lastClipboardJson.current);
+      }
       rootRef.current?.dispatchEvent(
         new ClipboardEvent("paste", {
           clipboardData: dt,
@@ -186,6 +190,9 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         const text = await navigator.clipboard.readText();
         const dt = new DataTransfer();
         dt.setData("text/plain", text);
+        if (lastClipboardJson.current) {
+          dt.setData("application/json", lastClipboardJson.current);
+        }
         rootRef.current?.dispatchEvent(
           new ClipboardEvent("paste", {
             clipboardData: dt,
@@ -194,10 +201,10 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
           }),
         );
       } catch {
-        // clipboard access denied
+        setAlertDialogMessage(t("error_dialog.error_clipboard_paste"));
       }
     }
-  }, [focusWorkbook]);
+  }, [focusWorkbook, t]);
 
   const onCopyStyles = () => {
     const {
@@ -593,6 +600,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
           sheet,
           clipboardId,
         });
+        lastClipboardJson.current = clipboardJsonStr;
         event.clipboardData.setData("text/plain", data.csv.trim());
         event.clipboardData.setData("application/json", clipboardJsonStr);
         event.preventDefault();
@@ -631,6 +639,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
           sheet,
           clipboardId,
         });
+        lastClipboardJson.current = clipboardJsonStr;
         event.clipboardData.setData("text/plain", data.csv);
         event.clipboardData.setData("application/json", clipboardJsonStr);
         workbookState.setCutRange({

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -163,6 +163,34 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
     updateRangeStyle("font.size_delta", `${delta}`);
   };
 
+  const handlePaste = useCallback(async (): Promise<void> => {
+    focusWorkbook();
+    try {
+      const items = await navigator.clipboard.read();
+      const dt = new DataTransfer();
+      for (const item of items) {
+        for (const type of item.types) {
+          dt.setData(type, await (await item.getType(type)).text());
+        }
+      }
+      rootRef.current?.dispatchEvent(
+        new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }),
+      );
+    } catch {
+      // fall back to text-only if clipboard.read() is unavailable
+      try {
+        const text = await navigator.clipboard.readText();
+        const dt = new DataTransfer();
+        dt.setData("text/plain", text);
+        rootRef.current?.dispatchEvent(
+          new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }),
+        );
+      } catch {
+        // clipboard access denied
+      }
+    }
+  }, [focusWorkbook]);
+
   const onCopyStyles = () => {
     const {
       sheet,
@@ -778,6 +806,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
             focusWorkbook();
             document.execCommand("copy");
           }}
+          onPaste={handlePaste}
         />
 
         <SheetTabBar

--- a/webapp/IronCalc/src/components/Worksheet/ContextMenus/Cell.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/ContextMenus/Cell.tsx
@@ -86,10 +86,10 @@ const CellContextMenu = (properties: CellContextMenuProps) => {
         submenu={
           <>
             <MenuItem onClick={onDeleteColumn}>
-              {t("context_menu.column_header.delete_column", { column })}
+              {t("context_menu.cell.delete_column", { column })}
             </MenuItem>
             <MenuItem onClick={onDeleteRow}>
-              {t("context_menu.row_header.delete_row", { row })}
+              {t("context_menu.cell.delete_row", { row })}
             </MenuItem>
           </>
         }

--- a/webapp/IronCalc/src/components/Worksheet/ContextMenus/Cell.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/ContextMenus/Cell.tsx
@@ -16,6 +16,8 @@ interface CellContextMenuProps {
   onInsertRowBelow: () => void;
   onDeleteColumn: () => void;
   onDeleteRow: () => void;
+  onCut: () => void;
+  onCopy: () => void;
 }
 
 const CellContextMenu = (properties: CellContextMenuProps) => {
@@ -32,6 +34,8 @@ const CellContextMenu = (properties: CellContextMenuProps) => {
     onInsertRowBelow,
     onDeleteColumn,
     onDeleteRow,
+    onCut,
+    onCopy,
   } = properties;
 
   if (!anchorPosition) {
@@ -40,10 +44,10 @@ const CellContextMenu = (properties: CellContextMenuProps) => {
 
   return (
     <Menu open={open} onClose={onClose} anchorPosition={anchorPosition}>
-      <MenuItem icon={<Scissors />} onClick={() => {}}>
+      <MenuItem icon={<Scissors />} onClick={onCut}>
         {t("context_menu.cell.cut")}
       </MenuItem>
-      <MenuItem icon={<Copy />} onClick={() => {}}>
+      <MenuItem icon={<Copy />} onClick={onCopy}>
         {t("context_menu.cell.copy")}
       </MenuItem>
       <MenuItem icon={<Clipboard />} onClick={() => {}}>

--- a/webapp/IronCalc/src/components/Worksheet/ContextMenus/Cell.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/ContextMenus/Cell.tsx
@@ -1,0 +1,97 @@
+import { Clipboard, Copy, Plus, Scissors, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Menu } from "../../Menu/Menu";
+import { MenuDivider } from "../../Menu/MenuDivider";
+import { MenuItem, MenuItemWithSubmenu } from "../../Menu/MenuItem";
+
+interface CellContextMenuProps {
+  open: boolean;
+  onClose: () => void;
+  anchorPosition: { x: number; y: number } | null;
+  column: string;
+  row: number;
+  onInsertColumnLeft: () => void;
+  onInsertColumnRight: () => void;
+  onInsertRowAbove: () => void;
+  onInsertRowBelow: () => void;
+  onDeleteColumn: () => void;
+  onDeleteRow: () => void;
+}
+
+const CellContextMenu = (properties: CellContextMenuProps) => {
+  const { t } = useTranslation();
+  const {
+    open,
+    onClose,
+    anchorPosition,
+    column,
+    row,
+    onInsertColumnLeft,
+    onInsertColumnRight,
+    onInsertRowAbove,
+    onInsertRowBelow,
+    onDeleteColumn,
+    onDeleteRow,
+  } = properties;
+
+  if (!anchorPosition) {
+    return null;
+  }
+
+  return (
+    <Menu open={open} onClose={onClose} anchorPosition={anchorPosition}>
+      <MenuItem icon={<Scissors />} onClick={() => {}}>
+        {t("context_menu.cell.cut")}
+      </MenuItem>
+      <MenuItem icon={<Copy />} onClick={() => {}}>
+        {t("context_menu.cell.copy")}
+      </MenuItem>
+      <MenuItem icon={<Clipboard />} onClick={() => {}}>
+        {t("context_menu.cell.paste")}
+      </MenuItem>
+
+      <MenuDivider />
+
+      <MenuItemWithSubmenu
+        icon={<Plus />}
+        submenu={
+          <>
+            <MenuItem onClick={onInsertColumnLeft}>
+              {t("context_menu.cell.insert_column_left")}
+            </MenuItem>
+            <MenuItem onClick={onInsertColumnRight}>
+              {t("context_menu.cell.insert_column_right")}
+            </MenuItem>
+            <MenuDivider />
+            <MenuItem onClick={onInsertRowAbove}>
+              {t("context_menu.cell.insert_row_above")}
+            </MenuItem>
+            <MenuItem onClick={onInsertRowBelow}>
+              {t("context_menu.cell.insert_row_below")}
+            </MenuItem>
+          </>
+        }
+      >
+        {t("context_menu.cell.insert")}
+      </MenuItemWithSubmenu>
+
+      <MenuItemWithSubmenu
+        icon={<Trash2 />}
+        submenu={
+          <>
+            <MenuItem onClick={onDeleteColumn}>
+              {t("context_menu.column_header.delete_column", { column })}
+            </MenuItem>
+            <MenuItem onClick={onDeleteRow}>
+              {t("context_menu.row_header.delete_row", { row })}
+            </MenuItem>
+          </>
+        }
+      >
+        {t("context_menu.cell.delete")}
+      </MenuItemWithSubmenu>
+    </Menu>
+  );
+};
+
+export default CellContextMenu;

--- a/webapp/IronCalc/src/components/Worksheet/ContextMenus/Cell.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/ContextMenus/Cell.tsx
@@ -18,6 +18,7 @@ interface CellContextMenuProps {
   onDeleteRow: () => void;
   onCut: () => void;
   onCopy: () => void;
+  onPaste: () => void;
 }
 
 const CellContextMenu = (properties: CellContextMenuProps) => {
@@ -36,6 +37,7 @@ const CellContextMenu = (properties: CellContextMenuProps) => {
     onDeleteRow,
     onCut,
     onCopy,
+    onPaste,
   } = properties;
 
   if (!anchorPosition) {
@@ -50,7 +52,7 @@ const CellContextMenu = (properties: CellContextMenuProps) => {
       <MenuItem icon={<Copy />} onClick={onCopy}>
         {t("context_menu.cell.copy")}
       </MenuItem>
-      <MenuItem icon={<Clipboard />} onClick={() => {}}>
+      <MenuItem icon={<Clipboard />} onClick={onPaste}>
         {t("context_menu.cell.paste")}
       </MenuItem>
 

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -48,6 +48,8 @@ const Worksheet = forwardRef(
       workbookState: WorkbookState;
       refresh: () => void;
       canEdit: boolean;
+      onCut: () => void;
+      onCopy: () => void;
     },
     ref,
   ) => {
@@ -82,7 +84,7 @@ const Worksheet = forwardRef(
 
     const ignoreScrollEventRef = useRef(false);
 
-    const { model, workbookState, refresh, canEdit } = props;
+    const { model, workbookState, refresh, canEdit, onCut, onCopy } = props;
     const { t } = useTranslation();
     const [clientWidth, clientHeight] = useWindowSize();
 
@@ -480,6 +482,8 @@ const Worksheet = forwardRef(
           }
           column={columnNameFromNumber(model.getSelectedView().column)}
           row={model.getSelectedView().row}
+          onCut={onCut}
+          onCopy={onCopy}
           onInsertColumnLeft={(): void => {
             const view = model.getSelectedView();
             try {

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -85,7 +85,8 @@ const Worksheet = forwardRef(
 
     const ignoreScrollEventRef = useRef(false);
 
-    const { model, workbookState, refresh, canEdit, onCut, onCopy, onPaste } = props;
+    const { model, workbookState, refresh, canEdit, onCut, onCopy, onPaste } =
+      props;
     const { t } = useTranslation();
     const [clientWidth, clientHeight] = useWindowSize();
 

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -21,6 +21,7 @@ import WorksheetCanvas, {
   headerRowHeight,
 } from "../WorksheetCanvas/worksheetCanvas";
 import type { WorkbookState } from "../workbookState";
+import CellContextMenu from "./ContextMenus/Cell";
 import ColumnHeaderContextMenu from "./ContextMenus/ColumnHeader";
 import RowHeaderContextMenu from "./ContextMenus/RowHeader";
 import usePointer from "./usePointer";
@@ -66,6 +67,7 @@ const Worksheet = forwardRef(
     const columnHeaders = useRef<HTMLDivElement>(null);
     const worksheetCanvas = useRef<WorksheetCanvas | null>(null);
 
+    const [cellContextMenuOpen, setCellContextMenuOpen] = useState(false);
     const [colHeaderContextMenuOpen, setColHeaderContextMenuOpen] =
       useState(false);
     const [rowHeaderContextMenuOpen, setRowHeaderContextMenuOpen] =
@@ -395,9 +397,15 @@ const Worksheet = forwardRef(
                 setRowHeaderContextMenuOpen(true);
                 return;
               }
+              // Cell area: select the clicked cell
+              const cell = worksheetCanvas.current?.getCellByCoordinates(x, y);
+              if (cell) {
+                model.setSelectedCell(cell.row, cell.column);
+                refresh();
+              }
             }
 
-            // setContextMenuOpen(true);
+            setCellContextMenuOpen(true);
           }}
           onDoubleClick={(event) => {
             // Starts editing cell
@@ -462,6 +470,77 @@ const Worksheet = forwardRef(
           <div className="ic-worksheet-row-resize-guide" ref={rowResizeGuide} />
           <div className="ic-worksheet-column-headers" ref={columnHeaders} />
         </div>
+        <CellContextMenu
+          open={cellContextMenuOpen}
+          onClose={() => setCellContextMenuOpen(false)}
+          anchorPosition={
+            contextMenuPosition
+              ? { x: contextMenuPosition.left, y: contextMenuPosition.top }
+              : null
+          }
+          column={columnNameFromNumber(model.getSelectedView().column)}
+          row={model.getSelectedView().row}
+          onInsertColumnLeft={(): void => {
+            const view = model.getSelectedView();
+            try {
+              model.insertColumns(view.sheet, view.column, 1);
+            } catch {
+              setRowColErrorTitle(t("error_dialog.error_inserting_columns"));
+            }
+            setCellContextMenuOpen(false);
+            refresh();
+          }}
+          onInsertColumnRight={(): void => {
+            const view = model.getSelectedView();
+            try {
+              model.insertColumns(view.sheet, view.column + 1, 1);
+            } catch {
+              setRowColErrorTitle(t("error_dialog.error_inserting_columns"));
+            }
+            setCellContextMenuOpen(false);
+            refresh();
+          }}
+          onInsertRowAbove={(): void => {
+            const view = model.getSelectedView();
+            try {
+              model.insertRows(view.sheet, view.row, 1);
+            } catch {
+              setRowColErrorTitle(t("error_dialog.error_inserting_rows"));
+            }
+            setCellContextMenuOpen(false);
+            refresh();
+          }}
+          onInsertRowBelow={(): void => {
+            const view = model.getSelectedView();
+            try {
+              model.insertRows(view.sheet, view.row + 1, 1);
+            } catch {
+              setRowColErrorTitle(t("error_dialog.error_inserting_rows"));
+            }
+            setCellContextMenuOpen(false);
+            refresh();
+          }}
+          onDeleteColumn={(): void => {
+            const view = model.getSelectedView();
+            try {
+              model.deleteColumns(view.sheet, view.column, 1);
+            } catch {
+              setRowColErrorTitle(t("error_dialog.error_deleting_columns"));
+            }
+            setCellContextMenuOpen(false);
+            refresh();
+          }}
+          onDeleteRow={(): void => {
+            const view = model.getSelectedView();
+            try {
+              model.deleteRows(view.sheet, view.row, 1);
+            } catch {
+              setRowColErrorTitle(t("error_dialog.error_deleting_rows"));
+            }
+            setCellContextMenuOpen(false);
+            refresh();
+          }}
+        />
         <ColumnHeaderContextMenu
           open={colHeaderContextMenuOpen}
           onClose={() => setColHeaderContextMenuOpen(false)}

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -50,6 +50,7 @@ const Worksheet = forwardRef(
       canEdit: boolean;
       onCut: () => void;
       onCopy: () => void;
+      onPaste: () => void;
     },
     ref,
   ) => {
@@ -84,7 +85,7 @@ const Worksheet = forwardRef(
 
     const ignoreScrollEventRef = useRef(false);
 
-    const { model, workbookState, refresh, canEdit, onCut, onCopy } = props;
+    const { model, workbookState, refresh, canEdit, onCut, onCopy, onPaste } = props;
     const { t } = useTranslation();
     const [clientWidth, clientHeight] = useWindowSize();
 
@@ -484,6 +485,7 @@ const Worksheet = forwardRef(
           row={model.getSelectedView().row}
           onCut={onCut}
           onCopy={onCopy}
+          onPaste={onPaste}
           onInsertColumnLeft={(): void => {
             const view = model.getSelectedView();
             try {

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -404,8 +404,19 @@ const Worksheet = forwardRef(
               // Cell area: select the clicked cell
               const cell = worksheetCanvas.current?.getCellByCoordinates(x, y);
               if (cell) {
-                model.setSelectedCell(cell.row, cell.column);
-                refresh();
+                const { range } = model.getSelectedView();
+                const [rowStart, columnStart, rowEnd, columnEnd] = range;
+                if (
+                  !(
+                    rowStart <= cell.row &&
+                    cell.row <= rowEnd &&
+                    columnStart <= cell.column &&
+                    cell.column <= columnEnd
+                  )
+                ) {
+                  model.setSelectedCell(cell.row, cell.column);
+                  refresh();
+                }
               }
             }
 
@@ -500,7 +511,7 @@ const Worksheet = forwardRef(
           onInsertColumnRight={(): void => {
             const view = model.getSelectedView();
             try {
-              model.insertColumns(view.sheet, view.column + 1, 1);
+              model.insertColumns(view.sheet, view.range[3] + 1, 1);
             } catch {
               setRowColErrorTitle(t("error_dialog.error_inserting_columns"));
             }
@@ -520,7 +531,7 @@ const Worksheet = forwardRef(
           onInsertRowBelow={(): void => {
             const view = model.getSelectedView();
             try {
-              model.insertRows(view.sheet, view.row + 1, 1);
+              model.insertRows(view.sheet, view.range[2] + 1, 1);
             } catch {
               setRowColErrorTitle(t("error_dialog.error_inserting_rows"));
             }

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -149,6 +149,7 @@
     }
   },
   "error_dialog": {
+    "error_clipboard_paste": "Zugriff auf die Zwischenablage verweigert. Bitte erlauben Sie Zwischenablage-Berechtigungen in Ihrem Browser.",
     "error_deleting_cells": "Zellen konnten nicht gelöscht werden",
     "error_deleting_columns": "Spalten konnten nicht gelöscht werden",
     "error_deleting_rows": "Zeilen konnten nicht gelöscht werden",
@@ -156,8 +157,7 @@
     "error_inserting_columns": "Spalten konnten nicht eingefügt werden",
     "error_inserting_rows": "Zeilen konnten nicht eingefügt werden",
     "error_moving_columns": "Spalten konnten nicht verschoben werden",
-    "error_moving_rows": "Zeilen konnten nicht verschoben werden",
-    "error_clipboard_paste": "Zugriff auf die Zwischenablage verweigert. Bitte erlauben Sie Zwischenablage-Berechtigungen in Ihrem Browser."
+    "error_moving_rows": "Zeilen konnten nicht verschoben werden"
   },
   "formula_bar": {
     "manage_named_ranges": "Benannte Bereiche verwalten"

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -121,6 +121,17 @@
       "show_hidden_columns": "Ausgeblendete Spalten einblenden",
       "unfreeze_columns": "Fixierung der Spalten aufheben"
     },
+    "cell": {
+      "cut": "Ausschneiden",
+      "copy": "Kopieren",
+      "paste": "Einfügen",
+      "insert": "Einfügen...",
+      "insert_column_left": "Spalte links",
+      "insert_column_right": "Spalte rechts",
+      "insert_row_above": "Zeile oben",
+      "insert_row_below": "Zeile unten",
+      "delete": "Löschen..."
+    },
     "row_header": {
       "delete_row": "Zeile '{{row}}' löschen",
       "delete_rows": "Zeilen {{rowStart}} - {{rowEnd}} löschen",

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -112,6 +112,8 @@
       "copy": "Kopieren",
       "cut": "Ausschneiden",
       "delete": "Löschen...",
+      "delete_column": "Spalte '{{column}}'",
+      "delete_row": "Zeile '{{row}}'",
       "insert": "Einfügen...",
       "insert_column_left": "Spalte links",
       "insert_column_right": "Spalte rechts",
@@ -154,7 +156,8 @@
     "error_inserting_columns": "Spalten konnten nicht eingefügt werden",
     "error_inserting_rows": "Zeilen konnten nicht eingefügt werden",
     "error_moving_columns": "Spalten konnten nicht verschoben werden",
-    "error_moving_rows": "Zeilen konnten nicht verschoben werden"
+    "error_moving_rows": "Zeilen konnten nicht verschoben werden",
+    "error_clipboard_paste": "Zugriff auf die Zwischenablage verweigert. Bitte erlauben Sie Zwischenablage-Berechtigungen in Ihrem Browser."
   },
   "formula_bar": {
     "manage_named_ranges": "Benannte Bereiche verwalten"

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -108,6 +108,17 @@
     "use_selection": "Auswahl übernehmen"
   },
   "context_menu": {
+    "cell": {
+      "copy": "Kopieren",
+      "cut": "Ausschneiden",
+      "delete": "Löschen...",
+      "insert": "Einfügen...",
+      "insert_column_left": "Spalte links",
+      "insert_column_right": "Spalte rechts",
+      "insert_row_above": "Zeile oben",
+      "insert_row_below": "Zeile unten",
+      "paste": "Einfügen"
+    },
     "column_header": {
       "delete_column": "Spalte '{{column}}' löschen",
       "delete_columns": "Spalten {{columnStart}} - {{columnEnd}} löschen",
@@ -120,17 +131,6 @@
       "move_columns_right": "Spalten nach rechts verschieben",
       "show_hidden_columns": "Ausgeblendete Spalten einblenden",
       "unfreeze_columns": "Fixierung der Spalten aufheben"
-    },
-    "cell": {
-      "cut": "Ausschneiden",
-      "copy": "Kopieren",
-      "paste": "Einfügen",
-      "insert": "Einfügen...",
-      "insert_column_left": "Spalte links",
-      "insert_column_right": "Spalte rechts",
-      "insert_row_above": "Zeile oben",
-      "insert_row_below": "Zeile unten",
-      "delete": "Löschen..."
     },
     "row_header": {
       "delete_row": "Zeile '{{row}}' löschen",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -112,6 +112,8 @@
       "copy": "Copy",
       "cut": "Cut",
       "delete": "Delete...",
+      "delete_column": "Column '{{column}}'",
+      "delete_row": "Row '{{row}}'",
       "insert": "Insert...",
       "insert_column_left": "Column left",
       "insert_column_right": "Column right",
@@ -154,7 +156,8 @@
     "error_inserting_columns": "Failed to insert columns",
     "error_inserting_rows": "Failed to insert rows",
     "error_moving_columns": "Failed to move columns",
-    "error_moving_rows": "Failed to move rows"
+    "error_moving_rows": "Failed to move rows",
+    "error_clipboard_paste": "Clipboard access denied. Please allow clipboard permissions in your browser."
   },
   "formula_bar": {
     "manage_named_ranges": "Manage Named Ranges"

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -108,6 +108,17 @@
     "use_selection": "Use selected range"
   },
   "context_menu": {
+    "cell": {
+      "copy": "Copy",
+      "cut": "Cut",
+      "delete": "Delete...",
+      "insert": "Insert...",
+      "insert_column_left": "Column left",
+      "insert_column_right": "Column right",
+      "insert_row_above": "Row above",
+      "insert_row_below": "Row below",
+      "paste": "Paste"
+    },
     "column_header": {
       "delete_column": "Delete column '{{column}}'",
       "delete_columns": "Delete columns {{columnStart}} - {{columnEnd}}",
@@ -120,17 +131,6 @@
       "move_columns_right": "Move columns right",
       "show_hidden_columns": "Show hidden columns",
       "unfreeze_columns": "Unfreeze columns"
-    },
-    "cell": {
-      "cut": "Cut",
-      "copy": "Copy",
-      "paste": "Paste",
-      "insert": "Insert...",
-      "insert_column_left": "Column left",
-      "insert_column_right": "Column right",
-      "insert_row_above": "Row above",
-      "insert_row_below": "Row below",
-      "delete": "Delete..."
     },
     "row_header": {
       "delete_row": "Delete row '{{row}}'",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -149,6 +149,7 @@
     }
   },
   "error_dialog": {
+    "error_clipboard_paste": "Clipboard access denied. Please allow clipboard permissions in your browser.",
     "error_deleting_cells": "Failed to delete cells",
     "error_deleting_columns": "Failed to delete columns",
     "error_deleting_rows": "Failed to delete rows",
@@ -156,8 +157,7 @@
     "error_inserting_columns": "Failed to insert columns",
     "error_inserting_rows": "Failed to insert rows",
     "error_moving_columns": "Failed to move columns",
-    "error_moving_rows": "Failed to move rows",
-    "error_clipboard_paste": "Clipboard access denied. Please allow clipboard permissions in your browser."
+    "error_moving_rows": "Failed to move rows"
   },
   "formula_bar": {
     "manage_named_ranges": "Manage Named Ranges"

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -121,6 +121,17 @@
       "show_hidden_columns": "Show hidden columns",
       "unfreeze_columns": "Unfreeze columns"
     },
+    "cell": {
+      "cut": "Cut",
+      "copy": "Copy",
+      "paste": "Paste",
+      "insert": "Insert...",
+      "insert_column_left": "Column left",
+      "insert_column_right": "Column right",
+      "insert_row_above": "Row above",
+      "insert_row_below": "Row below",
+      "delete": "Delete..."
+    },
     "row_header": {
       "delete_row": "Delete row '{{row}}'",
       "delete_rows": "Delete rows {{rowStart}} - {{rowEnd}}",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -112,6 +112,8 @@
       "copy": "Copiar",
       "cut": "Cortar",
       "delete": "Eliminar...",
+      "delete_column": "Columna '{{column}}'",
+      "delete_row": "Fila '{{row}}'",
       "insert": "Insertar...",
       "insert_column_left": "Columna a la izquierda",
       "insert_column_right": "Columna a la derecha",
@@ -154,7 +156,8 @@
     "error_inserting_columns": "Error al insertar las columnas",
     "error_inserting_rows": "Error al insertar las filas",
     "error_moving_columns": "Error al mover las columnas",
-    "error_moving_rows": "Error al mover las filas"
+    "error_moving_rows": "Error al mover las filas",
+    "error_clipboard_paste": "Acceso al portapapeles denegado. Por favor, permite el acceso al portapapeles en tu navegador."
   },
   "formula_bar": {
     "manage_named_ranges": "Gestionar rangos con nombre"

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -149,6 +149,7 @@
     }
   },
   "error_dialog": {
+    "error_clipboard_paste": "Acceso al portapapeles denegado. Por favor, permite el acceso al portapapeles en tu navegador.",
     "error_deleting_cells": "Error al eliminar las celdas",
     "error_deleting_columns": "Error al eliminar las columnas",
     "error_deleting_rows": "Error al eliminar las filas",
@@ -156,8 +157,7 @@
     "error_inserting_columns": "Error al insertar las columnas",
     "error_inserting_rows": "Error al insertar las filas",
     "error_moving_columns": "Error al mover las columnas",
-    "error_moving_rows": "Error al mover las filas",
-    "error_clipboard_paste": "Acceso al portapapeles denegado. Por favor, permite el acceso al portapapeles en tu navegador."
+    "error_moving_rows": "Error al mover las filas"
   },
   "formula_bar": {
     "manage_named_ranges": "Gestionar rangos con nombre"

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -121,6 +121,17 @@
       "show_hidden_columns": "Mostrar columnas ocultas",
       "unfreeze_columns": "Quitar fijación de columnas"
     },
+    "cell": {
+      "cut": "Cortar",
+      "copy": "Copiar",
+      "paste": "Pegar",
+      "insert": "Insertar...",
+      "insert_column_left": "Columna a la izquierda",
+      "insert_column_right": "Columna a la derecha",
+      "insert_row_above": "Fila encima",
+      "insert_row_below": "Fila debajo",
+      "delete": "Eliminar..."
+    },
     "row_header": {
       "delete_row": "Eliminar la fila '{{row}}'",
       "delete_rows": "Eliminar las filas {{rowStart}} - {{rowEnd}}",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -108,6 +108,17 @@
     "use_selection": "Usar rango seleccionado"
   },
   "context_menu": {
+    "cell": {
+      "copy": "Copiar",
+      "cut": "Cortar",
+      "delete": "Eliminar...",
+      "insert": "Insertar...",
+      "insert_column_left": "Columna a la izquierda",
+      "insert_column_right": "Columna a la derecha",
+      "insert_row_above": "Fila encima",
+      "insert_row_below": "Fila debajo",
+      "paste": "Pegar"
+    },
     "column_header": {
       "delete_column": "Eliminar la columna '{{column}}'",
       "delete_columns": "Eliminar las columnas {{columnStart}} - {{columnEnd}}",
@@ -120,17 +131,6 @@
       "move_columns_right": "Mover columnas a la derecha",
       "show_hidden_columns": "Mostrar columnas ocultas",
       "unfreeze_columns": "Quitar fijación de columnas"
-    },
-    "cell": {
-      "cut": "Cortar",
-      "copy": "Copiar",
-      "paste": "Pegar",
-      "insert": "Insertar...",
-      "insert_column_left": "Columna a la izquierda",
-      "insert_column_right": "Columna a la derecha",
-      "insert_row_above": "Fila encima",
-      "insert_row_below": "Fila debajo",
-      "delete": "Eliminar..."
     },
     "row_header": {
       "delete_row": "Eliminar la fila '{{row}}'",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -121,6 +121,17 @@
       "show_hidden_columns": "Afficher les colonnes masquées",
       "unfreeze_columns": "Annuler le figeage des colonnes"
     },
+    "cell": {
+      "cut": "Couper",
+      "copy": "Copier",
+      "paste": "Coller",
+      "insert": "Insérer...",
+      "insert_column_left": "Colonne à gauche",
+      "insert_column_right": "Colonne à droite",
+      "insert_row_above": "Ligne au-dessus",
+      "insert_row_below": "Ligne en-dessous",
+      "delete": "Supprimer..."
+    },
     "row_header": {
       "delete_row": "Supprimer la ligne '{{row}}'",
       "delete_rows": "Supprimer les lignes {{rowStart}} - {{rowEnd}}",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -149,6 +149,7 @@
     }
   },
   "error_dialog": {
+    "error_clipboard_paste": "Accès au presse-papiers refusé. Veuillez autoriser les permissions du presse-papiers dans votre navigateur.",
     "error_deleting_cells": "Échec de la suppression des cellules",
     "error_deleting_columns": "Échec de la suppression des colonnes",
     "error_deleting_rows": "Échec de la suppression des lignes",
@@ -156,8 +157,7 @@
     "error_inserting_columns": "Échec de l'insertion des colonnes",
     "error_inserting_rows": "Échec de l'insertion des lignes",
     "error_moving_columns": "Échec du déplacement des colonnes",
-    "error_moving_rows": "Échec du déplacement des lignes",
-    "error_clipboard_paste": "Accès au presse-papiers refusé. Veuillez autoriser les permissions du presse-papiers dans votre navigateur."
+    "error_moving_rows": "Échec du déplacement des lignes"
   },
   "formula_bar": {
     "manage_named_ranges": "Gérer les plages nommées"

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -108,6 +108,17 @@
     "use_selection": "Utiliser la plage sélectionnée"
   },
   "context_menu": {
+    "cell": {
+      "copy": "Copier",
+      "cut": "Couper",
+      "delete": "Supprimer...",
+      "insert": "Insérer...",
+      "insert_column_left": "Colonne à gauche",
+      "insert_column_right": "Colonne à droite",
+      "insert_row_above": "Ligne au-dessus",
+      "insert_row_below": "Ligne en-dessous",
+      "paste": "Coller"
+    },
     "column_header": {
       "delete_column": "Supprimer la colonne '{{column}}'",
       "delete_columns": "Supprimer les colonnes {{columnStart}} - {{columnEnd}}",
@@ -120,17 +131,6 @@
       "move_columns_right": "Déplacer les colonnes vers la droite",
       "show_hidden_columns": "Afficher les colonnes masquées",
       "unfreeze_columns": "Annuler le figeage des colonnes"
-    },
-    "cell": {
-      "cut": "Couper",
-      "copy": "Copier",
-      "paste": "Coller",
-      "insert": "Insérer...",
-      "insert_column_left": "Colonne à gauche",
-      "insert_column_right": "Colonne à droite",
-      "insert_row_above": "Ligne au-dessus",
-      "insert_row_below": "Ligne en-dessous",
-      "delete": "Supprimer..."
     },
     "row_header": {
       "delete_row": "Supprimer la ligne '{{row}}'",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -112,6 +112,8 @@
       "copy": "Copier",
       "cut": "Couper",
       "delete": "Supprimer...",
+      "delete_column": "Colonne '{{column}}'",
+      "delete_row": "Ligne '{{row}}'",
       "insert": "Insérer...",
       "insert_column_left": "Colonne à gauche",
       "insert_column_right": "Colonne à droite",
@@ -154,7 +156,8 @@
     "error_inserting_columns": "Échec de l'insertion des colonnes",
     "error_inserting_rows": "Échec de l'insertion des lignes",
     "error_moving_columns": "Échec du déplacement des colonnes",
-    "error_moving_rows": "Échec du déplacement des lignes"
+    "error_moving_rows": "Échec du déplacement des lignes",
+    "error_clipboard_paste": "Accès au presse-papiers refusé. Veuillez autoriser les permissions du presse-papiers dans votre navigateur."
   },
   "formula_bar": {
     "manage_named_ranges": "Gérer les plages nommées"

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -121,6 +121,17 @@
       "show_hidden_columns": "Mostra colonne nascoste",
       "unfreeze_columns": "Rimuovi blocco delle colonne"
     },
+    "cell": {
+      "cut": "Taglia",
+      "copy": "Copia",
+      "paste": "Incolla",
+      "insert": "Inserisci...",
+      "insert_column_left": "Colonna a sinistra",
+      "insert_column_right": "Colonna a destra",
+      "insert_row_above": "Riga sopra",
+      "insert_row_below": "Riga sotto",
+      "delete": "Elimina..."
+    },
     "row_header": {
       "delete_row": "Elimina la riga '{{row}}'",
       "delete_rows": "Elimina le righe {{rowStart}} - {{rowEnd}}",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -112,6 +112,8 @@
       "copy": "Copia",
       "cut": "Taglia",
       "delete": "Elimina...",
+      "delete_column": "Colonna '{{column}}'",
+      "delete_row": "Riga '{{row}}'",
       "insert": "Inserisci...",
       "insert_column_left": "Colonna a sinistra",
       "insert_column_right": "Colonna a destra",
@@ -154,7 +156,8 @@
     "error_inserting_columns": "Impossibile inserire le colonne",
     "error_inserting_rows": "Impossibile inserire le righe",
     "error_moving_columns": "Impossibile spostare le colonne",
-    "error_moving_rows": "Impossibile spostare le righe"
+    "error_moving_rows": "Impossibile spostare le righe",
+    "error_clipboard_paste": "Accesso agli appunti negato. Consenti le autorizzazioni per gli appunti nel tuo browser."
   },
   "formula_bar": {
     "manage_named_ranges": "Gestisci intervalli denominati"

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -149,6 +149,7 @@
     }
   },
   "error_dialog": {
+    "error_clipboard_paste": "Accesso agli appunti negato. Consenti le autorizzazioni per gli appunti nel tuo browser.",
     "error_deleting_cells": "Impossibile eliminare le celle",
     "error_deleting_columns": "Impossibile eliminare le colonne",
     "error_deleting_rows": "Impossibile eliminare le righe",
@@ -156,8 +157,7 @@
     "error_inserting_columns": "Impossibile inserire le colonne",
     "error_inserting_rows": "Impossibile inserire le righe",
     "error_moving_columns": "Impossibile spostare le colonne",
-    "error_moving_rows": "Impossibile spostare le righe",
-    "error_clipboard_paste": "Accesso agli appunti negato. Consenti le autorizzazioni per gli appunti nel tuo browser."
+    "error_moving_rows": "Impossibile spostare le righe"
   },
   "formula_bar": {
     "manage_named_ranges": "Gestisci intervalli denominati"

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -108,6 +108,17 @@
     "use_selection": "Usa intervallo selezionato"
   },
   "context_menu": {
+    "cell": {
+      "copy": "Copia",
+      "cut": "Taglia",
+      "delete": "Elimina...",
+      "insert": "Inserisci...",
+      "insert_column_left": "Colonna a sinistra",
+      "insert_column_right": "Colonna a destra",
+      "insert_row_above": "Riga sopra",
+      "insert_row_below": "Riga sotto",
+      "paste": "Incolla"
+    },
     "column_header": {
       "delete_column": "Elimina la colonna '{{column}}'",
       "delete_columns": "Elimina le colonne {{columnStart}} - {{columnEnd}}",
@@ -120,17 +131,6 @@
       "move_columns_right": "Sposta le colonne a destra",
       "show_hidden_columns": "Mostra colonne nascoste",
       "unfreeze_columns": "Rimuovi blocco delle colonne"
-    },
-    "cell": {
-      "cut": "Taglia",
-      "copy": "Copia",
-      "paste": "Incolla",
-      "insert": "Inserisci...",
-      "insert_column_left": "Colonna a sinistra",
-      "insert_column_right": "Colonna a destra",
-      "insert_row_above": "Riga sopra",
-      "insert_row_below": "Riga sotto",
-      "delete": "Elimina..."
     },
     "row_header": {
       "delete_row": "Elimina la riga '{{row}}'",


### PR DESCRIPTION
This PR adds back the cell context menu we temporarily removed a few weeks back. Changes:

- Adds a new file `Cell.tsx`, next to the Row and Header context menu files
  - It includes 3 new actions: Cut, Copy and Paste
  - Also includes 'Insert row above/below and column left/right' and 'Delete column/row'
- Updates `Worksheet.tsx` so the context is usable. Note that this brings some code repetition as some actions are shared with Row and Column Header contexts
- Updates all 5 locale files: en, es, de, it, fr

I also made a fix in the Menu component as there was a bug that was making submenu items unusable.