### PR TITLE
fix: submenu behavior and menu anchor positioning

### DIFF
--- a/webapp/IronCalc/src/components/Menu/Menu.stories.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.stories.tsx
@@ -206,37 +206,38 @@ export const WithSubmenu: Story = {
     trigger: <Button variant="secondary">Open menu</Button>,
     children: null,
   },
-  render: () => (
-    <Menu trigger={<Button variant="secondary">123</Button>}>
-      <MenuItem onClick={() => {}}>Auto</MenuItem>
-      <MenuDivider />
-      <MenuItem onClick={() => {}}>Number</MenuItem>
-      <MenuItem onClick={() => {}}>Percentage</MenuItem>
-      <MenuDivider />
-      <MenuItemWithSubmenu
-        submenu={
-          <>
-            <MenuItem onClick={() => {}}>EUR €</MenuItem>
-            <MenuItem onClick={() => {}}>USD $</MenuItem>
-            <MenuItem onClick={() => {}}>GBP £</MenuItem>
-          </>
-        }
-      >
-        Currency
-      </MenuItemWithSubmenu>
-      <MenuDivider />
-      <MenuItemWithSubmenu
-        submenu={
-          <>
-            <MenuItem onClick={() => {}}>Short date</MenuItem>
-            <MenuItem onClick={() => {}}>Long date</MenuItem>
-          </>
-        }
-      >
-        Date
-      </MenuItemWithSubmenu>
-    </Menu>
-  ),
+  render: () => {
+    const [selected, setSelected] = useState("123");
+    return (
+      <Menu trigger={<Button variant="secondary">{selected}</Button>}>
+        <MenuItemWithSubmenu
+          submenu={
+            <>
+              <MenuItem onClick={() => setSelected("EUR €")}>EUR €</MenuItem>
+              <MenuItem onClick={() => setSelected("USD $")}>USD $</MenuItem>
+              <MenuItem onClick={() => setSelected("GBP £")}>GBP £</MenuItem>
+            </>
+          }
+        >
+          Currency
+        </MenuItemWithSubmenu>
+        <MenuItemWithSubmenu
+          submenu={
+            <>
+              <MenuItem onClick={() => setSelected("Short date")}>
+                Short date
+              </MenuItem>
+              <MenuItem onClick={() => setSelected("Long date")}>
+                Long date
+              </MenuItem>
+            </>
+          }
+        >
+          Date
+        </MenuItemWithSubmenu>
+      </Menu>
+    );
+  },
 };
 
 export const ContextMenu: Story = {

--- a/webapp/IronCalc/src/components/Menu/Menu.stories.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.stories.tsx
@@ -55,6 +55,43 @@ function MenuItems() {
   );
 }
 
+function MenuItemsWithSub() {
+  return (
+    <>
+      <MenuItem icon={<Copy />} secondaryText="⌘C" onClick={() => {}}>
+        Copy
+      </MenuItem>
+      <MenuItem icon={<Scissors />} secondaryText="⌘X" onClick={() => {}}>
+        Cut
+      </MenuItem>
+      <MenuItem icon={<Clipboard />} secondaryText="⌘V" onClick={() => {}}>
+        Paste
+      </MenuItem>
+      <MenuDivider />
+      <MenuItem
+        icon={<Trash2 />}
+        secondaryText="⌘⌫"
+        destructive
+        onClick={() => {}}
+      >
+        Delete
+      </MenuItem>
+      <MenuDivider />
+      <MenuItemWithSubmenu
+        submenu={
+          <>
+            <MenuItem onClick={() => {}}>Option A</MenuItem>
+            <MenuItem onClick={() => {}}>Option B</MenuItem>
+            <MenuItem onClick={() => {}}>Option C</MenuItem>
+          </>
+        }
+      >
+        More
+      </MenuItemWithSubmenu>
+    </>
+  );
+}
+
 export const CornerPositioning: Story = {
   args: {
     trigger: <Button variant="secondary">Open menu</Button>,
@@ -65,7 +102,7 @@ export const CornerPositioning: Story = {
     <div>
       <div style={{ position: "absolute", top: 16, left: 16 }}>
         <Menu trigger={<Button variant="secondary">Top-left</Button>}>
-          <MenuItems />
+          <MenuItemsWithSub />
         </Menu>
       </div>
 
@@ -78,13 +115,13 @@ export const CornerPositioning: Story = {
         }}
       >
         <Menu trigger={<Button variant="secondary">Top-center</Button>}>
-          <MenuItems />
+          <MenuItemsWithSub />
         </Menu>
       </div>
 
       <div style={{ position: "absolute", top: 16, right: 16 }}>
         <Menu trigger={<Button variant="secondary">Top-right</Button>}>
-          <MenuItems />
+          <MenuItemsWithSub />
         </Menu>
       </div>
 
@@ -97,7 +134,7 @@ export const CornerPositioning: Story = {
         }}
       >
         <Menu trigger={<Button variant="secondary">Left-center</Button>}>
-          <MenuItems />
+          <MenuItemsWithSub />
         </Menu>
       </div>
 
@@ -110,13 +147,13 @@ export const CornerPositioning: Story = {
         }}
       >
         <Menu trigger={<Button variant="secondary">Right-center</Button>}>
-          <MenuItems />
+          <MenuItemsWithSub />
         </Menu>
       </div>
 
       <div style={{ position: "absolute", bottom: 16, left: 16 }}>
         <Menu trigger={<Button variant="secondary">Bottom-left</Button>}>
-          <MenuItems />
+          <MenuItemsWithSub />
         </Menu>
       </div>
 
@@ -129,13 +166,13 @@ export const CornerPositioning: Story = {
         }}
       >
         <Menu trigger={<Button variant="secondary">Bottom-center</Button>}>
