### PR TITLE
FIX: Typing an empty string would delete the cell's content

### DIFF
--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -2252,6 +2252,12 @@ impl<'a> Model<'a> {
     ) -> Result<(), String> {
         // first we make sure we can write in the cell and clear the spills.
         self.prepare_cell_for_user_input(sheet, row, column)?;
+        if value.is_empty() {
+            // If the value is empty we just clear the cell
+            let ws = self.workbook.worksheet_mut(sheet)?;
+            ws.cell_clear_contents(row, column)?;
+            return Ok(());
+        }
 
         // If value starts with "'" then we force the style to be quote_prefix
         let style_index = self.get_cell_style_index(sheet, row, column)?;
@@ -3787,10 +3793,8 @@ mod tests {
             Some(&Cell::NumberCell { v: 35.0, s: 0 })
         );
 
-        assert_eq!(
-            worksheet.cell(2, 1),
-            Some(&Cell::SharedString { si: 0, s: 0 })
-        );
+        // Clears the content of A2 but not the style
+        assert_eq!(worksheet.cell(2, 1), Some(&Cell::EmptyCell { s: 0 }));
         assert_eq!(worksheet.cell(3, 1), None)
     }
 

--- a/base/src/test/test_cell.rs
+++ b/base/src/test/test_cell.rs
@@ -20,12 +20,13 @@ fn test_cell_get_type() {
     model._set("A11", "=1/0");
     model._set("A12", "=1>0");
     model._set("A13", "=42"); // an Cell::EmptyCell, considered to be a CellType::Number
+    model._set("A15", "'"); // an empty string
     model.evaluate();
 
     model._cell_clear_contents(0, 13, 1).unwrap(); // A13
     model._set("A14", "=42"); // a CellFormula
 
-    assert_eq!(model._get_cell("A1").get_type(), CellType::Text);
+    assert_eq!(model._get_cell("A1").get_type(), CellType::Number);
     assert_eq!(model._get_cell("A2").get_type(), CellType::Number);
     assert_eq!(model._get_cell("A3").get_type(), CellType::Number);
     assert_eq!(model._get_cell("A4").get_type(), CellType::Text);
@@ -39,6 +40,7 @@ fn test_cell_get_type() {
     assert_eq!(model._get_cell("A12").get_type(), CellType::LogicalValue);
     assert_eq!(model._get_cell("A13").get_type(), CellType::Number);
     assert_eq!(model._get_cell("A14").get_type(), CellType::Number);
+    assert_eq!(model._get_cell("A15").get_type(), CellType::Text);
 }
 
 #[test]

--- a/base/src/test/test_fn_count.rs
+++ b/base/src/test/test_fn_count.rs
@@ -53,7 +53,7 @@ fn test_fn_count_minimal() {
     let mut model = new_empty_model();
     model._set("B1", "3.1415926");
     model._set("B2", "Tomorrow's the day my bride's gonna come");
-    model._set("B3", "");
+    model._set("B3", "'");
     model._set("A1", "=COUNT(B1:B5)");
     model._set("A2", "=COUNTA(B1:B5)");
     model._set("A3", "=COUNTBLANK(B1:B5)");
@@ -61,7 +61,7 @@ fn test_fn_count_minimal() {
 
     // There is only one number
     assert_eq!(model._get_text("A1"), *"1");
-    // Thre are three non-empty cells
+    // There are three non-empty cells
     assert_eq!(model._get_text("A2"), *"3");
     // There are 3 blank cells B4, B5 and B3 that contains the empty string
     assert_eq!(model._get_text("A3"), *"3");

--- a/base/src/test/test_model_is_empty_cell.rs
+++ b/base/src/test/test_model_is_empty_cell.rs
@@ -36,10 +36,10 @@ fn test_is_empty_cell_with_value() {
 }
 
 #[test]
-fn test_is_empty_cell_empty_string_not_empty() {
+fn test_is_empty_cell_empty_string_is_empty() {
     let mut model = new_empty_model();
     model._set("A1", "");
-    assert_eq!(model.is_empty_cell(0, 1, 1), Ok(false));
+    assert_eq!(model.is_empty_cell(0, 1, 1), Ok(true));
 }
 
 #[test]


### PR DESCRIPTION
Note in Google sheets. Backspace will actually delete the range content.
In IronCalc and Excel Backspace will start editing the selected cell in the range with empty content.
