### PR TITLE
fix: hide tooltips on touchscreens

### DIFF
--- a/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
+++ b/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
@@ -30,12 +30,12 @@ export function Tooltip({ title, children }: TooltipProperties) {
         role="none"
         className="ic-tooltip-trigger"
         aria-describedby={visible ? tooltipId : undefined}
-        onMouseEnter={() => {
-          if (!isMenuOpen()) {
+        onPointerEnter={(e) => {
+          if (e.pointerType === "mouse" && !isMenuOpen()) {
             setVisible(true);
           }
         }}
-        onMouseLeave={() => setVisible(false)}
+        onPointerLeave={() => setVisible(false)}
         onPointerDown={() => setVisible(false)}
         onFocus={() => {
           if (!isMenuOpen()) {


### PR DESCRIPTION
This PR introduces a small change by which we restrict tooltips to non-touchscreen devices.

The reasons to do this are a few:

1. Touchscreens don't have a hover state
2. Right now tooltips appear after the click, which makes them useless (they inform about the action after performing it!)
3. Because the mouse never leaves them, they can't be dismissed and sometimes they stay visible forever and can accumulate, like in here:
<img width="1179" height="443" alt="IMG_7056" src="https://github.com/user-attachments/assets/2e982ab7-cc8a-4a96-b8a5-3316895a0ae0" />

