### PR TITLE
update: swap download and hide grid buttons in toolbar

### DIFF
--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -499,6 +499,14 @@ function Toolbar(properties: ToolbarProperties) {
 
         {/* View & Tools Group */}
         <div className="ic-toolbar-button-group">
+          <Tooltip title={t("toolbar.selected_png")}>
+            <IconButton
+              icon={<ImageDown />}
+              aria-label={t("toolbar.download_png")}
+              onClick={() => properties.onDownloadPNG()}
+              disabled={!canEdit}
+            />
+          </Tooltip>
           <Tooltip title={t("toolbar.show_hide_grid_lines")}>
             <IconButton
               icon={properties.showGridLines ? <Grid2x2Check /> : <Grid2x2X />}
@@ -506,14 +514,6 @@ function Toolbar(properties: ToolbarProperties) {
               onClick={() =>
                 properties.onToggleShowGridLines(!properties.showGridLines)
               }
-              disabled={!canEdit}
-            />
-          </Tooltip>
-          <Tooltip title={t("toolbar.selected_png")}>
-            <IconButton
-              icon={<ImageDown />}
-              aria-label={t("toolbar.download_png")}
-              onClick={() => properties.onDownloadPNG()}
               disabled={!canEdit}
             />
           </Tooltip>


### PR DESCRIPTION
We're swapping the last 2 buttons in the toolbar to avoid missclicking the 'Download png' button.

<img width="88" height="46" alt="image" src="https://github.com/user-attachments/assets/26e1bb36-ac0f-46e4-9e7a-33fcd6c6e289" />

@nhatcher enjoy! 😄