### PR TITLE
fix: in toolbar, make focus border visible for Format Menu

### DIFF
--- a/webapp/IronCalc/src/components/Toolbar/toolbar.css
+++ b/webapp/IronCalc/src/components/Toolbar/toolbar.css
@@ -15,7 +15,7 @@
   flex: 1;
   align-items: center;
   overflow-x: auto;
-  padding: 0 8px;
+  padding: 4px 8px;
   gap: 4px;
   scrollbar-width: none; /* Firefox */
 }


### PR DESCRIPTION
Focus state on toolbar buttons would show the outline cropped on top and bottom sides, like in here:

<img width="156" height="110" alt="image" src="https://github.com/user-attachments/assets/3ae3aabf-6111-4e39-ab4b-9c2afb317de8" />

I've added some padding so we can see the whole outline:

<img width="145" height="64" alt="image" src="https://github.com/user-attachments/assets/b49d809a-937c-47df-96f0-3c52e2b5b476" />