### PR TITLE
UPDATE: Adds `TIMEZONE` and `TIMEZONES` to INFO function

### DIFF
--- a/base/src/expressions/parser/static_analysis.rs
+++ b/base/src/expressions/parser/static_analysis.rs
@@ -1821,7 +1821,7 @@ fn static_analysis_on_function(kind: &Function, args: &[Node]) -> StaticResult {
         Function::N => scalar_arguments(args),
         Function::Sheets => scalar_arguments(args),
         Function::Cell => StaticResult::Unknown,
-        Function::Info => scalar_arguments(args),
+        Function::Info => StaticResult::Unknown,
         Function::Dget => not_implemented(args),
         Function::Dmax => not_implemented(args),
         Function::Dmin => not_implemented(args),

--- a/base/src/functions/date_and_time.rs
+++ b/base/src/functions/date_and_time.rs
@@ -1006,15 +1006,37 @@ impl<'a> Model<'a> {
         CalcResult::Number(count as f64 * sign)
     }
 
+    // Extends the standard by adding an optional timezone parameter
     pub(crate) fn fn_today(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
-        if !args.is_empty() {
+        if args.len() > 1 {
             return CalcResult::Error {
                 error: Error::ERROR,
                 origin: cell,
                 message: "Wrong number of arguments".to_string(),
             };
         }
-        match crate::tz::excel_serial_for_now(&self.tz) {
+        let tz_owned;
+        let tz: &Tz = match args.first() {
+            Some(arg0) => {
+                let tz_str = match self.get_string(arg0, cell) {
+                    Ok(s) => s,
+                    Err(e) => return e,
+                };
+                tz_owned = match Tz::parse(&tz_str) {
+                    Ok(tz) => tz,
+                    Err(_) => {
+                        return CalcResult::Error {
+                            error: Error::VALUE,
+                            origin: cell,
+                            message: format!("Invalid timezone: {}", &tz_str),
+                        }
+                    }
+                };
+                &tz_owned
+            }
+            None => &self.tz,
+        };
+        match crate::tz::excel_serial_for_now(tz) {
             Some(serial) => CalcResult::Number(serial.floor()),
             None => CalcResult::Error {
                 error: Error::ERROR,
@@ -1024,6 +1046,7 @@ impl<'a> Model<'a> {
         }
     }
 
+    // Extends the standard by adding an optional timezone parameter
     pub(crate) fn fn_now(&mut self, args: &[Node], cell: CellReferenceIndex) -> CalcResult {
         if args.len() > 1 {
             return CalcResult::Error {

--- a/base/src/functions/information/mod.rs
+++ b/base/src/functions/information/mod.rs
@@ -2,7 +2,13 @@ mod isomitted;
 
 use crate::{
     calc_result::CalcResult,
-    expressions::{parser::Node, token::Error, types::CellReferenceIndex, utils::number_to_column},
+    expressions::{
+        parser::{ArrayNode, Node},
+        token::Error,
+        types::CellReferenceIndex,
+        utils::number_to_column,
+    },
+    get_all_timezones,
     model::{Model, ParsedDefinedName},
 };
 
@@ -510,6 +516,14 @@ impl<'a> Model<'a> {
             "RECALC" => CalcResult::String("Automatic".to_string()),
             "RELEASE" => CalcResult::String(release.to_string()),
             "SYSTEM" => CalcResult::String(get_system()),
+            "TIMEZONE" => CalcResult::String(self.get_timezone()),
+            "TIMEZONES" => {
+                let list: Vec<Vec<ArrayNode>> = get_all_timezones()
+                    .into_iter()
+                    .map(|name| vec![ArrayNode::String(name.to_string())])
+                    .collect();
+                CalcResult::Array(list)
+            }
             _ => CalcResult::Error {
                 error: Error::VALUE,
                 origin: cell,

--- a/base/src/functions/information/mod.rs
+++ b/base/src/functions/information/mod.rs
@@ -518,7 +518,9 @@ impl<'a> Model<'a> {
             "SYSTEM" => CalcResult::String(get_system()),
             "TIMEZONE" => CalcResult::String(self.get_timezone()),
             "TIMEZONES" => {
-                let list: Vec<Vec<ArrayNode>> = get_all_timezones()
+                let mut tzs = get_all_timezones();
+                tzs.sort();
+                let list: Vec<Vec<ArrayNode>> = tzs
                     .into_iter()
                     .map(|name| vec![ArrayNode::String(name.to_string())])
                     .collect();

--- a/base/src/test/test_cell_info_n_sheets.rs
+++ b/base/src/test/test_cell_info_n_sheets.rs
@@ -58,9 +58,8 @@ fn info_timezones() {
 
     model.evaluate();
 
-    // Well just remove this tests if it fails
-    assert_eq!(model._get_text("A1"), *"Africa/Abidjan");
-    let timezones = model._get_text("B1").parse::<i32>().unwrap_or(0);
+    assert_ne!(model._get_text("A1"), *"");
+    let timezones = model._get_text("B1").parse::<i32>().unwrap();
     assert!(timezones > 400);
 }
 

--- a/base/src/test/test_cell_info_n_sheets.rs
+++ b/base/src/test/test_cell_info_n_sheets.rs
@@ -35,6 +35,36 @@ fn arguments() {
 }
 
 #[test]
+fn info_timezone() {
+    let mut model = new_empty_model();
+    model._set("A1", "=INFO(\"timezone\")");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"UTC");
+
+    model.set_timezone("America/Panama").unwrap();
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"America/Panama");
+}
+
+#[test]
+fn info_timezones() {
+    let mut model = new_empty_model();
+    model._set("A1", "=INFO(\"timezones\")");
+    model._set("B1", "=COUNTA(A:A)");
+
+    model.evaluate();
+
+    // Well just remove this tests if it fails
+    assert_eq!(model._get_text("A1"), *"Africa/Abidjan");
+    let timezones = model._get_text("B1").parse::<i32>().unwrap_or(0);
+    assert!(timezones > 400);
+}
+
+#[test]
 fn cell_filename() {
     // Default workbook name is model
     let mut model = new_empty_model();

--- a/base/src/test/test_today.rs
+++ b/base/src/test/test_today.rs
@@ -49,3 +49,29 @@ fn now_basic_europe_berlin() {
     // This is UTC + 1 hour: 45005.572511574 + 1/24
     assert_eq!(model._get_text("A2"), *"3/20/2023, 2:44 PM");
 }
+
+#[test]
+fn today_with_timezone() {
+    mock_time::set_mock_time(TIMESTAMP_2023);
+    let mut model = Model::new_empty("model", "en", "UTC", "en").unwrap();
+    model._set("A1", "=TODAY(\"Pacific/Kiritimati\")");
+    model._set("A2", "=NOW(\"Europe/Berlin\")");
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"3/21/2023");
+    // 45005.572511574
+    assert_eq!(model._get_text("A2"), *"3/20/2023, 2:44 PM");
+    model.evaluate();
+}
+
+#[test]
+fn today_with_invalid_timezone() {
+    mock_time::set_mock_time(TIMESTAMP_2023);
+    let mut model = Model::new_empty("model", "en", "UTC", "en").unwrap();
+    model._set("A1", "=TODAY(\"Invalid/Timezone\")");
+    model._set("A2", "=NOW(\"Invalid/Timezone\")");
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"#VALUE!");
+    assert_eq!(model._get_text("A2"), *"#VALUE!");
+}

--- a/docs/src/functions/information/info.md
+++ b/docs/src/functions/information/info.md
@@ -18,7 +18,7 @@ The *type_text* argument is **always in English**, regardless of the workbook's 
 
 ### Syntax
 
-**INFO(<span title="Text" style="color:#E53935">type_text</span>) => <span title="Text" style="color:#E53935">text</span> | <span title="Number" style="color:#1E88E5">number</span>**
+**INFO(<span title="Text" style="color:#E53935">type_text</span>) => <span title="Text" style="color:#E53935">text</span> | <span title="Number" style="color:#1E88E5">number</span> | <span style="color:#A53735">array</span>**
 
 ### Argument descriptions
 
@@ -43,7 +43,7 @@ The *type_text* argument is case-insensitive. `"release"`, `"RELEASE"`, and `"Re
 
 ### Returned value
 
-INFO returns a [text](/features/value-types#text) string, or a [number](/features/value-types#numbers) for `"numfile"`.
+INFO returns a [text](/features/value-types#text) string, a [number](/features/value-types#numbers) for `"numfile"` or the list of supported timezones.
 
 ### Error conditions
 
@@ -59,6 +59,8 @@ INFO returns a [text](/features/value-types#text) string, or a [number](/feature
 | `=INFO("system")` | `"browser"` | Running in the web app |
 | `=INFO("numfile")` | `3` | Workbook has 3 sheets |
 | `=INFO("recalc")` | `"Automatic"` | Always automatic in IronCalc |
+| `=INFO("timezone")` | `"Australia/Hobart"` | If you happen to be in Tasmania, Australia |
+| `=INFO("timezones")` | (...) | A long list of the timezones supported by your system |
 
 ## Links
 

--- a/docs/src/functions/information/info.md
+++ b/docs/src/functions/information/info.md
@@ -32,6 +32,8 @@ The *type_text* argument is **always in English**, regardless of the workbook's 
 | `"recalc"` | The current recalculation mode. IronCalc always returns `"Automatic"`. |
 | `"release"` | The version of IronCalc as a text string. |
 | `"system"` | The name of the operating environment: `"browser"` in the web app, or the OS name (e.g. `"linux"`, `"windows"`, `"macos"`) in other contexts. |
+| `"timezone"` | The timezone of the workbook. |
+| `"timezones"` | The list of all available timezones. |
 
 The following *type_text* values are recognized but **not yet implemented** and return a [`#N/IMPL!`](/features/error-types.md#nimpl) error: `"directory"`, `"origin"`, `"osversion"`.
 


### PR DESCRIPTION
You can do now:

`=INFO("timezone")` => Europe/Berlin
`=INFO("timezones")` => List of supported timezones


NOTE: We can remove this in the future if it turns out problematic