### PR TITLE
UPDATE: Adds named cell styles

### DIFF
--- a/base/src/builtin_styles.rs
+++ b/base/src/builtin_styles.rs
@@ -1,0 +1,386 @@
+use crate::{
+    colors::hex_with_tint_to_rgb,
+    types::{Border, BorderItem, BorderStyle, Fill, Font, FontScheme, Style},
+};
+
+const ACCENT1: &str = "#4472C4";
+const ACCENT2: &str = "#ED7D31";
+const ACCENT3: &str = "#A5A5A5";
+const ACCENT4: &str = "#FFC000";
+const ACCENT5: &str = "#5B9BD5";
+const ACCENT6: &str = "#70AD47";
+const DK2: &str = "#44546A";
+
+fn solid_fill(color: &str) -> Fill {
+    Fill {
+        pattern_type: "solid".to_string(),
+        fg_color: Some(color.to_string()),
+        bg_color: None,
+    }
+}
+
+fn thin_box_border(color: &str) -> Border {
+    let item = Some(BorderItem {
+        style: BorderStyle::Thin,
+        color: Some(color.to_string()),
+    });
+    Border {
+        left: item.clone(),
+        right: item.clone(),
+        top: item.clone(),
+        bottom: item,
+        ..Default::default()
+    }
+}
+
+fn double_box_border(color: &str) -> Border {
+    let item = Some(BorderItem {
+        style: BorderStyle::Double,
+        color: Some(color.to_string()),
+    });
+    Border {
+        left: item.clone(),
+        right: item.clone(),
+        top: item.clone(),
+        bottom: item,
+        ..Default::default()
+    }
+}
+
+fn thick_bottom_border(color: &str) -> Border {
+    Border {
+        bottom: Some(BorderItem {
+            style: BorderStyle::Thick,
+            color: Some(color.to_string()),
+        }),
+        ..Default::default()
+    }
+}
+
+fn thin_top_double_bottom_border(color: &str) -> Border {
+    Border {
+        top: Some(BorderItem {
+            style: BorderStyle::Thin,
+            color: Some(color.to_string()),
+        }),
+        bottom: Some(BorderItem {
+            style: BorderStyle::Double,
+            color: Some(color.to_string()),
+        }),
+        ..Default::default()
+    }
+}
+
+/// Returns the full list of Excel built-in named styles with their style definitions.
+#[allow(clippy::vec_init_then_push)]
+pub fn builtin_named_styles() -> Vec<(String, Style)> {
+    let mut result = vec![];
+
+    // Good, Bad, Neutral
+    result.push((
+        "Good".to_string(),
+        Style {
+            font: Font {
+                color: Some("#006100".to_string()),
+                ..Default::default()
+            },
+            fill: solid_fill("#C6EFCE"),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Bad".to_string(),
+        Style {
+            font: Font {
+                color: Some("#9C0006".to_string()),
+                ..Default::default()
+            },
+            fill: solid_fill("#FFC7CE"),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Neutral".to_string(),
+        Style {
+            font: Font {
+                color: Some("#9C5700".to_string()),
+                ..Default::default()
+            },
+            fill: solid_fill("#FFEB9C"),
+            ..Default::default()
+        },
+    ));
+
+    // Normal (always in every model, included here for the panel)
+    result.push(("Normal".to_string(), Style::default()));
+
+    // Data and Model
+    result.push((
+        "Calculation".to_string(),
+        Style {
+            font: Font {
+                b: true,
+                color: Some("#FA7D00".to_string()),
+                ..Default::default()
+            },
+            fill: solid_fill("#F2F2F2"),
+            border: thin_box_border("#7F7F7F"),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Check Cell".to_string(),
+        Style {
+            font: Font {
+                b: true,
+                color: Some("#FFFFFF".to_string()),
+                ..Default::default()
+            },
+            fill: solid_fill("#A5A5A5"),
+            border: double_box_border("#3F3F3F"),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Explanatory Text".to_string(),
+        Style {
+            font: Font {
+                i: true,
+                color: Some("#7F7F7F".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Input".to_string(),
+        Style {
+            font: Font {
+                color: Some("#3F3F76".to_string()),
+                ..Default::default()
+            },
+            fill: solid_fill("#FFCC99"),
+            border: thin_box_border("#7F7F7F"),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Linked Cell".to_string(),
+        Style {
+            font: Font {
+                color: Some("#FA7D00".to_string()),
+                ..Default::default()
+            },
+            border: Border {
+                bottom: Some(BorderItem {
+                    style: BorderStyle::Double,
+                    color: Some("#FF8001".to_string()),
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Note".to_string(),
+        Style {
+            fill: solid_fill("#FFFFE1"),
+            border: thin_box_border("#B2B2B2"),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Output".to_string(),
+        Style {
+            font: Font {
+                b: true,
+                color: Some("#3F3F3F".to_string()),
+                ..Default::default()
+            },
+            fill: solid_fill("#F2F2F2"),
+            border: thin_box_border("#3F3F3F"),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Warning Text".to_string(),
+        Style {
+            font: Font {
+                color: Some("#FF0000".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ));
+
+    // Titles and Headings
+    result.push((
+        "Title".to_string(),
+        Style {
+            font: Font {
+                sz: 18,
+                color: Some(DK2.to_string()),
+                scheme: FontScheme::Major,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Heading 1".to_string(),
+        Style {
+            font: Font {
+                b: true,
+                sz: 15,
+                color: Some(DK2.to_string()),
+                ..Default::default()
+            },
+            border: thick_bottom_border(ACCENT1),
+            ..Default::default()
+        },
+    ));
+    let h2_border_color = hex_with_tint_to_rgb(ACCENT1, 0.5);
+    result.push((
+        "Heading 2".to_string(),
+        Style {
+            font: Font {
+                b: true,
+                sz: 13,
+                color: Some(DK2.to_string()),
+                ..Default::default()
+            },
+            border: thick_bottom_border(&h2_border_color),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Heading 3".to_string(),
+        Style {
+            font: Font {
+                b: true,
+                color: Some(DK2.to_string()),
+                ..Default::default()
+            },
+            border: Border {
+                bottom: Some(BorderItem {
+                    style: BorderStyle::Thin,
+                    color: Some(ACCENT1.to_string()),
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Heading 4".to_string(),
+        Style {
+            font: Font {
+                b: true,
+                i: true,
+                color: Some(DK2.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Total".to_string(),
+        Style {
+            font: Font {
+                b: true,
+                ..Default::default()
+            },
+            border: thin_top_double_bottom_border(ACCENT1),
+            ..Default::default()
+        },
+    ));
+
+    // Themed Cell Styles: 20% / 40% / 60% tints and solid for each accent
+    for (accent_name, accent_hex) in [
+        ("Accent1", ACCENT1),
+        ("Accent2", ACCENT2),
+        ("Accent3", ACCENT3),
+        ("Accent4", ACCENT4),
+        ("Accent5", ACCENT5),
+        ("Accent6", ACCENT6),
+    ] {
+        let c20 = hex_with_tint_to_rgb(accent_hex, 0.8);
+        result.push((
+            format!("20% - {accent_name}"),
+            Style {
+                fill: solid_fill(&c20),
+                ..Default::default()
+            },
+        ));
+        let c40 = hex_with_tint_to_rgb(accent_hex, 0.6);
+        result.push((
+            format!("40% - {accent_name}"),
+            Style {
+                fill: solid_fill(&c40),
+                ..Default::default()
+            },
+        ));
+        let c60 = hex_with_tint_to_rgb(accent_hex, 0.4);
+        result.push((
+            format!("60% - {accent_name}"),
+            Style {
+                fill: solid_fill(&c60),
+                ..Default::default()
+            },
+        ));
+        result.push((
+            accent_name.to_string(),
+            Style {
+                fill: solid_fill(accent_hex),
+                ..Default::default()
+            },
+        ));
+    }
+
+    // Number Format styles
+    result.push((
+        "Comma".to_string(),
+        Style {
+            num_fmt: "#,##0.00".to_string(),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Comma [0]".to_string(),
+        Style {
+            num_fmt: "#,##0".to_string(),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Currency".to_string(),
+        Style {
+            num_fmt: r#"_("$"* #,##0.00_);_("$"* \(#,##0.00\);_("$"* "-"??_);_(@_)"#.to_string(),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Currency [0]".to_string(),
+        Style {
+            num_fmt: r#"_("$"* #,##0_);_("$"* \(#,##0\);_("$"* "-"_);_(@_)"#.to_string(),
+            ..Default::default()
+        },
+    ));
+    result.push((
+        "Percent".to_string(),
+        Style {
+            num_fmt: "0%".to_string(),
+            ..Default::default()
+        },
+    ));
+
+    result
+}
+
+/// Looks up a built-in named style by name (case-sensitive). Returns `None` if not found.
+pub fn get_builtin_style(name: &str) -> Option<Style> {
+    builtin_named_styles()
+        .into_iter()
+        .find(|(n, _)| n == name)
+        .map(|(_, s)| s)
+}

--- a/base/src/colors.rs
+++ b/base/src/colors.rs
@@ -9,18 +9,18 @@ use core::cmp::min;
 // Warning: Excel uses a weird normalization for HSL colors (0, 255)
 // We use a more standard one but our HSL numbers will not coincide with Excel's
 
-pub(crate) fn hex_to_rgb(h: &str) -> [i32; 3] {
+pub fn hex_to_rgb(h: &str) -> [i32; 3] {
     let r = i32::from_str_radix(&h[1..3], 16).unwrap();
     let g = i32::from_str_radix(&h[3..5], 16).unwrap();
     let b = i32::from_str_radix(&h[5..7], 16).unwrap();
     [r, g, b]
 }
 
-pub(crate) fn rgb_to_hex(rgb: [i32; 3]) -> String {
+pub fn rgb_to_hex(rgb: [i32; 3]) -> String {
     format!("#{:02X}{:02X}{:02X}", rgb[0], rgb[1], rgb[2])
 }
 
-pub(crate) fn rgb_to_hsl(rgb: [i32; 3]) -> [i32; 3] {
+pub fn rgb_to_hsl(rgb: [i32; 3]) -> [i32; 3] {
     let r = rgb[0];
     let g = rgb[1];
     let b = rgb[2];
@@ -78,7 +78,7 @@ fn hue_to_rgb(p: f64, q: f64, t: f64) -> f64 {
     p
 }
 
-pub(crate) fn hsl_to_rgb(hsl: [i32; 3]) -> [i32; 3] {
+pub fn hsl_to_rgb(hsl: [i32; 3]) -> [i32; 3] {
     let hue = (hsl[0] as f64) / 360.0;
     let saturation = (hsl[1] as f64) / 100.0;
     let luminosity = (hsl[2] as f64) / 100.0;
@@ -110,7 +110,7 @@ pub(crate) fn hsl_to_rgb(hsl: [i32; 3]) -> [i32; 3] {
 }
 
 /* 18.8.3 bgColor tint algorithm */
-pub(crate) fn hex_with_tint_to_rgb(hex: &str, tint: f64) -> String {
+pub fn hex_with_tint_to_rgb(hex: &str, tint: f64) -> String {
     if tint == 0.0 {
         return hex.to_string();
     }
@@ -148,7 +148,7 @@ pub fn get_indexed_color(index: i32) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::import::colors::*;
+    use super::*;
 
     #[test]
     fn test_rgb_hex() {

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -27,9 +27,11 @@
 
 #![warn(clippy::print_stdout)]
 
+pub mod builtin_styles;
 pub mod calc_result;
 pub mod cell;
 pub mod cf_types;
+pub mod colors;
 pub mod expressions;
 pub mod formatter;
 pub mod language;

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -162,6 +162,50 @@ impl Styles {
         self.add_named_cell_style(style_name, style_index)
     }
 
+    /// Returns the names of all named styles
+    pub fn get_named_style_list(&self) -> Vec<String> {
+        self.cell_styles.iter().map(|cs| cs.name.clone()).collect()
+    }
+
+    /// Returns true if the named style is built-in and cannot be deleted or modified.
+    /// In OOXML, only "Normal" has builtinId=0; all other built-ins have builtinId > 0.
+    /// Custom styles also have builtinId=0 (absent attribute), so we distinguish by name for the zero case.
+    pub fn is_builtin_style(&self, style_name: &str) -> bool {
+        self.cell_styles.iter().any(|cs| {
+            cs.name == style_name && (cs.builtin_id > 0 || cs.name.eq_ignore_ascii_case("Normal"))
+        })
+    }
+
+    /// Removes a named style entry. Does not remove the underlying cell_xfs entry.
+    /// Fails if the style does not exist or is a built-in.
+    pub(crate) fn delete_named_style_entry(&mut self, style_name: &str) -> Result<(), String> {
+        let pos = self
+            .cell_styles
+            .iter()
+            .position(|cs| cs.name == style_name)
+            .ok_or_else(|| format!("Style '{style_name}' not found"))?;
+        self.cell_styles.remove(pos);
+        Ok(())
+    }
+
+    /// Updates the xf_id and name of an existing named style entry.
+    /// Fails if the style does not exist.
+    pub(crate) fn update_named_style_entry(
+        &mut self,
+        style_name: &str,
+        new_name: &str,
+        new_xf_id: i32,
+    ) -> Result<(), String> {
+        let cs = self
+            .cell_styles
+            .iter_mut()
+            .find(|cs| cs.name == style_name)
+            .ok_or_else(|| format!("Style '{style_name}' not found"))?;
+        cs.name = new_name.to_string();
+        cs.xf_id = new_xf_id;
+        Ok(())
+    }
+
     // Returns the style index of the style with `quote_prefix=true`
     // If there is no such style it creates it
     // TODO: It needs to be mutable, the name could reflect that
@@ -295,6 +339,82 @@ impl<'a> Model<'a> {
             .worksheet_mut(sheet)?
             .set_column_style(column, style_index)?;
         Ok(())
+    }
+
+    /// Returns the list of all named style names.
+    pub fn get_named_style_list(&self) -> Vec<String> {
+        self.workbook.styles.get_named_style_list()
+    }
+
+    /// Returns the `Style` associated with the named style.
+    pub fn get_named_style(&self, name: &str) -> Result<Style, String> {
+        let xf_id = self.workbook.styles.get_style_index_by_name(name)?;
+        self.workbook.styles.get_style(xf_id)
+    }
+
+    /// Creates a new named style. Fails if a style with that name already exists.
+    pub fn create_named_style(&mut self, name: &str, style: &Style) -> Result<(), String> {
+        self.workbook.styles.create_named_style(name, style)
+    }
+
+    /// Deletes a named style. Fails if the style does not exist or is built-in.
+    /// Cells that used this style keep their formatting; only the name association is removed.
+    pub fn delete_named_style(&mut self, name: &str) -> Result<(), String> {
+        if self.workbook.styles.is_builtin_style(name) {
+            return Err(format!("Cannot delete built-in style '{name}'"));
+        }
+        self.workbook.styles.delete_named_style_entry(name)
+    }
+
+    /// Updates the formatting and optionally the name of a named style.
+    /// All cells, rows, and columns that use the old style are updated to the new formatting.
+    /// Fails if the style does not exist, is built-in, or if `new_name` is already taken (when renaming).
+    /// Returns `(old_xf_id, new_xf_id)` for diff tracking.
+    pub fn update_named_style(
+        &mut self,
+        name: &str,
+        new_name: &str,
+        style: &Style,
+    ) -> Result<(i32, i32), String> {
+        if self.workbook.styles.is_builtin_style(name) {
+            return Err(format!("Cannot modify built-in style '{name}'"));
+        }
+        let old_xf_id = self.workbook.styles.get_style_index_by_name(name)?;
+        if name != new_name
+            && self
+                .workbook
+                .styles
+                .get_style_index_by_name(new_name)
+                .is_ok()
+        {
+            return Err(format!("A style named '{new_name}' already exists"));
+        }
+        let new_xf_id = self.workbook.styles.get_style_index_or_create(style);
+        if old_xf_id != new_xf_id {
+            for worksheet in &mut self.workbook.worksheets {
+                for row_data in worksheet.sheet_data.values_mut() {
+                    for cell in row_data.values_mut() {
+                        if cell.get_style() == old_xf_id {
+                            cell.set_style(new_xf_id);
+                        }
+                    }
+                }
+                for row in &mut worksheet.rows {
+                    if row.s == old_xf_id {
+                        row.s = new_xf_id;
+                    }
+                }
+                for col in &mut worksheet.cols {
+                    if col.style == Some(old_xf_id) {
+                        col.style = Some(new_xf_id);
+                    }
+                }
+            }
+        }
+        self.workbook
+            .styles
+            .update_named_style_entry(name, new_name, new_xf_id)?;
+        Ok((old_xf_id, new_xf_id))
     }
 }
 

--- a/base/src/test/test_styles.rs
+++ b/base/src/test/test_styles.rs
@@ -64,6 +64,102 @@ fn test_create_named_style() {
 }
 
 #[test]
+fn test_get_named_style_list() {
+    let model = new_empty_model();
+    let list = model.get_named_style_list();
+    // Default model has one entry: "normal"
+    assert_eq!(list, vec!["normal".to_string()]);
+}
+
+#[test]
+fn test_get_named_style() {
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    let retrieved = model.get_named_style("bold").unwrap();
+    assert!(retrieved.font.b);
+}
+
+#[test]
+fn test_create_named_style_via_model() {
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    assert!(model.create_named_style("bold", &style).is_ok());
+    // Duplicate name fails
+    assert!(model.create_named_style("bold", &style).is_err());
+    // Can apply the style to a cell
+    model.set_cell_style_by_name(0, 1, 1, "bold").unwrap();
+    assert!(model.get_style_for_cell(0, 1, 1).unwrap().font.b);
+}
+
+#[test]
+fn test_delete_named_style() {
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    // Apply it to a cell
+    model.set_cell_style_by_name(0, 1, 1, "bold").unwrap();
+    assert!(model.get_style_for_cell(0, 1, 1).unwrap().font.b);
+    // Delete the named style
+    assert!(model.delete_named_style("bold").is_ok());
+    // Named style is gone
+    assert!(model.get_named_style("bold").is_err());
+    // Cell retains its formatting
+    assert!(model.get_style_for_cell(0, 1, 1).unwrap().font.b);
+    // Built-in "normal" cannot be deleted
+    assert!(model.delete_named_style("normal").is_err());
+    // Deleting a non-existent style fails
+    assert!(model.delete_named_style("nonexistent").is_err());
+}
+
+#[test]
+fn test_update_named_style_updates_cells() {
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    // Apply to A1 and A2
+    model.set_cell_style_by_name(0, 1, 1, "bold").unwrap();
+    model.set_cell_style_by_name(0, 2, 1, "bold").unwrap();
+    // Update the style to also be italic
+    let mut new_style = model.get_named_style("bold").unwrap();
+    new_style.font.i = true;
+    model
+        .update_named_style("bold", "bold", &new_style)
+        .unwrap();
+    // Both cells now have the updated style
+    assert!(model.get_style_for_cell(0, 1, 1).unwrap().font.i);
+    assert!(model.get_style_for_cell(0, 2, 1).unwrap().font.i);
+    // The named style reflects the new formatting
+    assert!(model.get_named_style("bold").unwrap().font.i);
+}
+
+#[test]
+fn test_update_named_style_rename() {
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    // Rename it
+    model.update_named_style("bold", "bold2", &style).unwrap();
+    assert!(model.get_named_style("bold").is_err());
+    assert!(model.get_named_style("bold2").is_ok());
+}
+
+#[test]
+fn test_update_named_style_rejects_builtin() {
+    let mut model = new_empty_model();
+    let style = model.get_style_for_cell(0, 1, 1).unwrap();
+    assert!(model
+        .update_named_style("normal", "normal", &style)
+        .is_err());
+    assert!(model.delete_named_style("normal").is_err());
+}
+
+#[test]
 fn empty_models_have_two_fills() {
     let model = new_empty_model();
     assert_eq!(model.workbook.styles.fills.len(), 2);

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -20,6 +20,7 @@ mod test_hidden_columns;
 mod test_keyboard_navigation;
 mod test_last_empty_cell;
 mod test_multi_row_column;
+mod test_named_styles;
 mod test_on_area_selection;
 mod test_on_expand_selected_range;
 mod test_on_paste_styles;

--- a/base/src/test/user_model/test_named_styles.rs
+++ b/base/src/test/user_model/test_named_styles.rs
@@ -1,0 +1,220 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::user_model::util::new_empty_user_model;
+
+#[test]
+fn create_named_style() {
+    let mut model = new_empty_user_model();
+    let mut style = model.get_cell_style(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+
+    assert!(model.get_named_style_list().contains(&"bold".to_string()));
+    assert!(model.get_named_style("bold").unwrap().font.b);
+
+    // Duplicate name fails
+    assert!(model.create_named_style("bold", &style).is_err());
+}
+
+#[test]
+fn create_named_style_undo_redo() {
+    let mut model = new_empty_user_model();
+    let mut style = model.get_cell_style(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    assert!(model.get_named_style_list().contains(&"bold".to_string()));
+
+    // Undo removes the named style
+    model.undo().unwrap();
+    assert!(!model.get_named_style_list().contains(&"bold".to_string()));
+
+    // Redo restores it
+    model.redo().unwrap();
+    assert!(model.get_named_style_list().contains(&"bold".to_string()));
+    assert!(model.get_named_style("bold").unwrap().font.b);
+}
+
+#[test]
+fn delete_named_style() {
+    let mut model = new_empty_user_model();
+    let mut style = model.get_cell_style(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    // Apply to a cell via the raw model API
+    model.model.set_cell_style_by_name(0, 1, 1, "bold").unwrap();
+    assert!(model.get_cell_style(0, 1, 1).unwrap().font.b);
+
+    // Delete the named style
+    model.delete_named_style("bold").unwrap();
+    assert!(!model.get_named_style_list().contains(&"bold".to_string()));
+    // Cell retains its formatting after the named style is deleted
+    assert!(model.get_cell_style(0, 1, 1).unwrap().font.b);
+
+    // Built-in "normal" cannot be deleted
+    assert!(model.delete_named_style("normal").is_err());
+    // Non-existent style fails
+    assert!(model.delete_named_style("nonexistent").is_err());
+}
+
+#[test]
+fn delete_named_style_undo_redo() {
+    let mut model = new_empty_user_model();
+    let mut style = model.get_cell_style(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    model.delete_named_style("bold").unwrap();
+    assert!(!model.get_named_style_list().contains(&"bold".to_string()));
+
+    // Undo restores the named style
+    model.undo().unwrap();
+    assert!(model.get_named_style_list().contains(&"bold".to_string()));
+    assert!(model.get_named_style("bold").unwrap().font.b);
+
+    // Redo deletes it again
+    model.redo().unwrap();
+    assert!(!model.get_named_style_list().contains(&"bold".to_string()));
+}
+
+#[test]
+fn update_named_style_updates_cells() {
+    let mut model = new_empty_user_model();
+    let mut style = model.get_cell_style(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+
+    // Apply the named style to A1 by setting the style directly
+    model.model.set_cell_style_by_name(0, 1, 1, "bold").unwrap();
+    model.model.set_cell_style_by_name(0, 2, 1, "bold").unwrap();
+
+    // Update the style to also be italic
+    let mut new_style = model.get_named_style("bold").unwrap();
+    new_style.font.i = true;
+    model
+        .update_named_style("bold", "bold", &new_style)
+        .unwrap();
+
+    // Both cells should reflect the new formatting
+    assert!(model.get_cell_style(0, 1, 1).unwrap().font.i);
+    assert!(model.get_cell_style(0, 2, 1).unwrap().font.i);
+    assert!(model.get_named_style("bold").unwrap().font.i);
+}
+
+#[test]
+fn update_named_style_undo_redo() {
+    let mut model = new_empty_user_model();
+    let mut style = model.get_cell_style(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    model.model.set_cell_style_by_name(0, 1, 1, "bold").unwrap();
+
+    let mut new_style = model.get_named_style("bold").unwrap();
+    new_style.font.i = true;
+    model
+        .update_named_style("bold", "bold", &new_style)
+        .unwrap();
+
+    assert!(model.get_cell_style(0, 1, 1).unwrap().font.i);
+
+    // Undo: cell should lose the italic
+    model.undo().unwrap();
+    assert!(!model.get_cell_style(0, 1, 1).unwrap().font.i);
+    assert!(!model.get_named_style("bold").unwrap().font.i);
+
+    // Redo: cell gets italic back
+    model.redo().unwrap();
+    assert!(model.get_cell_style(0, 1, 1).unwrap().font.i);
+    assert!(model.get_named_style("bold").unwrap().font.i);
+}
+
+#[test]
+fn update_named_style_rename() {
+    let mut model = new_empty_user_model();
+    let mut style = model.get_cell_style(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+
+    // Rename without changing the style
+    model.update_named_style("bold", "bold2", &style).unwrap();
+    assert!(!model.get_named_style_list().contains(&"bold".to_string()));
+    assert!(model.get_named_style_list().contains(&"bold2".to_string()));
+
+    // Undo restores original name
+    model.undo().unwrap();
+    assert!(model.get_named_style_list().contains(&"bold".to_string()));
+    assert!(!model.get_named_style_list().contains(&"bold2".to_string()));
+
+    // Redo renames again
+    model.redo().unwrap();
+    assert!(model.get_named_style_list().contains(&"bold2".to_string()));
+}
+
+#[test]
+fn update_named_style_rejects_builtin() {
+    let mut model = new_empty_user_model();
+    let style = model.get_cell_style(0, 1, 1).unwrap();
+    assert!(model
+        .update_named_style("normal", "normal", &style)
+        .is_err());
+    assert!(model.delete_named_style("normal").is_err());
+}
+
+#[test]
+fn get_named_style_list_includes_default() {
+    let model = new_empty_user_model();
+    let list = model.get_named_style_list();
+    // Default model has "normal"
+    assert!(list.iter().any(|n| n.eq_ignore_ascii_case("normal")));
+}
+
+#[test]
+fn apply_builtin_named_style_lazy_adds_to_model() {
+    let mut model = new_empty_user_model();
+
+    // Fresh model has only "normal" — no builtin styles pre-loaded
+    let initial_list = model.get_named_style_list();
+    assert_eq!(initial_list, vec!["normal".to_string()]);
+    assert!(!initial_list.contains(&"Calculation".to_string()));
+
+    // Apply the "Calculation" builtin to the default selection (A1)
+    model.on_apply_named_style("Calculation").unwrap();
+
+    // "Calculation" is now in the model, and nothing else was added
+    let list = model.get_named_style_list();
+    assert_eq!(list.len(), 2);
+    assert!(list.contains(&"Calculation".to_string()));
+
+    // The cell A1 carries the correct Calculation properties
+    let style = model.get_cell_style(0, 1, 1).unwrap();
+    assert!(style.font.b);
+    assert_eq!(style.font.color.as_deref(), Some("#FA7D00"));
+    assert_eq!(style.fill.fg_color.as_deref(), Some("#F2F2F2"));
+
+    // Applying again does not add a duplicate entry
+    model.on_apply_named_style("Calculation").unwrap();
+    assert_eq!(model.get_named_style_list().len(), 2);
+}
+
+#[test]
+fn apply_builtin_named_style_undo_redo() {
+    let mut model = new_empty_user_model();
+
+    model.on_apply_named_style("Calculation").unwrap();
+    assert!(model
+        .get_named_style_list()
+        .contains(&"Calculation".to_string()));
+    assert!(model.get_cell_style(0, 1, 1).unwrap().font.b);
+
+    // Undo removes both the style application and the lazy-added named style
+    model.undo().unwrap();
+    assert!(!model
+        .get_named_style_list()
+        .contains(&"Calculation".to_string()));
+    assert!(!model.get_cell_style(0, 1, 1).unwrap().font.b);
+
+    // Redo restores it
+    model.redo().unwrap();
+    assert!(model
+        .get_named_style_list()
+        .contains(&"Calculation".to_string()));
+    assert!(model.get_cell_style(0, 1, 1).unwrap().font.b);
+}

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -3015,6 +3015,47 @@ impl<'a> UserModel<'a> {
                 } => {
                     self.model.set_timezone(old_value)?;
                 }
+                Diff::CreateNamedStyle { name, xf_id: _ } => {
+                    self.model.workbook.styles.delete_named_style_entry(name)?;
+                }
+                Diff::DeleteNamedStyle { name, old_xf_id } => {
+                    self.model
+                        .workbook
+                        .styles
+                        .add_named_cell_style(name, *old_xf_id)?;
+                }
+                Diff::UpdateNamedStyle {
+                    name,
+                    new_name,
+                    old_xf_id,
+                    new_xf_id,
+                } => {
+                    if old_xf_id != new_xf_id {
+                        for worksheet in &mut self.model.workbook.worksheets {
+                            for row_data in worksheet.sheet_data.values_mut() {
+                                for cell in row_data.values_mut() {
+                                    if cell.get_style() == *new_xf_id {
+                                        cell.set_style(*old_xf_id);
+                                    }
+                                }
+                            }
+                            for row in &mut worksheet.rows {
+                                if row.s == *new_xf_id {
+                                    row.s = *old_xf_id;
+                                }
+                            }
+                            for col in &mut worksheet.cols {
+                                if col.style == Some(*new_xf_id) {
+                                    col.style = Some(*old_xf_id);
+                                }
+                            }
+                        }
+                    }
+                    self.model
+                        .workbook
+                        .styles
+                        .update_named_style_entry(new_name, name, *old_xf_id)?;
+                }
                 Diff::AddConditionalFormatting {
                     sheet, priority, ..
                 } => {
@@ -3351,6 +3392,47 @@ impl<'a> UserModel<'a> {
                     new_value,
                 } => {
                     self.model.set_timezone(new_value)?;
+                }
+                Diff::CreateNamedStyle { name, xf_id } => {
+                    self.model
+                        .workbook
+                        .styles
+                        .add_named_cell_style(name, *xf_id)?;
+                }
+                Diff::DeleteNamedStyle { name, old_xf_id: _ } => {
+                    self.model.workbook.styles.delete_named_style_entry(name)?;
+                }
+                Diff::UpdateNamedStyle {
+                    name,
+                    new_name,
+                    old_xf_id,
+                    new_xf_id,
+                } => {
+                    if old_xf_id != new_xf_id {
+                        for worksheet in &mut self.model.workbook.worksheets {
+                            for row_data in worksheet.sheet_data.values_mut() {
+                                for cell in row_data.values_mut() {
+                                    if cell.get_style() == *old_xf_id {
+                                        cell.set_style(*new_xf_id);
+                                    }
+                                }
+                            }
+                            for row in &mut worksheet.rows {
+                                if row.s == *old_xf_id {
+                                    row.s = *new_xf_id;
+                                }
+                            }
+                            for col in &mut worksheet.cols {
+                                if col.style == Some(*old_xf_id) {
+                                    col.style = Some(*new_xf_id);
+                                }
+                            }
+                        }
+                    }
+                    self.model
+                        .workbook
+                        .styles
+                        .update_named_style_entry(name, new_name, *new_xf_id)?;
                 }
                 Diff::AddConditionalFormatting {
                     sheet,

--- a/base/src/user_model/history.rs
+++ b/base/src/user_model/history.rs
@@ -213,6 +213,21 @@ pub(crate) enum Diff {
         old_value: String,
         new_value: String,
     },
+    // Named style diffs
+    CreateNamedStyle {
+        name: String,
+        xf_id: i32,
+    },
+    DeleteNamedStyle {
+        name: String,
+        old_xf_id: i32,
+    },
+    UpdateNamedStyle {
+        name: String,
+        new_name: String,
+        old_xf_id: i32,
+        new_xf_id: i32,
+    },
     // Conditional formatting diffs
     AddConditionalFormatting {
         sheet: u32,

--- a/base/src/user_model/mod.rs
+++ b/base/src/user_model/mod.rs
@@ -5,6 +5,7 @@ mod border_utils;
 mod common;
 mod conditional_formatting;
 pub(crate) mod history;
+mod named_cell_styles;
 mod sequence_detector;
 mod ui;
 

--- a/base/src/user_model/named_cell_styles.rs
+++ b/base/src/user_model/named_cell_styles.rs
@@ -1,0 +1,129 @@
+use crate::{types::Style, user_model::history::Diff, UserModel};
+
+impl<'a> UserModel<'a> {
+    /// Returns the list of all named style names.
+    pub fn get_named_style_list(&self) -> Vec<String> {
+        self.model.get_named_style_list()
+    }
+
+    /// Returns the `Style` associated with the named style.
+    pub fn get_named_style(&self, name: &str) -> Result<Style, String> {
+        self.model.get_named_style(name)
+    }
+
+    /// Creates a new named style. Fails if a style with that name already exists.
+    pub fn create_named_style(&mut self, name: &str, style: &Style) -> Result<(), String> {
+        self.model.create_named_style(name, style)?;
+        let xf_id = self.model.workbook.styles.get_style_index_by_name(name)?;
+        self.push_diff_list(vec![Diff::CreateNamedStyle {
+            name: name.to_string(),
+            xf_id,
+        }]);
+        Ok(())
+    }
+
+    /// Deletes a named style. Fails if the style does not exist or is built-in.
+    /// Cells that used this style keep their formatting.
+    pub fn delete_named_style(&mut self, name: &str) -> Result<(), String> {
+        let old_xf_id = self.model.workbook.styles.get_style_index_by_name(name)?;
+        self.model.delete_named_style(name)?;
+        self.push_diff_list(vec![Diff::DeleteNamedStyle {
+            name: name.to_string(),
+            old_xf_id,
+        }]);
+        Ok(())
+    }
+
+    /// Updates the formatting and optionally the name of a named style.
+    /// All cells, rows, and columns using the old style are updated to the new formatting.
+    /// Fails if the style does not exist, is built-in, or if `new_name` is already taken.
+    pub fn update_named_style(
+        &mut self,
+        name: &str,
+        new_name: &str,
+        style: &Style,
+    ) -> Result<(), String> {
+        let (old_xf_id, new_xf_id) = self.model.update_named_style(name, new_name, style)?;
+        self.push_diff_list(vec![Diff::UpdateNamedStyle {
+            name: name.to_string(),
+            new_name: new_name.to_string(),
+            old_xf_id,
+            new_xf_id,
+        }]);
+        Ok(())
+    }
+
+    /// Returns all Excel built-in named styles as `(name, Style)` pairs.
+    /// These are static definitions that are not stored in the workbook until a user applies one.
+    pub fn get_builtin_named_styles(&self) -> Vec<(String, Style)> {
+        crate::builtin_styles::builtin_named_styles()
+    }
+
+    /// Applies a named style (custom or built-in) to the current selection.
+    ///
+    /// If the style is not in the model but is a known built-in, it is first added to the
+    /// model's style table, then applied to every cell in the selection with undo support.
+    pub fn on_apply_named_style(&mut self, name: &str) -> Result<(), String> {
+        let mut diff_list = Vec::new();
+
+        // Ensure the style exists in the model, adding it from builtins if needed.
+        if self
+            .model
+            .workbook
+            .styles
+            .get_style_index_by_name(name)
+            .is_err()
+        {
+            let style = crate::builtin_styles::get_builtin_style(name)
+                .ok_or_else(|| format!("Named style '{name}' not found"))?;
+            self.model
+                .workbook
+                .styles
+                .create_named_style(name, &style)?;
+            let xf_id = self.model.workbook.styles.get_style_index_by_name(name)?;
+            diff_list.push(Diff::CreateNamedStyle {
+                name: name.to_string(),
+                xf_id,
+            });
+        }
+
+        let xf_id = self.model.workbook.styles.get_style_index_by_name(name)?;
+
+        // Resolve the selection range.
+        let sheet = if let Some(view) = self.model.workbook.views.get(&self.model.view_id) {
+            view.sheet
+        } else {
+            return Ok(());
+        };
+        let range = if let Ok(worksheet) = self.model.workbook.worksheet(sheet) {
+            if let Some(view) = worksheet.views.get(&self.model.view_id) {
+                view.range
+            } else {
+                return Ok(());
+            }
+        } else {
+            return Ok(());
+        };
+
+        let [row_start, column_start, row_end, column_end] = range;
+        let new_style = self.model.workbook.styles.get_style(xf_id)?;
+        for row in row_start..=row_end {
+            for column in column_start..=column_end {
+                let old_value = self.model.get_cell_style_or_none(sheet, row, column)?;
+                self.model
+                    .workbook
+                    .worksheet_mut(sheet)?
+                    .set_cell_style(row, column, xf_id)?;
+                diff_list.push(Diff::SetCellStyle {
+                    sheet,
+                    row,
+                    column,
+                    old_value: Box::new(old_value),
+                    new_value: Box::new(new_style.clone()),
+                });
+            }
+        }
+        self.push_diff_list(diff_list);
+        Ok(())
+    }
+}

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -1023,4 +1023,77 @@ impl Model {
             .update_conditional_formatting(sheet, index, new_range, new_rule)
             .map_err(|e| to_js_error(e.to_string()))
     }
+
+    // Named styles
+
+    #[wasm_bindgen(js_name = "getNamedStyleList", unchecked_return_type = "string[]")]
+    pub fn get_named_style_list(&self) -> Vec<String> {
+        self.model.get_named_style_list()
+    }
+
+    #[wasm_bindgen(js_name = "getNamedStyle", unchecked_return_type = "CellStyle")]
+    pub fn get_named_style(&self, name: &str) -> Result<JsValue, JsError> {
+        let style = self.model.get_named_style(name).map_err(to_js_error)?;
+        serde_wasm_bindgen::to_value(&style).map_err(|e| to_js_error(e.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = "createNamedStyle")]
+    pub fn create_named_style(
+        &mut self,
+        name: &str,
+        #[wasm_bindgen(unchecked_param_type = "CellStyle")] style: JsValue,
+    ) -> Result<(), JsError> {
+        let style: Style =
+            serde_wasm_bindgen::from_value(style).map_err(|e| to_js_error(e.to_string()))?;
+        self.model
+            .create_named_style(name, &style)
+            .map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "deleteNamedStyle")]
+    pub fn delete_named_style(&mut self, name: &str) -> Result<(), JsError> {
+        self.model.delete_named_style(name).map_err(to_js_error)
+    }
+
+    #[wasm_bindgen(js_name = "updateNamedStyle")]
+    pub fn update_named_style(
+        &mut self,
+        name: &str,
+        new_name: &str,
+        #[wasm_bindgen(unchecked_param_type = "CellStyle")] style: JsValue,
+    ) -> Result<(), JsError> {
+        let style: Style =
+            serde_wasm_bindgen::from_value(style).map_err(|e| to_js_error(e.to_string()))?;
+        self.model
+            .update_named_style(name, new_name, &style)
+            .map_err(to_js_error)
+    }
+
+    /// Returns all Excel built-in named styles as a `NamedStyle[]`.
+    /// These are always available regardless of whether the workbook uses them.
+    #[wasm_bindgen(
+        js_name = "getBuiltinNamedStyles",
+        unchecked_return_type = "NamedStyle[]"
+    )]
+    pub fn get_builtin_named_styles(&self) -> Result<JsValue, JsError> {
+        #[derive(serde::Serialize)]
+        struct NamedStyleEntry {
+            name: String,
+            style: Style,
+        }
+        let entries: Vec<NamedStyleEntry> = self
+            .model
+            .get_builtin_named_styles()
+            .into_iter()
+            .map(|(name, style)| NamedStyleEntry { name, style })
+            .collect();
+        serde_wasm_bindgen::to_value(&entries).map_err(|e| to_js_error(e.to_string()))
+    }
+
+    /// Applies a named style to the current selection.
+    /// If the style is a built-in not yet in the workbook, it is added first.
+    #[wasm_bindgen(js_name = "onApplyNamedStyle")]
+    pub fn on_apply_named_style(&mut self, name: &str) -> Result<(), JsError> {
+        self.model.on_apply_named_style(name).map_err(to_js_error)
+    }
 }

--- a/bindings/wasm/types.ts
+++ b/bindings/wasm/types.ts
@@ -479,3 +479,11 @@ export interface FmtSettings {
   number_fmt: string;
   number_example: string;
 }
+
+/** A named cell style (e.g. "Normal", "Heading 1", or a custom style). */
+export interface NamedStyle {
+  /** The style name. */
+  name: string;
+  /** The full style definition. */
+  style: CellStyle;
+}

--- a/webapp/IronCalc/src/components/NamedStyles/NamedStylesPanel.tsx
+++ b/webapp/IronCalc/src/components/NamedStyles/NamedStylesPanel.tsx
@@ -1,0 +1,229 @@
+import type { CellStyle, NamedStyle } from "@ironcalc/wasm";
+import {
+  type CSSProperties,
+  type RefObject,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import "./named-styles.css";
+
+// Known Excel built-in style name→category mapping (case-insensitive)
+const BUILTIN_CATEGORIES: { label: string; names: string[] }[] = [
+  {
+    label: "Good, Bad and Neutral",
+    names: ["normal", "bad", "good", "neutral"],
+  },
+  {
+    label: "Data and Model",
+    names: [
+      "calculation",
+      "check cell",
+      "explanatory text",
+      "input",
+      "linked cell",
+      "note",
+      "output",
+      "warning text",
+    ],
+  },
+  {
+    label: "Titles and Headings",
+    names: [
+      "heading 1",
+      "heading 2",
+      "heading 3",
+      "heading 4",
+      "title",
+      "total",
+    ],
+  },
+  {
+    label: "Themed Cell Styles",
+    names: [
+      "20% - accent1",
+      "20% - accent2",
+      "20% - accent3",
+      "20% - accent4",
+      "20% - accent5",
+      "20% - accent6",
+      "40% - accent1",
+      "40% - accent2",
+      "40% - accent3",
+      "40% - accent4",
+      "40% - accent5",
+      "40% - accent6",
+      "60% - accent1",
+      "60% - accent2",
+      "60% - accent3",
+      "60% - accent4",
+      "60% - accent5",
+      "60% - accent6",
+      "accent1",
+      "accent2",
+      "accent3",
+      "accent4",
+      "accent5",
+      "accent6",
+    ],
+  },
+  {
+    label: "Number Format",
+    names: ["comma", "comma [0]", "currency", "currency [0]", "percent"],
+  },
+];
+
+function groupStyles(
+  customStyles: NamedStyle[],
+  builtinStyles: NamedStyle[],
+): { label: string; styles: NamedStyle[] }[] {
+  const byLowerName = new Map(
+    builtinStyles.map((s) => [s.name.toLowerCase(), s]),
+  );
+  const result: { label: string; styles: NamedStyle[] }[] = [];
+  if (customStyles.length > 0) {
+    result.push({ label: "Custom", styles: customStyles });
+  }
+  for (const cat of BUILTIN_CATEGORIES) {
+    const catStyles = cat.names
+      .map((n) => byLowerName.get(n))
+      .filter((s): s is NamedStyle => s !== undefined);
+    if (catStyles.length > 0) {
+      result.push({ label: cat.label, styles: catStyles });
+    }
+  }
+  return result;
+}
+
+function getTileStyle(style: CellStyle): CSSProperties {
+  const decorations: string[] = [];
+  if (style.font.u) decorations.push("underline");
+  if (style.font.strike) decorations.push("line-through");
+  return {
+    backgroundColor: style.fill.fg_color || undefined,
+    color: style.font.color || undefined,
+    fontWeight: style.font.b ? "bold" : undefined,
+    fontStyle: style.font.i ? "italic" : undefined,
+    textDecoration: decorations.length > 0 ? decorations.join(" ") : undefined,
+  };
+}
+
+interface NamedStylesPanelProps {
+  open: boolean;
+  customStyles: NamedStyle[];
+  builtinStyles: NamedStyle[];
+  onApplyNamedStyle: (name: string) => void;
+  onClose: () => void;
+  anchorEl: RefObject<HTMLElement | null>;
+}
+
+const NamedStylesPanel = ({
+  open,
+  customStyles,
+  builtinStyles,
+  onApplyNamedStyle,
+  onClose,
+  anchorEl,
+}: NamedStylesPanelProps) => {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
+  const { t } = useTranslation();
+
+  useLayoutEffect(() => {
+    if (!open) return;
+
+    const anchor = anchorEl.current;
+    const panel = panelRef.current;
+    if (!anchor || !panel) return;
+
+    const updatePosition = () => {
+      const anchorRect = anchor.getBoundingClientRect();
+      const panelWidth = panel.offsetWidth;
+      const panelHeight = panel.offsetHeight;
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const margin = 8;
+      const offset = 4;
+
+      let left = anchorRect.left;
+      let top = anchorRect.bottom + offset;
+
+      if (left + panelWidth > viewportWidth - margin) {
+        left = viewportWidth - panelWidth - margin;
+      }
+      if (left < margin) left = margin;
+      if (top + panelHeight > viewportHeight - margin) {
+        top = anchorRect.top - panelHeight - offset;
+      }
+      if (top < margin) top = margin;
+
+      setPosition({ top, left });
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [open, anchorEl]);
+
+  if (!open) return null;
+
+  const groups = groupStyles(customStyles, builtinStyles);
+
+  return createPortal(
+    <div className="ic-menu-layer">
+      <div
+        className="ic-menu-backdrop"
+        onPointerDown={onClose}
+        aria-hidden="true"
+      />
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: panel intercepts click only to prevent workbook focus steal */}
+      <div
+        ref={panelRef}
+        className="ic-named-styles-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("toolbar.named_styles")}
+        style={
+          {
+            top: `${position.top}px`,
+            left: `${position.left}px`,
+          } as CSSProperties
+        }
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {groups.map((group) => (
+          <div key={group.label} className="ic-named-styles-category">
+            <div className="ic-named-styles-category-label">{group.label}</div>
+            <div className="ic-named-styles-grid">
+              {group.styles.map(({ name, style }) => (
+                <button
+                  key={name}
+                  type="button"
+                  className="ic-named-styles-tile"
+                  style={getTileStyle(style)}
+                  title={name}
+                  onClick={() => {
+                    onApplyNamedStyle(name);
+                    onClose();
+                  }}
+                >
+                  {name}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default NamedStylesPanel;

--- a/webapp/IronCalc/src/components/NamedStyles/named-styles.css
+++ b/webapp/IronCalc/src/components/NamedStyles/named-styles.css
@@ -1,0 +1,66 @@
+.ic-named-styles-panel {
+  position: fixed;
+  z-index: 1300;
+  background: var(--palette-common-white, #fff);
+  border: 1px solid var(--palette-grey-300, #d0d0d0);
+  border-radius: 2px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  padding: 8px 10px 10px;
+  width: 572px;
+  max-height: 520px;
+  overflow-y: auto;
+  font-size: 11px;
+}
+
+.ic-named-styles-category {
+  margin-bottom: 6px;
+}
+
+.ic-named-styles-category:last-child {
+  margin-bottom: 0;
+}
+
+.ic-named-styles-category-label {
+  font-size: 11px;
+  color: var(--palette-text-primary, #333);
+  margin-bottom: 3px;
+  font-weight: normal;
+}
+
+.ic-named-styles-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 2px;
+}
+
+.ic-named-styles-tile {
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--palette-grey-400, #bdbdbd);
+  border-radius: 0;
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0 3px;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background-color: var(--palette-common-white, #fff);
+  font-family: inherit;
+}
+
+.ic-named-styles-tile:hover {
+  outline: 2px solid var(--palette-primary-main, #217346);
+  outline-offset: -2px;
+  z-index: 1;
+  position: relative;
+}
+
+.ic-named-styles-tile:focus-visible {
+  outline: 2px solid var(--palette-primary-main, #217346);
+  outline-offset: -2px;
+  z-index: 1;
+  position: relative;
+}

--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -2,6 +2,7 @@ import type {
   BorderOptions,
   FmtSettings,
   HorizontalAlignment,
+  NamedStyle,
   VerticalAlignment,
 } from "@ironcalc/wasm";
 import {
@@ -24,6 +25,7 @@ import {
   Grid2x2X,
   ImageDown,
   Italic,
+  Layers,
   Minus,
   PaintBucket,
   PaintRoller,
@@ -51,6 +53,7 @@ import {
   increaseDecimalPlaces,
   NumberFormats,
 } from "../FormatMenu/formatUtil";
+import NamedStylesPanel from "../NamedStyles/NamedStylesPanel";
 import "./toolbar.css";
 import { Tooltip } from "../Tooltip/Tooltip";
 
@@ -91,18 +94,23 @@ type ToolbarProperties = {
   formatOptions: FmtSettings;
   onOpenConditionalFormatting: () => void;
   isConditionalFormattingOpen: boolean;
+  customStyles: NamedStyle[];
+  builtinStyles: NamedStyle[];
+  onApplyNamedStyle: (name: string) => void;
 };
 
 function Toolbar(properties: ToolbarProperties) {
   const [fontColorPickerOpen, setFontColorPickerOpen] = useState(false);
   const [fillColorPickerOpen, setFillColorPickerOpen] = useState(false);
   const [borderPickerOpen, setBorderPickerOpen] = useState(false);
+  const [namedStylesPanelOpen, setNamedStylesPanelOpen] = useState(false);
   const [showLeftArrow, setShowLeftArrow] = useState(false);
   const [showRightArrow, setShowRightArrow] = useState(false);
 
   const fontColorButton = useRef(null);
   const fillColorButton = useRef(null);
   const borderButton = useRef(null);
+  const namedStylesButton = useRef(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
 
   const { t } = useTranslation();
@@ -394,6 +402,16 @@ function Toolbar(properties: ToolbarProperties) {
               disabled={!canEdit}
             />
           </Tooltip>
+          <Tooltip title={t("toolbar.named_styles")}>
+            <IconButton
+              icon={<Layers />}
+              aria-label={t("toolbar.named_styles")}
+              pressed={namedStylesPanelOpen}
+              ref={namedStylesButton}
+              onClick={() => setNamedStylesPanelOpen((open) => !open)}
+              disabled={!canEdit}
+            />
+          </Tooltip>
         </div>
 
         <div className="ic-toolbar-divider" />
@@ -542,6 +560,17 @@ function Toolbar(properties: ToolbarProperties) {
           }}
           anchorEl={borderButton}
           open={borderPickerOpen}
+        />
+        <NamedStylesPanel
+          open={namedStylesPanelOpen}
+          customStyles={properties.customStyles}
+          builtinStyles={properties.builtinStyles}
+          onApplyNamedStyle={(name) => {
+            properties.onApplyNamedStyle(name);
+            setNamedStylesPanelOpen(false);
+          }}
+          onClose={() => setNamedStylesPanelOpen(false)}
+          anchorEl={namedStylesButton}
         />
       </div>
 

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -738,6 +738,20 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         isConditionalFormattingOpen={
           isDrawerOpen && drawerType === "conditionalFormatting"
         }
+        customStyles={(() => {
+          const builtinNames = new Set(
+            model.getBuiltinNamedStyles().map((s) => s.name.toLowerCase()),
+          );
+          return model
+            .getNamedStyleList()
+            .filter((name) => !builtinNames.has(name.toLowerCase()))
+            .map((name) => ({ name, style: model.getNamedStyle(name) }));
+        })()}
+        builtinStyles={model.getBuiltinNamedStyles()}
+        onApplyNamedStyle={(name) => {
+          model.onApplyNamedStyle(name);
+          setRedrawId((id) => id + 1);
+        }}
       />
       <div
         className="ic-workbook-worksheet-area-left"

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -279,6 +279,7 @@
     "format_number": "Zahlenformat",
     "increase_font_size": "Schriftgröße erhöhen",
     "italic": "Kursiv",
+    "named_styles": "Zellformate",
     "percentage": "Als Prozent formatieren",
     "redo": "Wiederholen",
     "scroll_left": "Nach links scrollen",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -279,6 +279,7 @@
     "format_number": "Format number",
     "increase_font_size": "Increase font size",
     "italic": "Italic",
+    "named_styles": "Cell styles",
     "percentage": "Format as percentage",
     "redo": "Redo",
     "scroll_left": "Scroll left",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -279,6 +279,7 @@
     "format_number": "Formato de número",
     "increase_font_size": "Aumentar tamaño de fuente",
     "italic": "Cursiva",
+    "named_styles": "Estilos de celda",
     "percentage": "Formato porcentaje",
     "redo": "Rehacer",
     "scroll_left": "Desplazar a la izquierda",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -279,6 +279,7 @@
     "format_number": "Format de nombre",
     "increase_font_size": "Augmenter la taille de la police",
     "italic": "Italique",
+    "named_styles": "Styles de cellule",
     "percentage": "Formater pourcentage",
     "redo": "Rétablir",
     "scroll_left": "Faire défiler vers la gauche",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -279,6 +279,7 @@
     "format_number": "Formato numero",
     "increase_font_size": "Aumenta dimensione carattere",
     "italic": "Corsivo",
+    "named_styles": "Stili di cella",
     "percentage": "Formato percentuale",
     "redo": "Ripeti",
     "scroll_left": "Scorri a sinistra",

--- a/xlsx/src/import/mod.rs
+++ b/xlsx/src/import/mod.rs
@@ -1,4 +1,3 @@
-mod colors;
 mod conditional_formatting;
 mod metadata;
 pub(crate) mod shared_strings;

--- a/xlsx/src/import/styles.rs
+++ b/xlsx/src/import/styles.rs
@@ -278,6 +278,12 @@ pub(super) fn load_styles<R: Read + std::io::Seek>(
         let name = get_attribute(&cell_style, "name")?.to_string();
         let xf_id = get_number(cell_style, "xfId");
         let builtin_id = get_number(cell_style, "builtinId");
+        // NB: A builtin style could be hidden (this is removed in the UI)
+        // <cellStyle name="Linked Cell" xfId="8" builtinId="24" hidden="1"/>
+        // NB: A builtin style could be modified
+        // <cellStyle name="Good" xfId="4" builtinId="26" customBuiltin="1"/>
+        // let hidden = get_bool(cell_style, "hidden");
+        // let custom_builtin = get_bool(cell_style, "customBuiltin");
         style_names.insert(xf_id, name.clone());
         cell_styles.push(CellStyles {
             name,

--- a/xlsx/src/import/theme.rs
+++ b/xlsx/src/import/theme.rs
@@ -1,10 +1,9 @@
 use std::io::Read;
 
+use ironcalc_base::colors::hex_with_tint_to_rgb;
 use roxmltree::Node;
 
 use crate::error::XlsxError;
-
-use super::colors::hex_with_tint_to_rgb;
 
 const PALETTE_LEN: usize = 12;
 

--- a/xlsx/src/import/util.rs
+++ b/xlsx/src/import/util.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::unwrap_used)]
 
-use colors::get_indexed_color;
+use ironcalc_base::colors::get_indexed_color;
 use roxmltree::{ExpandedName, Node};
 
 use crate::error::XlsxError;
 
-use super::colors;
 use super::theme::Theme;
 
 pub(crate) fn get_number(node: Node, s: &str) -> i32 {


### PR DESCRIPTION
This implements named cell styles:

* API (create/update/delete/apply)
* Tests
* Bindings
* Frontend: this is to be thrown away though
* Present defaults are placeholders (most notably the formatting ones)

I had to meve some of the color logic from the xlsx crate to the base crate.

Note that Themes are ignored for now. Everything with themes is broken in IronCalc at the moment

You can create/delete/update names in the UI just yet