-          <MenuItems />
+          <MenuItemsWithSub />
         </Menu>
       </div>
 
       <div style={{ position: "absolute", bottom: 16, right: 16 }}>
         <Menu trigger={<Button variant="secondary">Bottom-right</Button>}>
-          <MenuItems />
+          <MenuItemsWithSub />
         </Menu>
       </div>
     </div>

--- a/webapp/IronCalc/src/components/Menu/Menu.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.tsx
@@ -93,8 +93,13 @@ export function Menu(props: MenuProperties) {
         ? (triggerPosition.triggerRef.current?.contains(target) ?? false)
         : false;
 
-      const insideAnyMenu = (target as Element).closest?.(".ic-menu-wrapper") !== null;
-      if (!triggerContains && !(menuRef.current?.contains(target) ?? false) && !insideAnyMenu) {
+      const insideAnyMenu =
+        (target as Element).closest?.(".ic-menu-wrapper") !== null;
+      if (
+        !triggerContains &&
+        !(menuRef.current?.contains(target) ?? false) &&
+        !insideAnyMenu
+      ) {
         close();
       }
     }

--- a/webapp/IronCalc/src/components/Menu/Menu.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.tsx
@@ -93,7 +93,8 @@ export function Menu(props: MenuProperties) {
         ? (triggerPosition.triggerRef.current?.contains(target) ?? false)
         : false;
 
-      if (!triggerContains && !(menuRef.current?.contains(target) ?? false)) {
+      const insideAnyMenu = (target as Element).closest?.(".ic-menu-wrapper") !== null;
+      if (!triggerContains && !(menuRef.current?.contains(target) ?? false) && !insideAnyMenu) {
         close();
       }
     }

--- a/webapp/IronCalc/src/components/Menu/Menu.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.tsx
@@ -94,7 +94,8 @@ export function Menu(props: MenuProperties) {
         : false;
 
       const insideAnyMenu =
-        (target as Element).closest?.(".ic-menu-wrapper") !== null;
+        target instanceof Element &&
+        target.closest(".ic-menu-wrapper") !== null;
       if (
         !triggerContains &&
         !(menuRef.current?.contains(target) ?? false) &&

--- a/webapp/IronCalc/src/components/Menu/MenuItem.tsx
+++ b/webapp/IronCalc/src/components/Menu/MenuItem.tsx
@@ -86,7 +86,7 @@ export function MenuItemWithSubmenu({
   const parentActiveSetOpenRef = parentMenu?.activeSetOpenRef ?? null;
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState<
-    { x: number; y: number; flipX?: number } | undefined
+    { x: number; y: number; flipX?: number; flipY?: number } | undefined
   >();
   const itemRef = useRef<HTMLButtonElement>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -134,7 +134,12 @@ export function MenuItemWithSubmenu({
     if (parentActiveSetOpenRef) parentActiveSetOpenRef.current = setOpen;
     const rect = itemRef.current?.getBoundingClientRect();
     if (rect) {
-      setAnchor({ x: rect.right + 4, y: rect.top - 4, flipX: rect.left - 4 });
+      setAnchor({
+        x: rect.right + 4,
+        y: rect.top - 4,
+        flipX: rect.left - 4,
+        flipY: rect.bottom + 4,
+      });
     }
     setOpen(true);
   }

--- a/webapp/IronCalc/src/components/Menu/useAnchorPosition.ts
+++ b/webapp/IronCalc/src/components/Menu/useAnchorPosition.ts
@@ -2,7 +2,7 @@ import { type CSSProperties, useLayoutEffect, useRef, useState } from "react";
 
 export function useAnchorPosition(
   open: boolean,
-  anchor: { x: number; y: number; flipX?: number } | undefined,
+  anchor: { x: number; y: number; flipX?: number; flipY?: number } | undefined,
 ) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState<CSSProperties>({});
@@ -27,12 +27,15 @@ export function useAnchorPosition(
       let left = anchor.x;
       let top = anchor.y;
 
-      // Flip above the anchor when the menu would overflow below and there's room above
-      if (
-        top + menuHeight > viewportHeight - margin &&
-        anchor.y - menuHeight > margin
-      ) {
-        top = anchor.y - menuHeight;
+      // Flip vertically when the menu would overflow below
+      if (top + menuHeight > viewportHeight - margin) {
+        if (anchor.flipY !== undefined) {
+          // Submenu: align bottom of submenu with item bottom
+          top = anchor.flipY - menuHeight;
+        } else if (anchor.y - menuHeight > margin) {
+          // Dropdown: flip above the anchor point
+          top = anchor.y - menuHeight;
+        }
       }
 
       if (left + menuWidth > viewportWidth - margin) {


### PR DESCRIPTION
This PR fixes 2 issues we were having with the Menu component:

1. Submenu items were not applying changes: clicking items inside a submenu was closing the parent menu before the `onClick` handler could fire, because clicks inside nested menus were incorrectly treated as outside clicks. 

2. Submenus were not properly aligned when placed near the bottom of the viewport

### Changes:

- `Menu.tsx`: ignore outside-click events when the target is inside a nested menu wrapper
- `MenuItem.tsx`: pass `flipY` anchor coordinate when computing submenu position
- `useAnchorPosition.ts`: handle `flipY` to align submenu bottom edge when near the viewport bottom
- `Menu.stories.tsx`: improve submenu stories so we can catch issues with clicking and positioning


After the fix, this how the submenu is aligned when near the bottom edge:

<img width="488" height="258" alt="image" src="https://github.com/user-attachments/assets/34648b5f-bba5-46fd-aa26-023b683d2ff3" />

---

Fixes #970 