### PR TITLE
fix: stick footer to bottom in CF drawer

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/edit-rule.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/edit-rule.css
@@ -1,5 +1,7 @@
 .ic-edit-rule-container {
   height: 100%;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   overscroll-behavior: contain;
   isolation: isolate;
@@ -9,6 +11,7 @@
   display: flex;
   flex-direction: column;
   font-size: 12px;
+  flex: 1 0 auto;
 }
 
 .ic-edit-rule-header-box {
@@ -17,6 +20,7 @@
   align-items: center;
   gap: 8px;
   padding: 24px 12px;
+  flex-shrink: 0;
   border-bottom: 1px solid var(--palette-grey-300);
   font-size: 14px;
   font-weight: 600;
@@ -49,6 +53,7 @@
   display: flex;
   flex-direction: row;
   height: 44px;
+  flex-shrink: 0;
   border-bottom: 1px solid var(--palette-grey-300);
   position: sticky;
   top: 0;
@@ -383,6 +388,7 @@
   justify-content: space-between;
   gap: 8px;
   padding: 8px;
+  flex-shrink: 0;
   border-top: 1px solid var(--palette-grey-300);
   position: sticky;
   bottom: 0;


### PR DESCRIPTION
This PR fixes a bug by which the footer in the Conditional Formatting drawer was not appearing at the bottom edge, see the before/after:

<img width="288" height="723" alt="image" src="https://github.com/user-attachments/assets/fdc38883-20c5-4f2d-a81e-83b126e9119f" />
<img width="auto" height="723" alt="image" src="https://github.com/user-attachments/assets/c3901cc0-ca5f-466d-9131-195b219393d3" />

We are also adding `flex-shrink: 0` to some elements (header, tab buttons, footer) so they don't stretch when pushed by other elements.