### PR TITLE
update: add arrow indicators for hidden rows and columns

### DIFF
--- a/webapp/IronCalc/src/components/Worksheet/ContextMenus/RowHeader.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/ContextMenus/RowHeader.tsx
@@ -25,6 +25,7 @@ interface RowHeaderContextMenuProps {
   onMoveRowsDown: () => void;
   onHideRows: () => void;
   onShowHiddenRows: () => void;
+  hiddenRowsCount: number;
   range: {
     rowStart: number;
     columnStart: string;
@@ -50,6 +51,7 @@ const RowHeaderContextMenu = (properties: RowHeaderContextMenuProps) => {
     onMoveRowsDown,
     onHideRows,
     onShowHiddenRows,
+    hiddenRowsCount,
     range,
     frozenRowsCount,
   } = properties;
@@ -86,9 +88,11 @@ const RowHeaderContextMenu = (properties: RowHeaderContextMenuProps) => {
           ? t("context_menu.row_header.hide_row", { row: rowStart })
           : t("context_menu.row_header.hide_rows", { rowStart, rowEnd })}
       </MenuItem>
-      <MenuItem icon={<Eye />} onClick={onShowHiddenRows}>
-        {t("context_menu.row_header.show_hidden_rows")}
-      </MenuItem>
+      {hiddenRowsCount > 0 && (
+        <MenuItem icon={<Eye />} onClick={onShowHiddenRows}>
+          {t("context_menu.row_header.show_hidden_rows")}
+        </MenuItem>
+      )}
 
       <MenuDivider />
 

--- a/webapp/IronCalc/src/components/Worksheet/ContextMenus/RowHeader.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/ContextMenus/RowHeader.tsx
@@ -25,7 +25,7 @@ interface RowHeaderContextMenuProps {
   onMoveRowsDown: () => void;
   onHideRows: () => void;
   onShowHiddenRows: () => void;
-  hiddenRowsCount: number;
+  hasHiddenRows: boolean;
   range: {
     rowStart: number;
     columnStart: string;
@@ -51,7 +51,7 @@ const RowHeaderContextMenu = (properties: RowHeaderContextMenuProps) => {
     onMoveRowsDown,
     onHideRows,
     onShowHiddenRows,
-    hiddenRowsCount,
+    hasHiddenRows,
     range,
     frozenRowsCount,
   } = properties;
@@ -88,7 +88,7 @@ const RowHeaderContextMenu = (properties: RowHeaderContextMenuProps) => {
           ? t("context_menu.row_header.hide_row", { row: rowStart })
           : t("context_menu.row_header.hide_rows", { rowStart, rowEnd })}
       </MenuItem>
-      {hiddenRowsCount > 0 && (
+      {hasHiddenRows && (
         <MenuItem icon={<Eye />} onClick={onShowHiddenRows}>
           {t("context_menu.row_header.show_hidden_rows")}
         </MenuItem>

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -793,6 +793,18 @@ const Worksheet = forwardRef(
             };
           })()}
           frozenRowsCount={model.getFrozenRowsCount(model.getSelectedSheet())}
+          hiddenRowsCount={(() => {
+            const view = model.getSelectedView();
+            const rowStart = view.range[0];
+            const rowEnd = view.range[2];
+            let count = 0;
+            for (let row = rowStart; row <= rowEnd; row++) {
+              if (model.getRowHeight(view.sheet, row) === 0) {
+                count += 1;
+              }
+            }
+            return count;
+          })()}
         />
         <Alert
           open={rowColErrorTitle !== null}

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -793,17 +793,16 @@ const Worksheet = forwardRef(
             };
           })()}
           frozenRowsCount={model.getFrozenRowsCount(model.getSelectedSheet())}
-          hiddenRowsCount={(() => {
+          hasHiddenRows={(() => {
             const view = model.getSelectedView();
             const rowStart = view.range[0];
             const rowEnd = view.range[2];
-            let count = 0;
             for (let row = rowStart; row <= rowEnd; row++) {
               if (model.getRowHeight(view.sheet, row) === 0) {
-                count += 1;
+                return true;
               }
             }
-            return count;
+            return false;
           })()}
         />
         <Alert

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -1300,6 +1300,7 @@ export default class WorksheetCanvas {
     const points = direction === "left" ? "0,0 4,4 0,8" : "4,0 0,4 4,8";
     span.innerHTML = `<svg width="4" height="8" viewBox="0 0 4 8" fill="currentColor"><polygon points="${points}"/></svg>`;
     span.style[direction] = "4px";
+    span.style.pointerEvents = "none";
     return span;
   }
 

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -1102,8 +1102,8 @@ export default class WorksheetCanvas {
     div.style.fontWeight = "bold";
     div.style.borderLeft = `1px solid ${this.theme.headerBorderColor}`;
     div.style.borderTop = `1px solid ${this.theme.headerBorderColor}`;
+    div.style.borderBottom = `1px solid ${selected ? this.theme.outlineColor : "transparent"}`;
     if (selected) {
-      div.style.borderBottom = `1px solid ${this.theme.outlineColor}`;
       div.classList.add("selected");
     } else {
       div.classList.remove("selected");
@@ -1222,6 +1222,12 @@ export default class WorksheetCanvas {
     columnHeaders.style.lineHeight = `${headerRowHeight}px`;
     columnHeaders.style.left = `${headerColumnWidth}px`;
 
+    const selectedSheet = this.model.getSelectedSheet();
+    const isHidden = (col: number): boolean =>
+      col >= 1 &&
+      col <= LAST_COLUMN &&
+      this.getColumnWidth(selectedSheet, col) === 0;
+
     // Frozen headers
     for (let column = 1; column <= frozenColumns; column += 1) {
       const selected = column >= columnStart && column <= columnEnd;
@@ -1230,6 +1236,8 @@ export default class WorksheetCanvas {
         column,
         selected,
         isFullColumnSelected,
+        isHidden(column - 1),
+        isHidden(column + 1),
       );
     }
 
@@ -1251,10 +1259,25 @@ export default class WorksheetCanvas {
         column,
         selected,
         isFullColumnSelected,
+        isHidden(column - 1),
+        isHidden(column + 1),
       );
     }
 
     columnHeaders.style.width = `${deltaX}px`;
+  }
+
+  private createHiddenColumnChevron(direction: "left" | "right"): HTMLElement {
+    const span = document.createElement("span");
+    span.style.position = "absolute";
+    span.style.top = "50%";
+    span.style.transform = "translateY(-50%)";
+    span.style.display = "flex";
+    span.style.alignItems = "center";
+    const points = direction === "left" ? "0,0 4,4 0,8" : "4,0 0,4 4,8";
+    span.innerHTML = `<svg width="4" height="8" viewBox="0 0 4 8" fill="currentColor"><polygon points="${points}"/></svg>`;
+    span.style[direction] = "4px";
+    return span;
   }
 
   private addColumnHeader(
@@ -1262,6 +1285,8 @@ export default class WorksheetCanvas {
     column: number,
     selected: boolean,
     isFullColumnSelected: boolean,
+    hasHiddenLeft = false,
+    hasHiddenRight = false,
   ): number {
     const columnWidth = this.getColumnWidth(
       this.model.getSelectedSheet(),
@@ -1272,9 +1297,19 @@ export default class WorksheetCanvas {
     }
     const div = document.createElement("div");
     div.className = "column-header";
-    div.textContent = columnNameFromNumber(column);
-    this.columnHeaders.insertBefore(div, null);
+    div.style.position = "relative";
 
+    if (hasHiddenLeft) {
+      div.appendChild(this.createHiddenColumnChevron("left"));
+    }
+    const label = document.createElement("span");
+    label.textContent = columnNameFromNumber(column);
+    div.appendChild(label);
+    if (hasHiddenRight) {
+      div.appendChild(this.createHiddenColumnChevron("right"));
+    }
+
+    this.columnHeaders.insertBefore(div, null);
     this.styleColumnHeader(columnWidth, div, selected, isFullColumnSelected);
     this.addColumnResizeHandle(deltaX + columnWidth, column, columnWidth);
     return columnWidth;

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -47,7 +47,7 @@ export interface CanvasSettings {
 }
 
 export const headerRowHeight = 28;
-export const headerColumnWidth = 30;
+export const headerColumnWidth = 40;
 export const devicePixelRatio = window.devicePixelRatio || 1;
 
 export const frozenSeparatorWidth = 3;
@@ -1140,6 +1140,8 @@ export default class WorksheetCanvas {
 
     let topLeftCornerY = headerRowHeight + 0.5;
     const firstRow = frozenRows === 0 ? topLeftCell.row : 1;
+    const isRowHidden = (r: number): boolean =>
+      r >= 1 && r <= LAST_ROW && this.getRowHeight(selectedSheet, r) === 0;
 
     for (let row = firstRow; row <= bottomRightCell.row; row += 1) {
       const rowHeight = this.getRowHeight(selectedSheet, row);
@@ -1176,6 +1178,27 @@ export default class WorksheetCanvas {
         topLeftCornerY + rowHeight / 2,
         headerColumnWidth,
       );
+
+      const centerX = 8;
+      if (isRowHidden(row - 1)) {
+        const tip = topLeftCornerY + 8;
+        context.beginPath();
+        context.moveTo(centerX, tip);
+        context.lineTo(centerX - 4, tip - 4);
+        context.lineTo(centerX + 4, tip - 4);
+        context.closePath();
+        context.fill();
+      }
+      if (isRowHidden(row + 1)) {
+        const tip = topLeftCornerY + rowHeight - 8;
+        context.beginPath();
+        context.moveTo(centerX, tip);
+        context.lineTo(centerX - 4, tip + 4);
+        context.lineTo(centerX + 4, tip + 4);
+        context.closePath();
+        context.fill();
+      }
+
       topLeftCornerY += rowHeight;
       this.addRowResizeHandle(topLeftCornerY, row, rowHeight);
       if (row === frozenRows) {


### PR DESCRIPTION
Currently, we can hide rows and columns but show no indicator on that. This PR adds a minimum visual indicator that shows where these hidden rows and columns are.

https://github.com/user-attachments/assets/854c8f43-24b4-4bca-bb18-caec4b780da9


### Changes

1. Add chevron arrow indicators on column headers to show when adjacent columns are hidden
<img width="271" height="151" alt="image" src="https://github.com/user-attachments/assets/9cf813a3-4b45-4c82-aafc-34ccfea5ddac" />

2. Add triangle arrow indicators on row headers to show when adjacent rows are hidden
<img width="53" height="86" alt="image" src="https://github.com/user-attachments/assets/928e916c-76fa-4914-9bf9-a86443bf5df3" />

3. Increase `headerColumnWidth` from 30 to 40px for better readability

4. Additionally, we've fixed a bug in which we were showing the 'Show hidden rows' item in Row Header context menus, even without having hidden rows.

Note that we still need to select the adjacent columns/rows if we want to unhide. In a future iteration we may add some interactivity to these indicators so we can unhide columns/rows just by clicking.