### PR TITLE
update: more refinements in Cell Styles drawer

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/ManageCustomStyles.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/ManageCustomStyles.tsx
@@ -1,0 +1,53 @@
+import type { NamedStyle } from "@ironcalc/wasm";
+import { PencilLine, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { IconButton } from "../../Button/IconButton";
+import { Tooltip } from "../../Tooltip/Tooltip";
+import { getTileStyle } from "./named-styles-utils";
+
+interface ManageCustomStylesProps {
+  customStyles: NamedStyle[];
+  onEdit: (style: NamedStyle) => void;
+  onDelete: (style: NamedStyle) => void;
+}
+
+const ManageCustomStyles = ({
+  customStyles,
+  onEdit,
+  onDelete,
+}: ManageCustomStylesProps) => {
+  const { t } = useTranslation();
+  return (
+    <div className="ic-named-styles-manage-list">
+      {customStyles.map((s) => (
+        <div key={s.name} className="ic-named-styles-manage-item">
+          <div
+            className="ic-named-styles-manage-item-preview"
+            style={getTileStyle(s.style)}
+          >
+            Aa
+          </div>
+          <div className="ic-named-styles-manage-item-name">{s.name}</div>
+          <div className="ic-named-styles-manage-item-icons">
+            <Tooltip title={t("named_styles.update_style")}>
+              <IconButton
+                icon={<PencilLine size={16} />}
+                onClick={() => onEdit(s)}
+                aria-label={t("named_styles.update_style")}
+              />
+            </Tooltip>
+            <Tooltip title={t("named_styles.delete_style")}>
+              <IconButton
+                icon={<Trash2 size={16} />}
+                onClick={() => onDelete(s)}
+                aria-label={t("named_styles.delete_style")}
+              />
+            </Tooltip>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ManageCustomStyles;

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/NamedStylesPanel.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/NamedStylesPanel.tsx
@@ -1,5 +1,5 @@
 import type { CellStyle, FmtSettings, NamedStyle } from "@ironcalc/wasm";
-import { ArrowLeft, Pencil, Plus, Trash2, X } from "lucide-react";
+import { ArrowLeft, Plus, Settings2, Trash2, X } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -102,26 +102,17 @@ interface StyleGroup {
   styles: NamedStyle[];
 }
 
-function groupStyles(
-  customStyles: NamedStyle[],
-  builtinStyles: NamedStyle[],
-): StyleGroup[] {
+function getBuiltinGroups(builtinStyles: NamedStyle[]): StyleGroup[] {
   const byLowerName = new Map(
     builtinStyles.map((s) => [s.name.toLowerCase(), s]),
   );
-  const result: StyleGroup[] = [];
-  if (customStyles.length > 0) {
-    result.push({ label: "Custom", type: "grid", styles: customStyles });
-  }
-  for (const cat of BUILTIN_CATEGORIES) {
-    const styles = cat.names
+  return BUILTIN_CATEGORIES.map((cat) => ({
+    label: cat.label,
+    type: cat.type,
+    styles: cat.names
       .map((n) => byLowerName.get(n))
-      .filter((s): s is NamedStyle => s !== undefined);
-    if (styles.length > 0) {
-      result.push({ label: cat.label, type: cat.type, styles });
-    }
-  }
-  return result;
+      .filter((s): s is NamedStyle => s !== undefined),
+  })).filter((g) => g.styles.length > 0);
 }
 
 const BORDER_WIDTH: Record<string, string> = {
@@ -230,7 +221,7 @@ const NamedStylesPanel = ({
   const normalStyle = builtinStyles.find(
     (s) => s.name.toLowerCase() === "normal",
   );
-  const groups = groupStyles(customStyles, builtinStyles);
+  const builtinGroups = getBuiltinGroups(builtinStyles);
   const allStyleNames = [
     ...customStyles.map((s) => s.name),
     ...builtinStyles.map((s) => s.name),
@@ -451,32 +442,43 @@ const NamedStylesPanel = ({
         </Tooltip>
       </div>
       <div className="ic-named-styles-content">
-        {groups.map((group) => (
-          <div key={group.label} className="ic-named-styles-section">
+        {customStyles.length > 0 && (
+          <div className="ic-named-styles-section">
             <div className="ic-named-styles-section-title">
-              {group.label}
-              {group.label === "Custom" && (
-                <div className="ic-named-styles-section-title-actions">
-                  <Tooltip title={t("named_styles.update_style")}>
-                    <IconButton
-                      icon={<Pencil size={14} />}
-                      onClick={() => setView({ mode: "edit-list" })}
-                      aria-label={t("named_styles.update_style")}
-                    />
-                  </Tooltip>
-                  <Tooltip title={t("named_styles.delete_style")}>
-                    <IconButton
-                      icon={<Trash2 size={14} />}
-                      onClick={() => setView({ mode: "delete-list" })}
-                      aria-label={t("named_styles.delete_style")}
-                    />
-                  </Tooltip>
-                </div>
-              )}
+              Custom
+              <div className="ic-named-styles-section-title-actions">
+                <Tooltip title={t("named_styles.manage_styles")}>
+                  <IconButton
+                    icon={<Settings2 size={14} />}
+                    onClick={() => setView({ mode: "edit-list" })}
+                    aria-label={t("named_styles.manage_styles")}
+                  />
+                </Tooltip>
+                <Tooltip title={t("named_styles.delete_style")}>
+                  <IconButton
+                    icon={<Trash2 size={14} />}
+                    onClick={() => setView({ mode: "delete-list" })}
+                    aria-label={t("named_styles.delete_style")}
+                  />
+                </Tooltip>
+              </div>
             </div>
-            {renderGroupContent(group)}
+            <div className="ic-named-styles-grid">
+              {customStyles.map((s) => renderTile(s))}
+            </div>
           </div>
-        ))}
+        )}
+        <div className="ic-named-styles-section">
+          <div className="ic-named-styles-section-title">Theme</div>
+          {builtinGroups.map((group) => (
+            <div key={group.label} className="ic-named-styles-category">
+              <div className="ic-named-styles-category-label">
+                {group.label}
+              </div>
+              {renderGroupContent(group)}
+            </div>
+          ))}
+        </div>
       </div>
       <div className="ic-named-styles-footer">
         <Button

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/NamedStylesPanel.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/NamedStylesPanel.tsx
@@ -1,6 +1,5 @@
-import type { CellStyle, FmtSettings, NamedStyle } from "@ironcalc/wasm";
-import { ArrowLeft, Plus, Settings2, Trash2, X } from "lucide-react";
-import type { CSSProperties } from "react";
+import type { FmtSettings, NamedStyle } from "@ironcalc/wasm";
+import { ArrowLeft, Plus, Settings2, X } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../Button/Button";
@@ -10,7 +9,9 @@ import EditNamedStyle, {
   type NamedStyleSavePayload,
   type SaveError,
 } from "./EditNamedStyle";
+import ManageCustomStyles from "./ManageCustomStyles";
 import "./named-styles.css";
+import { getTileStyle } from "./named-styles-utils";
 
 type CategoryType = "grid" | "themed";
 
@@ -115,65 +116,6 @@ function getBuiltinGroups(builtinStyles: NamedStyle[]): StyleGroup[] {
   })).filter((g) => g.styles.length > 0);
 }
 
-const BORDER_WIDTH: Record<string, string> = {
-  thin: "1px",
-  medium: "2px",
-  thick: "3px",
-  double: "3px",
-  dotted: "1px",
-  slantdashdot: "1px",
-  mediumdashed: "2px",
-  mediumdashdotdot: "2px",
-  mediumdashdot: "2px",
-};
-
-const BORDER_CSS_STYLE: Record<string, string> = {
-  thin: "solid",
-  medium: "solid",
-  thick: "solid",
-  double: "double",
-  dotted: "dotted",
-  slantdashdot: "dashed",
-  mediumdashed: "dashed",
-  mediumdashdotdot: "dashed",
-  mediumdashdot: "dashed",
-};
-
-interface BorderItem {
-  style: string;
-  color: string;
-}
-
-function getBorderValue(item: BorderItem | undefined): string | undefined {
-  if (!item?.style) {
-    return undefined;
-  }
-  const width = BORDER_WIDTH[item.style] ?? "1px";
-  const cssStyle = BORDER_CSS_STYLE[item.style] ?? "solid";
-  return `${width} ${cssStyle} ${item.color || "currentColor"}`;
-}
-
-function getTileStyle(style: CellStyle): CSSProperties {
-  const decorations: string[] = [];
-  if (style.font.u) {
-    decorations.push("underline");
-  }
-  if (style.font.strike) {
-    decorations.push("line-through");
-  }
-  return {
-    backgroundColor: style.fill.fg_color || undefined,
-    color: style.font.color || undefined,
-    fontWeight: style.font.b ? "bold" : undefined,
-    fontStyle: style.font.i ? "italic" : undefined,
-    textDecoration: decorations.length > 0 ? decorations.join(" ") : undefined,
-    borderTop: getBorderValue(style.border?.top),
-    borderRight: getBorderValue(style.border?.right),
-    borderBottom: getBorderValue(style.border?.bottom),
-    borderLeft: getBorderValue(style.border?.left),
-  };
-}
-
 const ACCENT_LABELS = [
   "Accent 1",
   "Accent 2",
@@ -186,9 +128,8 @@ const ACCENT_LABELS = [
 type PanelView =
   | { mode: "list" }
   | { mode: "create" }
-  | { mode: "edit-list" }
+  | { mode: "manage" }
   | { mode: "editing"; style: NamedStyle }
-  | { mode: "delete-list" }
   | { mode: "delete-confirm"; style: NamedStyle };
 
 interface NamedStylesPanelProps {
@@ -271,12 +212,12 @@ const NamedStylesPanel = ({
     );
   };
 
-  const renderSubHeader = (title: string) => (
+  const renderSubHeader = (title: string, onBack?: () => void) => (
     <div className="ic-named-styles-edit-header">
       <Tooltip title={t("named_styles.back_to_list")}>
         <IconButton
           icon={<ArrowLeft />}
-          onClick={() => setView({ mode: "list" })}
+          onClick={onBack ?? (() => setView({ mode: "list" }))}
           aria-label={t("named_styles.back_to_list")}
         />
       </Tooltip>
@@ -318,24 +259,16 @@ const NamedStylesPanel = ({
     );
   }
 
-  if (view.mode === "edit-list") {
+  if (view.mode === "manage") {
     return (
       <div className="ic-named-styles-container">
-        {renderSubHeader(t("named_styles.pick_to_edit"))}
+        {renderSubHeader(t("named_styles.manage_styles"))}
         <div className="ic-named-styles-content">
-          <div className="ic-named-styles-pick-list">
-            {customStyles.map((s) => (
-              <button
-                key={s.name}
-                type="button"
-                className="ic-named-styles-pick-item"
-                style={getTileStyle(s.style)}
-                onClick={() => setView({ mode: "editing", style: s })}
-              >
-                {s.name}
-              </button>
-            ))}
-          </div>
+          <ManageCustomStyles
+            customStyles={customStyles}
+            onEdit={(style) => setView({ mode: "editing", style })}
+            onDelete={(style) => setView({ mode: "delete-confirm", style })}
+          />
         </div>
       </div>
     );
@@ -348,7 +281,9 @@ const NamedStylesPanel = ({
     );
     return (
       <div className="ic-named-styles-container">
-        {renderSubHeader(t("named_styles.update_style"))}
+        {renderSubHeader(t("named_styles.update_style"), () =>
+          setView({ mode: "manage" }),
+        )}
         <div className="ic-named-styles-content">
           <EditNamedStyle
             name={editingStyle.name}
@@ -365,31 +300,8 @@ const NamedStylesPanel = ({
               }
               return onUpdateNamedStyle(editingStyle.name, payload);
             }}
-            onClose={() => setView({ mode: "list" })}
+            onClose={() => setView({ mode: "manage" })}
           />
-        </div>
-      </div>
-    );
-  }
-
-  if (view.mode === "delete-list") {
-    return (
-      <div className="ic-named-styles-container">
-        {renderSubHeader(t("named_styles.pick_to_delete"))}
-        <div className="ic-named-styles-content">
-          <div className="ic-named-styles-pick-list">
-            {customStyles.map((s) => (
-              <button
-                key={s.name}
-                type="button"
-                className="ic-named-styles-pick-item"
-                style={getTileStyle(s.style)}
-                onClick={() => setView({ mode: "delete-confirm", style: s })}
-              >
-                {s.name}
-              </button>
-            ))}
-          </div>
         </div>
       </div>
     );
@@ -399,7 +311,9 @@ const NamedStylesPanel = ({
     const { style: deletingStyle } = view;
     return (
       <div className="ic-named-styles-container">
-        {renderSubHeader(t("named_styles.delete_style"))}
+        {renderSubHeader(t("named_styles.delete_style"), () =>
+          setView({ mode: "manage" }),
+        )}
         <div className="ic-named-styles-confirm">
           <p className="ic-named-styles-confirm-message">
             {t("named_styles.confirm_delete_message")}{" "}
@@ -408,7 +322,7 @@ const NamedStylesPanel = ({
           <div className="ic-named-styles-confirm-actions">
             <Button
               variant="secondary"
-              onClick={() => setView({ mode: "delete-list" })}
+              onClick={() => setView({ mode: "manage" })}
             >
               {t("named_styles.cancel")}
             </Button>
@@ -444,21 +358,17 @@ const NamedStylesPanel = ({
       <div className="ic-named-styles-content">
         {customStyles.length > 0 && (
           <div className="ic-named-styles-section">
-            <div className="ic-named-styles-section-title">
+            <div
+              className="ic-named-styles-section-title"
+              style={{ height: "17px" }}
+            >
               Custom
               <div className="ic-named-styles-section-title-actions">
                 <Tooltip title={t("named_styles.manage_styles")}>
                   <IconButton
                     icon={<Settings2 size={14} />}
-                    onClick={() => setView({ mode: "edit-list" })}
+                    onClick={() => setView({ mode: "manage" })}
                     aria-label={t("named_styles.manage_styles")}
-                  />
-                </Tooltip>
-                <Tooltip title={t("named_styles.delete_style")}>
-                  <IconButton
-                    icon={<Trash2 size={14} />}
-                    onClick={() => setView({ mode: "delete-list" })}
-                    aria-label={t("named_styles.delete_style")}
                   />
                 </Tooltip>
               </div>

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/edit-named-style.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/edit-named-style.css
@@ -61,7 +61,7 @@
 }
 
 .ic-edit-style-preview {
-  width: 56px;
+  width: 40px;
   height: 32px;
   border-radius: 4px;
   box-shadow: inset 0 0 0 1px

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles-utils.ts
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles-utils.ts
@@ -1,0 +1,61 @@
+import type { CellStyle } from "@ironcalc/wasm";
+import type { CSSProperties } from "react";
+
+const BORDER_WIDTH: Record<string, string> = {
+  thin: "1px",
+  medium: "2px",
+  thick: "3px",
+  double: "3px",
+  dotted: "1px",
+  slantdashdot: "1px",
+  mediumdashed: "2px",
+  mediumdashdotdot: "2px",
+  mediumdashdot: "2px",
+};
+
+const BORDER_CSS_STYLE: Record<string, string> = {
+  thin: "solid",
+  medium: "solid",
+  thick: "solid",
+  double: "double",
+  dotted: "dotted",
+  slantdashdot: "dashed",
+  mediumdashed: "dashed",
+  mediumdashdotdot: "dashed",
+  mediumdashdot: "dashed",
+};
+
+interface BorderItem {
+  style: string;
+  color: string;
+}
+
+function getBorderValue(item: BorderItem | undefined): string | undefined {
+  if (!item?.style) {
+    return undefined;
+  }
+  const width = BORDER_WIDTH[item.style] ?? "1px";
+  const cssStyle = BORDER_CSS_STYLE[item.style] ?? "solid";
+  return `${width} ${cssStyle} ${item.color || "currentColor"}`;
+}
+
+export function getTileStyle(style: CellStyle): CSSProperties {
+  const decorations: string[] = [];
+  if (style.font.u) {
+    decorations.push("underline");
+  }
+  if (style.font.strike) {
+    decorations.push("line-through");
+  }
+  return {
+    backgroundColor: style.fill.fg_color || undefined,
+    color: style.font.color || undefined,
+    fontWeight: style.font.b ? "bold" : undefined,
+    fontStyle: style.font.i ? "italic" : undefined,
+    textDecoration: decorations.length > 0 ? decorations.join(" ") : undefined,
+    borderTop: getBorderValue(style.border?.top),
+    borderRight: getBorderValue(style.border?.right),
+    borderBottom: getBorderValue(style.border?.bottom),
+    borderLeft: getBorderValue(style.border?.left),
+  };
+}

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
@@ -157,31 +157,53 @@
   position: relative;
 }
 
-.ic-named-styles-pick-list {
+.ic-named-styles-manage-list {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 8px 0;
 }
 
-.ic-named-styles-pick-item {
-  height: 36px;
-  padding: 0 16px;
+.ic-named-styles-manage-item {
   display: flex;
   align-items: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: var(--typography-font-size);
-  font-family: inherit;
-  text-align: left;
+  gap: 12px;
+  padding: 8px 12px 8px 15px;
+  height: 68px;
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--palette-grey-200);
 }
 
-.ic-named-styles-pick-item:hover {
-  background-color: color-mix(
-    in srgb,
-    var(--palette-common-black) 6%,
-    transparent
-  );
+.ic-named-styles-manage-item-preview {
+  width: 40px;
+  height: 36px;
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--palette-common-black) 12%, transparent);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--typography-font-size);
+  font-family: var(--typography-font-family);
+  font-weight: 600;
+}
+
+.ic-named-styles-manage-item-name {
+  flex: 1;
+  font-size: var(--typography-font-size);
+  font-family: var(--typography-font-family);
+  color: var(--palette-common-black);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+}
+
+.ic-named-styles-manage-item-icons {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
 }
 
 .ic-named-styles-confirm {

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
@@ -80,6 +80,19 @@
   margin-left: auto;
 }
 
+.ic-named-styles-category {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ic-named-styles-category-label {
+  font-size: var(--typography-font-size);
+  font-family: var(--typography-font-family);
+  font-weight: 500;
+  color: var(--palette-common-black);
+}
+
 .ic-named-styles-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -192,12 +192,13 @@
     "workbook": "Arbeitsmappe"
   },
   "named_styles": {
-    "add_new_style": "Neuen Stil hinzufügen",
+    "add_new_style": "Neu hinzufügen",
     "apply": "Anwenden",
     "back_to_list": "Zurück zur Liste",
     "cancel": "Abbrechen",
     "confirm_delete_message": "Möchten Sie wirklich löschen",
     "delete_style": "Stil löschen",
+    "manage_styles": "Stile verwalten",
     "name_already_exists": "Ein Stil mit diesem Namen existiert bereits",
     "new_style": "Neuer Stil",
     "panel_title": "Zellformate",

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -202,8 +202,7 @@
     "name_already_exists": "Ein Stil mit diesem Namen existiert bereits",
     "new_style": "Neuer Stil",
     "panel_title": "Zellformate",
-    "pick_to_delete": "Stil zum Löschen auswählen",
-    "pick_to_edit": "Stil zum Bearbeiten auswählen",
+
     "update_style": "Stil bearbeiten"
   },
   "navigation": {

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -202,8 +202,7 @@
     "name_already_exists": "A style with this name already exists",
     "new_style": "New style",
     "panel_title": "Cell styles",
-    "pick_to_delete": "Select a style to delete",
-    "pick_to_edit": "Select a style to edit",
+
     "update_style": "Edit style"
   },
   "navigation": {

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -192,12 +192,13 @@
     "workbook": "Workbook"
   },
   "named_styles": {
-    "add_new_style": "Add a new style",
+    "add_new_style": "Add new",
     "apply": "Apply",
     "back_to_list": "Back to list",
     "cancel": "Cancel",
     "confirm_delete_message": "Are you sure you want to delete",
     "delete_style": "Delete style",
+    "manage_styles": "Manage styles",
     "name_already_exists": "A style with this name already exists",
     "new_style": "New style",
     "panel_title": "Cell styles",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -202,8 +202,7 @@
     "name_already_exists": "Ya existe un estilo con este nombre",
     "new_style": "Nuevo estilo",
     "panel_title": "Estilos de celda",
-    "pick_to_delete": "Seleccione un estilo para eliminar",
-    "pick_to_edit": "Seleccione un estilo para editar",
+
     "update_style": "Editar estilo"
   },
   "navigation": {

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -192,12 +192,13 @@
     "workbook": "Libro"
   },
   "named_styles": {
-    "add_new_style": "Agregar un nuevo estilo",
+    "add_new_style": "Añadir nuevo",
     "apply": "Aplicar",
     "back_to_list": "Volver a la lista",
     "cancel": "Cancelar",
     "confirm_delete_message": "¿Seguro que desea eliminar",
     "delete_style": "Eliminar estilo",
+    "manage_styles": "Gestionar estilos",
     "name_already_exists": "Ya existe un estilo con este nombre",
     "new_style": "Nuevo estilo",
     "panel_title": "Estilos de celda",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -202,8 +202,7 @@
     "name_already_exists": "Un style avec ce nom existe déjà",
     "new_style": "Nouveau style",
     "panel_title": "Styles de cellule",
-    "pick_to_delete": "Sélectionner un style à supprimer",
-    "pick_to_edit": "Sélectionner un style à modifier",
+
     "update_style": "Modifier le style"
   },
   "navigation": {

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -192,12 +192,13 @@
     "workbook": "Classeur"
   },
   "named_styles": {
-    "add_new_style": "Ajouter un nouveau style",
+    "add_new_style": "Ajouter",
     "apply": "Appliquer",
     "back_to_list": "Retour à la liste",
     "cancel": "Annuler",
     "confirm_delete_message": "Voulez-vous vraiment supprimer",
     "delete_style": "Supprimer le style",
+    "manage_styles": "Gérer les styles",
     "name_already_exists": "Un style avec ce nom existe déjà",
     "new_style": "Nouveau style",
     "panel_title": "Styles de cellule",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -202,8 +202,7 @@
     "name_already_exists": "Esiste già uno stile con questo nome",
     "new_style": "Nuovo stile",
     "panel_title": "Stili di cella",
-    "pick_to_delete": "Seleziona uno stile da eliminare",
-    "pick_to_edit": "Seleziona uno stile da modificare",
+
     "update_style": "Modifica stile"
   },
   "navigation": {

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -192,12 +192,13 @@
     "workbook": "Cartella di lavoro"
   },
   "named_styles": {
-    "add_new_style": "Aggiungi un nuovo stile",
+    "add_new_style": "Aggiungi nuovo",
     "apply": "Applica",
     "back_to_list": "Torna all'elenco",
     "cancel": "Annulla",
     "confirm_delete_message": "Sei sicuro di voler eliminare",
     "delete_style": "Elimina stile",
+    "manage_styles": "Gestisci stili",
     "name_already_exists": "Esiste già uno stile con questo nome",
     "new_style": "Nuovo stile",
     "panel_title": "Stili di cella",


### PR DESCRIPTION
This PR introduces a few more refinements to the Cell Styles drawer:

1. Reorganised the styles list into two explicit sections: Custom (only shown when custom styles exist) and Theme
2. Moved Custom Styles to their own folder and screen
   - In this screen we can edit and remove styles. It's consistent with other lists like Named Ranges or Cond. Formatting
3. Wording adjustments, in all locales