### PR TITLE
FIX: We can use r and c and variable names in LET/LAMBDA

### DIFF
--- a/base/src/expressions/lexer/mod.rs
+++ b/base/src/expressions/lexer/mod.rs
@@ -376,7 +376,7 @@ impl<'a> Lexer<'a> {
                                             return TokenType::Illegal(error);
                                         }
                                     }
-                                } else if utils::is_valid_identifier(&name) {
+                                } else if utils::is_valid_a1_identifier(&name) {
                                     if peek_char == Some('[') {
                                         if let Ok(r) = self.consume_structured_reference(&name) {
                                             return r;

--- a/base/src/expressions/parser/tests/test_lambda.rs
+++ b/base/src/expressions/parser/tests/test_lambda.rs
@@ -259,6 +259,40 @@ fn lambda_optional_called_with_one_arg() {
     assert_eq!(t, expected);
 }
 
+#[test]
+fn lambda_r_and_c_parameters() {
+    // r and c must be valid LAMBDA parameter names (they are not restricted
+    // to R1C1 notation in A1 mode when used as formula identifiers).
+    let mut p = parser();
+    let t = p.parse("LAMBDA(r, c, r+c)", &cell());
+    let expected = Node::LambdaDefKind {
+        parameters: vec![
+            NamedVariable {
+                name: "r".to_string(),
+                id: None,
+                is_optional: false,
+            },
+            NamedVariable {
+                name: "c".to_string(),
+                id: None,
+                is_optional: false,
+            },
+        ],
+        body: Box::new(Node::OpSumKind {
+            kind: token::OpSum::Add,
+            left: Box::new(Node::NamedVariableKind {
+                name: "r".to_string(),
+                id: None,
+            }),
+            right: Box::new(Node::NamedVariableKind {
+                name: "c".to_string(),
+                id: None,
+            }),
+        }),
+    };
+    assert_eq!(t, expected);
+}
+
 // SIN(x) is a fully-resolved function call, not a lambda — calling it with (3)
 // afterwards is syntactically invalid per the grammar.  The parser returns just
 // SIN(x) and the trailing (3) is left unconsumed (no parse error is raised at

--- a/base/src/expressions/utils/mod.rs
+++ b/base/src/expressions/utils/mod.rs
@@ -204,11 +204,14 @@ pub fn parse_reference_a1(r: &str) -> Option<ParsedReference> {
     })
 }
 
-pub fn is_valid_identifier(name: &str) -> bool {
+/// Returns true if `name` is a valid identifier in an A1-mode formula expression.
+/// This is a superset of `is_valid_identifier`: it permits the single-character
+/// names "R" and "C" that are valid as LAMBDA parameters or LET variables but
+/// not as worksheet-level defined names.
+pub fn is_valid_a1_identifier(name: &str) -> bool {
     // https://support.microsoft.com/en-us/office/names-in-formulas-fc2935f9-115d-4bef-a370-3aa8bb4c91f1
     // https://github.com/MartinTrummer/excel-names/
     let upper = name.to_uppercase();
-    // length of chars
     let len = upper.chars().count();
 
     let mut chars = upper.chars();
@@ -220,12 +223,9 @@ pub fn is_valid_identifier(name: &str) -> bool {
         Some(ch) => ch,
         None => return false,
     };
+
     // The first character of a name must be a letter, an underscore character (_), or a backslash (\).
     if !(first.is_ascii_alphabetic() || first == '_' || first == '\\') {
-        return false;
-    }
-    // You cannot use the uppercase and lowercase characters "C", "c", "R", or "r" as a defined name
-    if len == 1 && (first == 'R' || first == 'C') {
         return false;
     }
     if upper == *"TRUE" || upper == *"FALSE" {
@@ -244,6 +244,15 @@ pub fn is_valid_identifier(name: &str) -> bool {
     }
 
     true
+}
+
+pub fn is_valid_identifier(name: &str) -> bool {
+    // You cannot use the uppercase and lowercase characters "C", "c", "R", or "r" as a defined name
+    let upper = name.to_uppercase();
+    if upper == "R" || upper == "C" {
+        return false;
+    }
+    is_valid_a1_identifier(name)
 }
 
 fn name_needs_quoting(name: &str) -> bool {

--- a/base/src/expressions/utils/test.rs
+++ b/base/src/expressions/utils/test.rs
@@ -214,3 +214,16 @@ fn test_names() {
 
     assert!(!is_valid_identifier("LOG10"));
 }
+
+#[test]
+fn test_a1_identifier_allows_r_and_c() {
+    // is_valid_a1_identifier permits "R" and "C" (valid LAMBDA/LET variable names).
+    assert!(is_valid_a1_identifier("R"));
+    assert!(is_valid_a1_identifier("r"));
+    assert!(is_valid_a1_identifier("C"));
+    assert!(is_valid_a1_identifier("c"));
+    // All other is_valid_identifier rules still apply.
+    assert!(!is_valid_a1_identifier("R1C1"));
+    assert!(!is_valid_a1_identifier("A23"));
+    assert!(!is_valid_a1_identifier("true"));
+}

--- a/base/src/test/test_fn_let.rs
+++ b/base/src/test/test_fn_let.rs
@@ -59,3 +59,21 @@ fn test_let_rebind_same_name_within_single_let() {
     model.evaluate();
     assert_eq!(model._get_text("A1"), "#ERROR!");
 }
+
+#[test]
+fn test_let_r_and_c_variables() {
+    let mut model = new_empty_model();
+    // r and c must work as LET variable names
+    model._set("A1", "=LET(r,3,c,4,r+c)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "7");
+}
+
+#[test]
+fn test_lambda_r_and_c_parameters() {
+    let mut model = new_empty_model();
+    // r and c must work as LAMBDA parameter names
+    model._set("A1", "=LAMBDA(r,c,r+c)(3,4)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "7");
+}


### PR DESCRIPTION
Fixes #1070 