### PR TITLE
fix: element overlap in CF tabs

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/edit-rule.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/edit-rule.css
@@ -2,6 +2,7 @@
   height: 100%;
   overflow-y: auto;
   overscroll-behavior: contain;
+  isolation: isolate;
 }
 
 .ic-edit-rule-content {
@@ -52,6 +53,7 @@
   position: sticky;
   top: 0;
   background: var(--palette-common-white);
+  z-index: 1;
 }
 
 .ic-edit-rule-tab.ic-button {


### PR DESCRIPTION
This PR fixes the `z-index` issue we were suffering on the new CF tab buttons:

<img width="1004" height="560" alt="image" src="https://github.com/user-attachments/assets/f5cea2b4-4971-4f9d-8f6d-4d094cef7f24" />

Now it looks like this:

<img width="973" height="587" alt="image" src="https://github.com/user-attachments/assets/18ef194d-f338-4360-b4d6-25a674682c7a" />
