### PR TITLE
fix[app]: consistent workbook selection after delete

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/storage.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/storage.ts
@@ -259,7 +259,12 @@ export function deleteSelectedModel(): Model | null {
   if (uuids.length === 0) {
     return createNewModel();
   }
-  return selectModelFromStorage(uuids[0]);
+  const newestUuid = uuids.reduce((newest, current) => {
+    const newestTime = metadata[newest]?.createdAt || 0;
+    const currentTime = metadata[current]?.createdAt || 0;
+    return currentTime > newestTime ? current : newest;
+  });
+  return selectModelFromStorage(newestUuid);
 }
 
 export function deleteModelByUuid(uuid: string): Model | null {


### PR DESCRIPTION
When deleting a workbook from the top nav `FileMenu`, the app would open an arbitrary workbook (uuids[0], insertion order).

The left drawer `WorkbookMenu` already correctly opened the newest by `createdAt`. This aligns `deleteSelectedModel` to use the same logic.