### PR TITLE
fix: bug in `Menu` component

### DIFF
--- a/webapp/IronCalc/src/components/Menu/Menu.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.tsx
@@ -22,6 +22,7 @@ const focusableSelector =
 export const MenuContext = createContext<{
   close: () => void;
   activeSetOpenRef: RefObject<((open: boolean) => void) | null>;
+  activeSubMenuNodeRef: RefObject<Element | null>;
 } | null>(null);
 
 interface MenuTriggerProperties {
@@ -62,6 +63,7 @@ export function Menu(props: MenuProperties) {
     : anchorPosition.position;
 
   const activeSetOpenRef = useRef<((open: boolean) => void) | null>(null);
+  const activeSubMenuNodeRef = useRef<Element | null>(null);
 
   const onClose = !isTriggerMode ? props.onClose : undefined;
   const close = useCallback(() => {
@@ -93,7 +95,13 @@ export function Menu(props: MenuProperties) {
         ? (triggerPosition.triggerRef.current?.contains(target) ?? false)
         : false;
 
-      if (!triggerContains && !(menuRef.current?.contains(target) ?? false)) {
+      const subMenuContains =
+        activeSubMenuNodeRef.current?.contains(target) ?? false;
+      if (
+        !triggerContains &&
+        !(menuRef.current?.contains(target) ?? false) &&
+        !subMenuContains
+      ) {
         close();
       }
     }
@@ -133,7 +141,9 @@ export function Menu(props: MenuProperties) {
 
   if (!isTriggerMode) {
     return (
-      <MenuContext.Provider value={{ close, activeSetOpenRef }}>
+      <MenuContext.Provider
+        value={{ close, activeSetOpenRef, activeSubMenuNodeRef }}
+      >
         {menu}
       </MenuContext.Provider>
     );
@@ -155,7 +165,9 @@ export function Menu(props: MenuProperties) {
   );
 
   return (
-    <MenuContext.Provider value={{ close, activeSetOpenRef }}>
+    <MenuContext.Provider
+      value={{ close, activeSetOpenRef, activeSubMenuNodeRef }}
+    >
       {clonedTrigger}
       {menu}
     </MenuContext.Provider>

--- a/webapp/IronCalc/src/components/Menu/MenuItem.tsx
+++ b/webapp/IronCalc/src/components/Menu/MenuItem.tsx
@@ -1,5 +1,12 @@
 import { Check, ChevronRight } from "lucide-react";
-import { type ReactNode, useContext, useEffect, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { MenuContext } from "./Menu";
 import { useAnchorPosition } from "./useAnchorPosition";
@@ -94,6 +101,7 @@ export function MenuItemWithSubmenu({
   const submenuActiveSetOpenRef = useRef<((open: boolean) => void) | null>(
     null,
   );
+  const submenuActiveSubMenuNodeRef = useRef<Element | null>(null);
 
   const { menuRef, position } = useAnchorPosition(open, anchor);
   const { handleMenuKeyDown } = useMenuKeyDown(
@@ -122,6 +130,16 @@ export function MenuItemWithSubmenu({
       }
     };
   }, [parentActiveSetOpenRef]);
+
+  useLayoutEffect(() => {
+    const subMenuNodeRef = parentMenu?.activeSubMenuNodeRef;
+    if (!subMenuNodeRef) return;
+    if (open) {
+      subMenuNodeRef.current = menuRef.current;
+    } else {
+      subMenuNodeRef.current = null;
+    }
+  }, [open, parentMenu, menuRef]);
 
   function show() {
     if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
@@ -193,6 +211,7 @@ export function MenuItemWithSubmenu({
               value={{
                 close: closeAll,
                 activeSetOpenRef: submenuActiveSetOpenRef,
+                activeSubMenuNodeRef: submenuActiveSubMenuNodeRef,
               }}
             >
               <div


### PR DESCRIPTION
This PR fixes the language switcher broken by the menu refactor. See #970 

The outside-click handler was closing the parent menu on `pointerdown` before the submenu click could fire.