### PR TITLE
FIX: Dynamic array functions cal also SPILL out of boundaries

### DIFF
--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -819,6 +819,17 @@ impl<'a> Model<'a> {
 
             match original_range {
                 Some((true, _)) => {
+                    if row + array_height - 1 > LAST_ROW || column + array_width - 1 > LAST_COLUMN {
+                        return self.set_cells_with_result(
+                            cell_reference,
+                            cell,
+                            &CalcResult::new_error(
+                                Error::SPILL,
+                                cell_reference,
+                                "Spill would exceed worksheet bounds".to_string(),
+                            ),
+                        );
+                    }
                     // Check that the full spill area (based on actual result dimensions) is clear.
                     // The stored range may be (1,1) on first evaluation, so we must re-check here.
                     let sheet_data = &self.workbook.worksheets[sheet as usize].sheet_data;

--- a/base/src/test/array_formulas/test_whole_column_row_reference.rs
+++ b/base/src/test/array_formulas/test_whole_column_row_reference.rs
@@ -137,3 +137,63 @@ fn row_spill_fitting_exactly_at_last_column_succeeds() {
     assert_eq!(model._get_text_at(0, 3, anchor_col + 1), "2");
     assert_eq!(model._get_text_at(0, 3, anchor_col + 2), "3");
 }
+
+// ── SEQUENCE / RANDARRAY near the sheet border ────────────────────────────────
+
+#[test]
+fn sequence_spill_overflowing_last_row_yields_spill_error() {
+    let mut model = new_empty_model();
+
+    // SEQUENCE(10) produces a 10×1 array.  Anchored at LAST_ROW-8 the last
+    // spill row is (LAST_ROW-8)+10-1 = LAST_ROW+1, which overflows.
+    let anchor_row = LAST_ROW - 8;
+    model
+        .set_user_input(0, anchor_row, 1, "=SEQUENCE(10)".to_string())
+        .unwrap();
+    model.evaluate();
+
+    assert_eq!(
+        model._get_text_at(0, anchor_row, 1),
+        "#SPILL!",
+        "SEQUENCE(10) near the bottom border must produce #SPILL!, not #ERROR!"
+    );
+    // No partial spill cells should have been written.
+    assert_eq!(model._get_text_at(0, anchor_row + 1, 1), "");
+}
+
+#[test]
+fn sequence_spill_fitting_exactly_at_last_row_succeeds() {
+    let mut model = new_empty_model();
+
+    // SEQUENCE(10) anchored at LAST_ROW-9: last spill row = LAST_ROW, fits exactly.
+    let anchor_row = LAST_ROW - 9;
+    model
+        .set_user_input(0, anchor_row, 1, "=SEQUENCE(10)".to_string())
+        .unwrap();
+    model.evaluate();
+
+    assert_eq!(model._get_text_at(0, anchor_row, 1), "1");
+    assert_eq!(model._get_text_at(0, anchor_row + 1, 1), "2");
+    assert_eq!(model._get_text_at(0, anchor_row + 9, 1), "10");
+}
+
+#[test]
+fn randarray_spill_overflowing_last_column_yields_spill_error() {
+    let mut model = new_empty_model();
+
+    // RANDARRAY(1,10) produces a 1×10 array.  Anchored at column LAST_COLUMN-8
+    // the last spill column is (LAST_COLUMN-8)+10-1 = LAST_COLUMN+1, which overflows.
+    let anchor_col = LAST_COLUMN - 8;
+    model
+        .set_user_input(0, 3, anchor_col, "=RANDARRAY(1,10)".to_string())
+        .unwrap();
+    model.evaluate();
+
+    assert_eq!(
+        model._get_text_at(0, 3, anchor_col),
+        "#SPILL!",
+        "RANDARRAY(1,10) near the right border must produce #SPILL!, not #ERROR!"
+    );
+    // No partial spill cells should have been written.
+    assert_eq!(model._get_text_at(0, 3, anchor_col + 1), "");
+}


### PR DESCRIPTION
This is addressing a Copilot's comment I overlooked :/

https://github.com/ironcalc/IronCalc/pull/1018#discussion_r3292621037