### PR TITLE
FIX: Show the Dynamic array outline as in the design

### DIFF
--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -453,6 +453,10 @@ const Worksheet = forwardRef(
           }}
         >
           <canvas className="ic-worksheet-sheet-canvas" ref={canvasElement} />
+          <div
+            className="ic-worksheet-cell-array-structure"
+            ref={cellArrayStructure}
+          />
           <div className="ic-worksheet-cell-outline" ref={cellOutline} />
           <div className="ic-worksheet-editor-wrapper" ref={editorElement}>
             <Editor
@@ -470,10 +474,6 @@ const Worksheet = forwardRef(
             />
           </div>
           <div className="ic-worksheet-area-outline" ref={areaOutline} />
-          <div
-            className="ic-worksheet-cell-array-structure"
-            ref={cellArrayStructure}
-          />
           <div
             className="ic-worksheet-extend-to-outline"
             ref={extendToOutline}

--- a/webapp/IronCalc/src/components/Worksheet/worksheet.css
+++ b/webapp/IronCalc/src/components/Worksheet/worksheet.css
@@ -120,8 +120,8 @@
 
 .ic-worksheet-cell-array-structure {
   position: absolute;
-  outline: 3px dashed var(--palette-sheet-cell-array-structure-color);
-  border-radius: 3px;
+  box-sizing: border-box;
+  border: 1px solid var(--palette-sheet-cell-array-structure-color);
 }
 
 /* Cell outline */

--- a/webapp/IronCalc/src/theme/theme.css
+++ b/webapp/IronCalc/src/theme/theme.css
@@ -82,5 +82,5 @@
     "Inter", "Adjusted Arial Fallback", sans-serif;
   --palette-sheet-header-font:
     bold 12px "Inter", "Adjusted Arial Fallback", sans-serif;
-  --palette-sheet-cell-array-structure-color: #e4c286ad;
+  --palette-sheet-cell-array-structure-color: #2f80ed;
 }


### PR DESCRIPTION
Changes the color of the border, 1x smaller and "bellow" the cell outline.

New:

<img width="675" height="177" alt="image" src="https://github.com/user-attachments/assets/428f652f-fbba-433b-8cfd-d5ad0c174388" />

Old:

<img width="675" height="177" alt="image" src="https://github.com/user-attachments/assets/920e298f-10da-4705-a5a5-feb0f3acfb91" />

