### PR TITLE
update: make font size toolbar control an editable input

### DIFF
--- a/base/src/test/user_model/test_styles.rs
+++ b/base/src/test/user_model/test_styles.rs
@@ -497,9 +497,7 @@ fn basic_font_size() {
     let style = model.get_cell_style(0, 1, 1).unwrap();
     assert_eq!(style.font.sz, 13);
 
-    model
-        .update_range_style(&range, "font.size", "24")
-        .unwrap();
+    model.update_range_style(&range, "font.size", "24").unwrap();
     let style = model.get_cell_style(0, 1, 1).unwrap();
     assert_eq!(style.font.sz, 24);
 

--- a/base/src/test/user_model/test_styles.rs
+++ b/base/src/test/user_model/test_styles.rs
@@ -482,3 +482,67 @@ fn cell_clear_formatting() {
     assert!(!style.font.b);
     assert_eq!(style.alignment, None);
 }
+
+#[test]
+fn basic_font_size() {
+    let mut model = new_empty_user_model();
+    let range = Area {
+        sheet: 0,
+        row: 1,
+        column: 1,
+        width: 1,
+        height: 1,
+    };
+
+    let style = model.get_cell_style(0, 1, 1).unwrap();
+    assert_eq!(style.font.sz, 13);
+
+    model
+        .update_range_style(&range, "font.size", "24")
+        .unwrap();
+    let style = model.get_cell_style(0, 1, 1).unwrap();
+    assert_eq!(style.font.sz, 24);
+
+    model.undo().unwrap();
+    let style = model.get_cell_style(0, 1, 1).unwrap();
+    assert_eq!(style.font.sz, 13);
+
+    model.redo().unwrap();
+    let style = model.get_cell_style(0, 1, 1).unwrap();
+    assert_eq!(style.font.sz, 24);
+
+    let send_queue = model.flush_send_queue();
+    let mut model2 = new_empty_user_model();
+    model2.apply_external_diffs(&send_queue).unwrap();
+    let style = model2.get_cell_style(0, 1, 1).unwrap();
+    assert_eq!(style.font.sz, 24);
+}
+
+#[test]
+fn font_size_errors() {
+    let mut model = new_empty_user_model();
+    let range = Area {
+        sheet: 0,
+        row: 1,
+        column: 1,
+        width: 1,
+        height: 1,
+    };
+
+    assert_eq!(
+        model.update_range_style(&range, "font.size", "abc"),
+        Err("Invalid value for font size: 'abc'.".to_string())
+    );
+    assert_eq!(
+        model.update_range_style(&range, "font.size", ""),
+        Err("Invalid value for font size: ''.".to_string())
+    );
+    assert_eq!(
+        model.update_range_style(&range, "font.size", "0"),
+        Err("Invalid value for font size: '0'.".to_string())
+    );
+    assert_eq!(
+        model.update_range_style(&range, "font.size", "-1"),
+        Err("Invalid value for font size: '-1'.".to_string())
+    );
+}

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -124,6 +124,15 @@ fn update_style(old_value: &Style, style_path: &str, value: &str) -> Result<Styl
         "font.color" => {
             style.font.color = color(value)?;
         }
+        "font.size" => {
+            let new_size: i32 = value
+                .parse()
+                .map_err(|_| format!("Invalid value for font size: '{value}'."))?;
+            if new_size < 1 {
+                return Err(format!("Invalid value for font size: '{new_size}'."));
+            }
+            style.font.sz = new_size;
+        }
         "font.size_delta" => {
             // This is a special case, we need to add the value to the current size
             let size_delta: i32 = value

--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -74,6 +74,7 @@ type ToolbarProperties = {
   onBorderChanged: (border: BorderOptions) => void;
   onClearFormatting: () => void;
   onIncreaseFontSize: (delta: number) => void;
+  onSetFontSize: (size: number) => void;
   onDownloadPNG: () => void;
   fillColor: string;
   fontColor: string;
@@ -102,6 +103,7 @@ function Toolbar(properties: ToolbarProperties) {
   const [borderPickerOpen, setBorderPickerOpen] = useState(false);
   const [showLeftArrow, setShowLeftArrow] = useState(false);
   const [showRightArrow, setShowRightArrow] = useState(false);
+  const [fontSizeInput, setFontSizeInput] = useState(`${properties.fontSize}`);
 
   const fontColorButton = useRef(null);
   const fillColorButton = useRef(null);
@@ -111,6 +113,10 @@ function Toolbar(properties: ToolbarProperties) {
   const { t } = useTranslation();
 
   const { canEdit } = properties;
+
+  useEffect(() => {
+    setFontSizeInput(`${properties.fontSize}`);
+  }, [properties.fontSize]);
 
   const scrollLeft = () =>
     toolbarRef.current?.scrollBy({ left: -200, behavior: "smooth" });
@@ -282,7 +288,32 @@ function Toolbar(properties: ToolbarProperties) {
               disabled={!canEdit}
             />
           </Tooltip>
-          <div className="ic-toolbar-font-size-box">{properties.fontSize}</div>
+          <input
+            className="ic-toolbar-font-size-box"
+            type="text"
+            inputMode="numeric"
+            value={fontSizeInput}
+            disabled={!canEdit}
+            onClick={(e) => e.stopPropagation()}
+            onFocus={(e) => e.target.select()}
+            onChange={(e) => setFontSizeInput(e.target.value)}
+            onBlur={() => {
+              const parsed = parseInt(fontSizeInput, 10);
+              if (!Number.isNaN(parsed) && parsed > 0 && parsed <= 400) {
+                properties.onSetFontSize(parsed);
+              } else {
+                setFontSizeInput(`${properties.fontSize}`);
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.currentTarget.blur();
+              } else if (e.key === "Escape") {
+                setFontSizeInput(`${properties.fontSize}`);
+                e.currentTarget.blur();
+              }
+            }}
+          />
           <Tooltip title={t("toolbar.increase_font_size")}>
             <IconButton
               icon={<Plus />}

--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -110,6 +110,7 @@ function Toolbar(properties: ToolbarProperties) {
   const borderButton = useRef(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const fontSizeInputRef = useRef<HTMLInputElement>(null);
+  const cancelFontSizeCommit = useRef(false);
 
   const { t } = useTranslation();
 
@@ -304,8 +305,12 @@ function Toolbar(properties: ToolbarProperties) {
             onFocus={(e) => e.target.select()}
             onChange={(e) => setFontSizeInput(e.target.value)}
             onBlur={() => {
-              const parsed = parseInt(fontSizeInput, 10);
-              if (!Number.isNaN(parsed) && parsed > 0 && parsed <= 400) {
+              if (cancelFontSizeCommit.current) {
+                cancelFontSizeCommit.current = false;
+                return;
+              }
+              const parsed = Number(fontSizeInput.trim());
+              if (Number.isInteger(parsed) && parsed > 0 && parsed <= 400) {
                 properties.onSetFontSize(parsed);
               } else {
                 setFontSizeInput(`${properties.fontSize}`);
@@ -315,12 +320,13 @@ function Toolbar(properties: ToolbarProperties) {
               if (e.key === "Enter") {
                 e.currentTarget.blur();
               } else if (e.key === "Escape") {
+                cancelFontSizeCommit.current = true;
                 setFontSizeInput(`${properties.fontSize}`);
                 e.currentTarget.blur();
               } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
                 e.preventDefault();
-                const current = parseInt(fontSizeInput, 10);
-                if (!Number.isNaN(current)) {
+                const current = Number(fontSizeInput.trim());
+                if (Number.isInteger(current)) {
                   const delta = e.shiftKey ? 10 : 1;
                   const next =
                     e.key === "ArrowUp"

--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -294,6 +294,7 @@ function Toolbar(properties: ToolbarProperties) {
             className="ic-toolbar-font-size-box"
             type="text"
             inputMode="numeric"
+            aria-label={t("toolbar.font_size")}
             value={fontSizeInput}
             disabled={!canEdit}
             onClick={(e) => {

--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -109,6 +109,7 @@ function Toolbar(properties: ToolbarProperties) {
   const fillColorButton = useRef(null);
   const borderButton = useRef(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
+  const fontSizeInputRef = useRef<HTMLInputElement>(null);
 
   const { t } = useTranslation();
 
@@ -289,12 +290,16 @@ function Toolbar(properties: ToolbarProperties) {
             />
           </Tooltip>
           <input
+            ref={fontSizeInputRef}
             className="ic-toolbar-font-size-box"
             type="text"
             inputMode="numeric"
             value={fontSizeInput}
             disabled={!canEdit}
-            onClick={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.currentTarget.select();
+            }}
             onFocus={(e) => e.target.select()}
             onChange={(e) => setFontSizeInput(e.target.value)}
             onBlur={() => {
@@ -311,6 +316,21 @@ function Toolbar(properties: ToolbarProperties) {
               } else if (e.key === "Escape") {
                 setFontSizeInput(`${properties.fontSize}`);
                 e.currentTarget.blur();
+              } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+                e.preventDefault();
+                const current = parseInt(fontSizeInput, 10);
+                if (!Number.isNaN(current)) {
+                  const delta = e.shiftKey ? 10 : 1;
+                  const next =
+                    e.key === "ArrowUp"
+                      ? Math.min(current + delta, 400)
+                      : Math.max(current - delta, 1);
+                  setFontSizeInput(`${next}`);
+                  properties.onSetFontSize(next);
+                  requestAnimationFrame(() =>
+                    fontSizeInputRef.current?.focus(),
+                  );
+                }
               }
             }}
           />

--- a/webapp/IronCalc/src/components/Toolbar/toolbar.css
+++ b/webapp/IronCalc/src/components/Toolbar/toolbar.css
@@ -52,7 +52,7 @@
   justify-content: center;
   text-align: center;
   font-family: var(--typography-font-family);
-  font-size: 12px;
+  font-size: var(--typography-font-size);
   border: 1px solid var(--palette-grey-300);
   border-radius: 6px;
   min-width: 24px;
@@ -63,7 +63,7 @@
   box-sizing: border-box;
 }
 .ic-toolbar-font-size-box:focus {
-  background: var(--palette-grey-100, #f5f5f5);
+  background: var(--palette-common-white);
   border: 1px solid var(--palette-grey-500);
 }
 

--- a/webapp/IronCalc/src/components/Toolbar/toolbar.css
+++ b/webapp/IronCalc/src/components/Toolbar/toolbar.css
@@ -53,9 +53,18 @@
   text-align: center;
   font-family: var(--typography-font-family);
   font-size: 12px;
-  border: none;
-  border-radius: 4px;
+  border: 1px solid var(--palette-grey-300);
+  border-radius: 6px;
   min-width: 24px;
+  background: transparent;
+  cursor: text;
+  outline: none;
+  padding: 0;
+  box-sizing: border-box;
+}
+.ic-toolbar-font-size-box:focus {
+  background: var(--palette-grey-100, #f5f5f5);
+  border: 1px solid var(--palette-grey-500);
 }
 
 /* Button group */

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -165,6 +165,10 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
     updateRangeStyle("font.size_delta", `${delta}`);
   };
 
+  const onSetFontSize = (size: number) => {
+    updateRangeStyle("font.size", `${size}`);
+  };
+
   const handlePaste = useCallback(async (): Promise<void> => {
     focusWorkbook();
     try {
@@ -687,6 +691,9 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         }}
         onIncreaseFontSize={(delta: number) => {
           onIncreaseFontSize(delta);
+        }}
+        onSetFontSize={(size: number) => {
+          onSetFontSize(size);
         }}
         onDownloadPNG={() => {
           // creates a new canvas element in the visible part of the the selected area

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -289,6 +289,7 @@
     "download_png": "Als PNG herunterladen",
     "fill_color": "Füllfarbe",
     "font_color": "Schriftfarbe",
+    "font_size": "Schriftgröße",
     "format_menu": {
       "auto": "Automatisch",
       "currency_eur": "Euro (EUR)",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -289,6 +289,7 @@
     "download_png": "Download as PNG",
     "fill_color": "Fill color",
     "font_color": "Font color",
+    "font_size": "Font size",
     "format_menu": {
       "auto": "Auto",
       "currency_eur": "Euro (EUR)",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -289,6 +289,7 @@
     "download_png": "Descargar como PNG",
     "fill_color": "Color de relleno",
     "font_color": "Color de fuente",
+    "font_size": "Tamaño de fuente",
     "format_menu": {
       "auto": "Automático",
       "currency_eur": "Euro (EUR)",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -289,6 +289,7 @@
     "download_png": "Télécharger en PNG",
     "fill_color": "Couleur de remplissage",
     "font_color": "Couleur de police",
+    "font_size": "Taille de la police",
     "format_menu": {
       "auto": "Automatique",
       "currency_eur": "Euro (EUR)",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -289,6 +289,7 @@
     "download_png": "Scarica come PNG",
     "fill_color": "Colore riempimento",
     "font_color": "Colore carattere",
+    "font_size": "Dimensione carattere",
     "format_menu": {
       "auto": "Automatico",
       "currency_eur": "Euro (EUR)",


### PR DESCRIPTION
The current font size control in the toolbar is read-only, and the font size can only be changed by clicking the −/+ buttons. This can be time-consuming when increasing or decreasing sizes by a large amount. Additionally, it was not possible to force the same font size across cells that have different sizes.

### Changes:

1. Converted the read-only font size display into an editable input
2. Users can now type a size directly, or use arrow keys to increment/decrement (±1, or ±10 with Shift)
3. Clicking or focusing the input selects all content
4. Typing a value while a range of cells with mixed font sizes is selected sets them all to the same size

> Note: Invalid input reverts to the current size; Escape cancels, Enter commits.

See in this video how things should work now:

https://github.com/user-attachments/assets/72e66f3b-7929-43b6-95c0-d7570655c42c

