### PR TITLE
fix: modal dialogs rendered inside the worksheet now work correctly

### DIFF
--- a/webapp/IronCalc/src/components/Modal/Alert.tsx
+++ b/webapp/IronCalc/src/components/Modal/Alert.tsx
@@ -49,6 +49,7 @@ export function Alert({
     <div
       className="ic-modal-dialog-backdrop"
       onClick={closeModal}
+      // HACK: prevents the workbook from stealing focus while the modal is open
       onPointerDown={(event) => event.stopPropagation()}
       role="none"
     >

--- a/webapp/IronCalc/src/components/Modal/Alert.tsx
+++ b/webapp/IronCalc/src/components/Modal/Alert.tsx
@@ -46,7 +46,12 @@ export function Alert({
   }
 
   return createPortal(
-    <div className="ic-modal-dialog-backdrop" onClick={closeModal} role="none">
+    <div
+      className="ic-modal-dialog-backdrop"
+      onClick={closeModal}
+      onPointerDown={(event) => event.stopPropagation()}
+      role="none"
+    >
       <div
         ref={modalRef}
         className="ic-modal-dialog"

--- a/webapp/IronCalc/src/components/Modal/Confirm.tsx
+++ b/webapp/IronCalc/src/components/Modal/Confirm.tsx
@@ -57,7 +57,12 @@ export function Confirm({
   }
 
   return createPortal(
-    <div className="ic-modal-dialog-backdrop" onClick={closeModal} role="none">
+    <div
+      className="ic-modal-dialog-backdrop"
+      onClick={closeModal}
+      onPointerDown={(event) => event.stopPropagation()}
+      role="none"
+    >
       <div
         ref={modalRef}
         className="ic-modal-dialog"

--- a/webapp/IronCalc/src/components/Modal/Prompt.tsx
+++ b/webapp/IronCalc/src/components/Modal/Prompt.tsx
@@ -69,7 +69,12 @@ export function Prompt({
   }
 
   return createPortal(
-    <div className="ic-modal-dialog-backdrop" onClick={closeModal} role="none">
+    <div
+      className="ic-modal-dialog-backdrop"
+      onClick={closeModal}
+      onPointerDown={(event) => event.stopPropagation()}
+      role="none"
+    >
       <div
         ref={modalRef}
         className={["ic-modal-dialog", className].filter(Boolean).join(" ")}

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -74,7 +74,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
     // Basically prevents the workbook from stealing focus when the user is interacting with the color picker, border picker or advanced color picker
     if (
       active?.closest(
-        ".ic-color-picker, .ic-advanced-color-picker-panel, .ic-border-picker",
+        ".ic-color-picker, .ic-advanced-color-picker-panel, .ic-border-picker, .ic-modal-dialog",
       )
     ) {
       return;

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -71,7 +71,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
   const focusWorkbook = useCallback(() => {
     const active = document.activeElement as HTMLElement | null;
     // FIXME: Horrible HACK for now
-    // Basically prevents the workbook from stealing focus when the user is interacting with the color picker, border picker or advanced color picker
+    // Prevents the workbook from stealing focus when the user is interacting with the color picker, border picker, advanced color picker, or a modal dialog
     if (
       active?.closest(
         ".ic-color-picker, .ic-advanced-color-picker-panel, .ic-border-picker, .ic-modal-dialog",


### PR DESCRIPTION
This PR fixes 2 issues that affected modals opened from within the cell editor:

- Enter key did not close the dialog because `focusWorkbook()` was stealing focus from the autoFocused button. Fixed by adding `.ic-modal-dialog` to the focus-stealing guard.

- Clicking the backdrop also triggered cell selection. Fixed by stopping pointer event  propagation on the backdrop in all 3 modal components: Alert, Confirm, and Prompt.