### PR TITLE
update: place resizing handle on top of other drawer content

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/RightDrawer.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/RightDrawer.tsx
@@ -207,6 +207,8 @@ const RightDrawer = ({
       className="ic-drawer-container"
       style={{ ["--ic-runtime-drawer-width" as string]: `${drawerWidth}px` }}
     >
+      <div className="ic-drawer-divider" />
+      <div className="ic-drawer-content">{renderDrawerContent()}</div>
       <hr
         className={`ic-drawer-resize-handle ${isResizing ? "ic-drawer-resize-handle--resizing" : ""}`}
         tabIndex={0}
@@ -215,8 +217,6 @@ const RightDrawer = ({
         onMouseDown={handleMouseDown}
         onKeyDown={handleKeyDown}
       />
-      <div className="ic-drawer-divider" />
-      <div className="ic-drawer-content">{renderDrawerContent()}</div>
     </div>
   );
 };

--- a/webapp/IronCalc/src/components/RightDrawer/rightdrawer.css
+++ b/webapp/IronCalc/src/components/RightDrawer/rightdrawer.css
@@ -42,7 +42,7 @@
   left: 0;
   top: 0;
   bottom: 0;
-  width: 4px;
+  width: 3px;
   cursor: col-resize;
   background-color: transparent;
   transition: background-color 0.2s ease;


### PR DESCRIPTION
There was a bug in the right drawer that prevented users from resizing it in some situations. The content would be placed on top and the resizing handle wasn't being shown on hover, as it should be. This happened, for example, in the Conditional Formatting tabs.

Note here how the tab buttons block the handle:
<img width="433" height="555" alt="image" src="https://github.com/user-attachments/assets/c9edc372-c1ea-4333-9237-039f127f6e7d" />

We've fixed this just by placing the handle above all other elements of the drawer.

Additionally I've adjusted the handle's width (4px → 3px) so it's consistent with other borders (yeah this is probably something that only bothers me 🤓).