### PR TITLE
update: add a common modal component

### DIFF
--- a/webapp/IronCalc/src/components/Modal/Alert.tsx
+++ b/webapp/IronCalc/src/components/Modal/Alert.tsx
@@ -1,9 +1,9 @@
 import "./modal-dialog.css";
 import { X } from "lucide-react";
 import { type ReactNode, useId, useRef } from "react";
-import { createPortal } from "react-dom";
 import { Button } from "../Button/Button";
 import { IconButton } from "../Button/IconButton";
+import { ModalDialog } from "./ModalDialog";
 import { useModalFocus } from "./useModalFocus";
 import { useModalKeyDown } from "./useModalKeyDown";
 
@@ -45,49 +45,31 @@ export function Alert({
     return null;
   }
 
-  return createPortal(
-    <div
-      className="ic-modal-dialog-backdrop"
-      onClick={closeModal}
-      // HACK: prevents the workbook from stealing focus while the modal is open
-      onPointerDown={(event) => event.stopPropagation()}
-      role="none"
+  return (
+    <ModalDialog
+      modalRef={modalRef}
+      titleId={titleId}
+      onClose={closeModal}
+      onKeyDown={onKeyDown}
     >
-      <div
-        ref={modalRef}
-        className="ic-modal-dialog"
-        onClick={(event) => event.stopPropagation()}
-        onKeyDown={onKeyDown}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        tabIndex={-1}
-      >
-        <div className="ic-modal-dialog-header">
-          <h2 id={titleId}>{title}</h2>
-          <IconButton
-            ref={closeButtonRef}
-            icon={<X />}
-            aria-label={closeLabel}
-            onClick={closeModal}
-          />
-        </div>
-        <div className="ic-modal-dialog-body">
-          {typeof message === "string" ? <p>{message}</p> : message}
-        </div>
-        <div className="ic-modal-dialog-footer">
-          <Button
-            ref={confirmButtonRef}
-            size="md"
-            onClick={closeModal}
-            autoFocus
-          >
-            {confirmLabel}
-          </Button>
-        </div>
+      <div className="ic-modal-dialog-header">
+        <h2 id={titleId}>{title}</h2>
+        <IconButton
+          ref={closeButtonRef}
+          icon={<X />}
+          aria-label={closeLabel}
+          onClick={closeModal}
+        />
       </div>
-    </div>,
-    document.body,
+      <div className="ic-modal-dialog-body">
+        {typeof message === "string" ? <p>{message}</p> : message}
+      </div>
+      <div className="ic-modal-dialog-footer">
+        <Button ref={confirmButtonRef} size="md" onClick={closeModal} autoFocus>
+          {confirmLabel}
+        </Button>
+      </div>
+    </ModalDialog>
   );
 }
 

--- a/webapp/IronCalc/src/components/Modal/Confirm.tsx
+++ b/webapp/IronCalc/src/components/Modal/Confirm.tsx
@@ -1,9 +1,9 @@
 import "./modal-dialog.css";
 import { X } from "lucide-react";
 import { type ReactNode, useId, useRef } from "react";
-import { createPortal } from "react-dom";
 import { Button } from "../Button/Button";
 import { IconButton } from "../Button/IconButton";
+import { ModalDialog } from "./ModalDialog";
 import { useModalFocus } from "./useModalFocus";
 import { useModalKeyDown } from "./useModalKeyDown";
 
@@ -56,52 +56,40 @@ export function Confirm({
     return null;
   }
 
-  return createPortal(
-    <div
-      className="ic-modal-dialog-backdrop"
-      onClick={closeModal}
-      onPointerDown={(event) => event.stopPropagation()}
-      role="none"
+  return (
+    <ModalDialog
+      modalRef={modalRef}
+      titleId={titleId}
+      onClose={closeModal}
+      onKeyDown={onKeyDown}
     >
-      <div
-        ref={modalRef}
-        className="ic-modal-dialog"
-        onClick={(event) => event.stopPropagation()}
-        onKeyDown={onKeyDown}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        tabIndex={-1}
-      >
-        <div className="ic-modal-dialog-header">
-          <h2 id={titleId}>{title}</h2>
-          <IconButton
-            ref={closeButtonRef}
-            icon={<X />}
-            aria-label={closeLabel}
-            onClick={closeModal}
-          />
-        </div>
-        <div className="ic-modal-dialog-body">
-          {typeof message === "string" ? <p>{message}</p> : message}
-        </div>
-        <div className="ic-modal-dialog-footer">
-          <Button size="md" variant="secondary" onClick={closeModal}>
-            {cancelLabel}
-          </Button>
-          <Button
-            ref={confirmButtonRef}
-            size="md"
-            autoFocus
-            variant={variant === "destructive" ? "destructive" : undefined}
-            onClick={handleConfirm}
-          >
-            {confirmLabel}
-          </Button>
-        </div>
+      <div className="ic-modal-dialog-header">
+        <h2 id={titleId}>{title}</h2>
+        <IconButton
+          ref={closeButtonRef}
+          icon={<X />}
+          aria-label={closeLabel}
+          onClick={closeModal}
+        />
       </div>
-    </div>,
-    document.body,
+      <div className="ic-modal-dialog-body">
+        {typeof message === "string" ? <p>{message}</p> : message}
+      </div>
+      <div className="ic-modal-dialog-footer">
+        <Button size="md" variant="secondary" onClick={closeModal}>
+          {cancelLabel}
+        </Button>
+        <Button
+          ref={confirmButtonRef}
+          size="md"
+          autoFocus
+          variant={variant === "destructive" ? "destructive" : undefined}
+          onClick={handleConfirm}
+        >
+          {confirmLabel}
+        </Button>
+      </div>
+    </ModalDialog>
   );
 }
 

--- a/webapp/IronCalc/src/components/Modal/ModalDialog.tsx
+++ b/webapp/IronCalc/src/components/Modal/ModalDialog.tsx
@@ -22,6 +22,7 @@ export function ModalDialog({
     <div
       className="ic-modal-dialog-backdrop"
       onClick={onClose}
+      // HACK: prevents the workbook from stealing focus while the modal is open
       onPointerDown={(event) => event.stopPropagation()}
       role="none"
     >

--- a/webapp/IronCalc/src/components/Modal/ModalDialog.tsx
+++ b/webapp/IronCalc/src/components/Modal/ModalDialog.tsx
@@ -1,0 +1,43 @@
+import type { KeyboardEventHandler, ReactNode, RefObject } from "react";
+import { createPortal } from "react-dom";
+
+interface ModalDialogProperties {
+  modalRef: RefObject<HTMLDivElement | null>;
+  titleId: string;
+  onClose: () => void;
+  onKeyDown: KeyboardEventHandler<HTMLDivElement>;
+  className?: string;
+  children: ReactNode;
+}
+
+export function ModalDialog({
+  modalRef,
+  titleId,
+  onClose,
+  onKeyDown,
+  className,
+  children,
+}: ModalDialogProperties) {
+  return createPortal(
+    <div
+      className="ic-modal-dialog-backdrop"
+      onClick={onClose}
+      onPointerDown={(event) => event.stopPropagation()}
+      role="none"
+    >
+      <div
+        ref={modalRef}
+        className={["ic-modal-dialog", className].filter(Boolean).join(" ")}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={onKeyDown}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/webapp/IronCalc/src/components/Modal/Prompt.tsx
+++ b/webapp/IronCalc/src/components/Modal/Prompt.tsx
@@ -1,10 +1,10 @@
 import "./modal-dialog.css";
 import { X } from "lucide-react";
 import { type ReactNode, useEffect, useId, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { Button } from "../Button/Button";
 import { IconButton } from "../Button/IconButton";
 import { Input, type InputProperties } from "../Input/Input";
+import { ModalDialog } from "./ModalDialog";
 import { useModalFocus } from "./useModalFocus";
 import { useModalKeyDown } from "./useModalKeyDown";
 
@@ -68,68 +68,56 @@ export function Prompt({
     return null;
   }
 
-  return createPortal(
-    <div
-      className="ic-modal-dialog-backdrop"
-      onClick={closeModal}
-      onPointerDown={(event) => event.stopPropagation()}
-      role="none"
+  return (
+    <ModalDialog
+      modalRef={modalRef}
+      titleId={titleId}
+      onClose={closeModal}
+      onKeyDown={onKeyDown}
+      className={className}
     >
-      <div
-        ref={modalRef}
-        className={["ic-modal-dialog", className].filter(Boolean).join(" ")}
-        onClick={(event) => event.stopPropagation()}
-        onKeyDown={onKeyDown}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        tabIndex={-1}
-      >
-        <div className="ic-modal-dialog-header">
-          <h2 id={titleId}>{title}</h2>
-          <IconButton
-            ref={closeButtonRef}
-            icon={<X />}
-            aria-label={closeLabel}
-            onClick={closeModal}
-          />
-        </div>
-        <div className="ic-modal-dialog-body">
-          {message &&
-            (typeof message === "string" ? <p>{message}</p> : message)}
-          <Input
-            autoFocus
-            {...inputProps}
-            value={value}
-            onChange={(event) => setValue(event.target.value)}
-            onKeyDown={(event) => {
-              event.stopPropagation();
-              if (event.key === "Escape") {
-                event.preventDefault();
-                closeModal();
-              } else if (event.key === "Enter") {
-                event.preventDefault();
-                submitButtonRef.current?.focus();
-              }
-              inputProps?.onKeyDown?.(event);
-            }}
-            onClick={(event) => {
-              event.stopPropagation();
-              inputProps?.onClick?.(event);
-            }}
-          />
-        </div>
-        <div className="ic-modal-dialog-footer">
-          <Button size="md" variant="secondary" onClick={closeModal}>
-            {cancelLabel}
-          </Button>
-          <Button ref={submitButtonRef} size="md" onClick={handleSubmit}>
-            {confirmLabel}
-          </Button>
-        </div>
+      <div className="ic-modal-dialog-header">
+        <h2 id={titleId}>{title}</h2>
+        <IconButton
+          ref={closeButtonRef}
+          icon={<X />}
+          aria-label={closeLabel}
+          onClick={closeModal}
+        />
       </div>
-    </div>,
-    document.body,
+      <div className="ic-modal-dialog-body">
+        {message && (typeof message === "string" ? <p>{message}</p> : message)}
+        <Input
+          autoFocus
+          {...inputProps}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          onKeyDown={(event) => {
+            event.stopPropagation();
+            if (event.key === "Escape") {
+              event.preventDefault();
+              closeModal();
+            } else if (event.key === "Enter") {
+              event.preventDefault();
+              submitButtonRef.current?.focus();
+            }
+            inputProps?.onKeyDown?.(event);
+          }}
+          onClick={(event) => {
+            event.stopPropagation();
+            inputProps?.onClick?.(event);
+          }}
+        />
+      </div>
+      <div className="ic-modal-dialog-footer">
+        <Button size="md" variant="secondary" onClick={closeModal}>
+          {cancelLabel}
+        </Button>
+        <Button ref={submitButtonRef} size="md" onClick={handleSubmit}>
+          {confirmLabel}
+        </Button>
+      </div>
+    </ModalDialog>
   );
 }
 


### PR DESCRIPTION
This PR (a follow-up from #1063) extracts the repeated portal + backdrop + dialog shell from Alert, Confirm, and Prompt into a shared ModalDialog component.

This way we can centralice the onPointerDown stopPropagation hack that prevents the workbook from stealing focus while a modal is open.