### PR TITLE
fix: styling and flickering in Name Manager input

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
@@ -6,6 +6,7 @@ import { Button } from "../../Button/Button";
 import { IconButton } from "../../Button/IconButton";
 import { Input } from "../../Input/Input";
 import { Select } from "../../Select/Select";
+import { Tooltip } from "../../Tooltip/Tooltip";
 import { getFullRangeToString } from "../../util";
 import "./edit-name-range.css";
 
@@ -204,23 +205,24 @@ const EditNamedRange = ({
             ]}
           />
           <Input
-              label={t("name_manager_dialog.refers_to")}
-              placeholder={t("name_manager_dialog.enter_formula")}
-              value={formula}
-              error={!!formulaError}
-              helperText={formulaError || undefined}
-              onChange={(e) => {
-                setFormula(e.target.value);
-                setFormulaError("");
-              }}
-              onKeyDown={handleKeyDown}
-              endAdornment={
+            label={t("name_manager_dialog.refers_to")}
+            placeholder={t("name_manager_dialog.enter_formula")}
+            value={formula}
+            error={!!formulaError}
+            helperText={formulaError || undefined}
+            onChange={(e) => {
+              setFormula(e.target.value);
+              setFormulaError("");
+            }}
+            onKeyDown={handleKeyDown}
+            endAdornment={
+              <Tooltip title={t("name_manager_dialog.use_selection")}>
                 <IconButton
-                  title={t("name_manager_dialog.use_selection")}
-                  aria-label={t("name_manager_dialog.use_selection")}
                   size="sm"
-                  variant="ghost"
+                  variant="secondary"
                   icon={<SquareMousePointer />}
+                  aria-label={t("name_manager_dialog.use_selection")}
+                  className="ic-edit-range-range-button"
                   onClick={() => {
                     const worksheetNames = model
                       .getWorksheetsProperties()
@@ -233,8 +235,9 @@ const EditNamedRange = ({
                     setFormula(formula);
                   }}
                 />
-              }
-            />
+              </Tooltip>
+            }
+          />
         </div>
       </div>
       <div className="ic-edit-range-footer">

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
@@ -80,7 +80,6 @@ const EditNamedRange = ({
   const isSelected = (value: string) => scope === value;
 
   const nameId = useId();
-  const formulaId = useId();
 
   // Validate name (format and duplicates)
   useEffect(() => {
@@ -204,54 +203,38 @@ const EditNamedRange = ({
               })),
             ]}
           />
-          <div className="ic-edit-range-field-wrapper">
-            <div className="ic-edit-range-line-wrapper">
-              <label className="ic-edit-range-label" htmlFor={formulaId}>
-                {t("name_manager_dialog.refers_to")}
-              </label>
-              <IconButton
-                title={t("name_manager_dialog.use_selection")}
-                aria-label={t("name_manager_dialog.use_selection")}
-                size="sm"
-                variant="ghost"
-                icon={<SquareMousePointer />}
-                onClick={() => {
-                  const worksheetNames = model
-                    .getWorksheetsProperties()
-                    .map((s) => s.name);
-                  const selectedView = model.getSelectedView();
-                  const formula = getFullRangeToString(
-                    selectedView,
-                    worksheetNames,
-                  );
-                  setFormula(formula);
-                }}
-              />
-            </div>
-            <div className="ic-edit-range-form-control">
-              <textarea
-                id={formulaId}
-                className={`ic-edit-range-textarea ${
-                  formulaError ? "ic-edit-range-textarea--error" : ""
-                }`}
-                placeholder={t("name_manager_dialog.enter_formula")}
-                rows={3}
-                value={formula}
-                onChange={(e) => {
-                  setFormula(e.target.value);
-                  setFormulaError("");
-                }}
-                onKeyDown={handleKeyDown}
-                onClick={(e) => e.stopPropagation()}
-                aria-invalid={formulaError ? "true" : "false"}
-              />
-              {formulaError && (
-                <span className="ic-edit-range-helper-text ic-edit-range-error-text">
-                  {formulaError}
-                </span>
-              )}
-            </div>
-          </div>
+          <Input
+              label={t("name_manager_dialog.refers_to")}
+              placeholder={t("name_manager_dialog.enter_formula")}
+              value={formula}
+              error={!!formulaError}
+              helperText={formulaError || undefined}
+              onChange={(e) => {
+                setFormula(e.target.value);
+                setFormulaError("");
+              }}
+              onKeyDown={handleKeyDown}
+              endAdornment={
+                <IconButton
+                  title={t("name_manager_dialog.use_selection")}
+                  aria-label={t("name_manager_dialog.use_selection")}
+                  size="sm"
+                  variant="ghost"
+                  icon={<SquareMousePointer />}
+                  onClick={() => {
+                    const worksheetNames = model
+                      .getWorksheetsProperties()
+                      .map((s) => s.name);
+                    const selectedView = model.getSelectedView();
+                    const formula = getFullRangeToString(
+                      selectedView,
+                      worksheetNames,
+                    );
+                    setFormula(formula);
+                  }}
+                />
+              }
+            />
         </div>
       </div>
       <div className="ic-edit-range-footer">

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
@@ -84,26 +84,29 @@ const EditNamedRange = ({
 
   // Validate name (format and duplicates)
   useEffect(() => {
-    const worksheets = model.getWorksheetsProperties();
-    const scopeIndex = worksheets.findIndex((s) => s.name === scope);
-    const newScope = scopeIndex >= 0 ? scopeIndex : null;
-    try {
-      model.isValidDefinedName(name, newScope, formula);
-    } catch (e) {
-      const message = (e as Error).message;
-      if (editingDefinedName && message.includes("already exists")) {
-        // Allow the same name if it's the one being edited
-        setNameError("");
-        setFormulaError("");
+    const timer = setTimeout(() => {
+      const worksheets = model.getWorksheetsProperties();
+      const scopeIndex = worksheets.findIndex((s) => s.name === scope);
+      const newScope = scopeIndex >= 0 ? scopeIndex : null;
+      try {
+        model.isValidDefinedName(name, newScope, formula);
+      } catch (e) {
+        const message = (e as Error).message;
+        if (editingDefinedName && message.includes("already exists")) {
+          // Allow the same name if it's the one being edited
+          setNameError("");
+          setFormulaError("");
+          return;
+        }
+        const { nameError, formulaError } = formatOnSaveError(message);
+        setNameError(nameError);
+        setFormulaError(formulaError);
         return;
       }
-      const { nameError, formulaError } = formatOnSaveError(message);
-      setNameError(nameError);
-      setFormulaError(formulaError);
-      return;
-    }
-    setNameError("");
-    setFormulaError("");
+      setNameError("");
+      setFormulaError("");
+    }, 300);
+    return () => clearTimeout(timer);
   }, [name, scope, formula, model, editingDefinedName]);
 
   const hasAnyError = nameError !== "" || formulaError !== "";

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/edit-name-range.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/edit-name-range.css
@@ -86,6 +86,11 @@
   }
 }
 
+.ic-edit-range-range-button.ic-button {
+  --button-height: 24px;
+  margin-right: -2px;
+  border-radius: 3px;
+}
 
 .ic-edit-range-footer {
   display: flex;

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/edit-name-range.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/edit-name-range.css
@@ -86,39 +86,6 @@
   }
 }
 
-/* Used by the formula textarea field which is not an Input component */
-.ic-edit-range-field-wrapper {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  gap: 2px;
-}
-
-.ic-edit-range-label {
-  display: block;
-  font-size: var(--typography-font-size);
-  font-family: var(--typography-font-family);
-  font-weight: 500;
-  color: var(--palette-common-black);
-}
-
-.ic-edit-range-helper-text {
-  margin: 0;
-  padding: 0;
-  font-size: var(--typography-font-size);
-  font-family: var(--typography-font-family);
-  line-height: 1.4;
-  color: var(--palette-grey-500);
-}
-
-.ic-edit-range-error-text {
-  color: var(--palette-error-main);
-}
-
-.ic-edit-range-form-control {
-  display: flex;
-  flex-direction: column;
-}
 
 .ic-edit-range-footer {
   display: flex;
@@ -127,35 +94,4 @@
   gap: 8px;
   padding: 8px;
   border-top: 1px solid var(--palette-grey-300);
-}
-
-.ic-edit-range-textarea {
-  width: 100%;
-  box-sizing: border-box;
-
-  font-family: var(--typography-font-family);
-  font-size: var(--typography-font-size);
-
-  padding: 8px;
-  margin: 0;
-
-  border: 1px solid var(--palette-grey-300);
-  border-radius: 4px;
-  background-color: var(--palette-common-white);
-  color: var(--palette-common-black);
-
-  resize: none;
-  outline: none;
-}
-
-.ic-edit-range-textarea:hover:not(.ic-edit-range-textarea--error) {
-  border: 1px solid var(--palette-grey-600);
-}
-
-.ic-edit-range-textarea:focus:not(.ic-edit-range-textarea--error) {
-  border: 2px solid var(--palette-primary-main);
-}
-
-.ic-edit-range-textarea--error {
-  border: 2px solid var(--palette-error-main);
 }


### PR DESCRIPTION
This PR fixes the following in the Edit Named Ranges drawer:

1. An aesthetic inconsistency in the 'Refers to' input:
  - We were using a custom textarea and now we use the `Input` component
  - The 'Update selection' icon button was using and old styling so I've put it inside the input, as we do in the Conditional Formatting inputs

Before:
<img width="350" height="107" alt="image" src="https://github.com/user-attachments/assets/150448fa-2420-46a0-bbb6-322d196055c2" /> 

After:
<img width="353" height="79" alt="image" src="https://github.com/user-attachments/assets/6305903e-c8cb-4a8d-942f-834141a719eb" />

2. There was an annoying flickering while typing this input, it would appear in between introducing every character. Now we're adding a 300ms timeout so there's some time until the error message appears.