### PR TITLE
fix: preview stacking, dark-background contrast, and imported themes in panel

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/Themes/themes.css
+++ b/webapp/IronCalc/src/components/RightDrawer/Themes/themes.css
@@ -66,8 +66,8 @@
 }
 
 .ic-themes-list-item-preview {
-  width: 52px;
-  height: 36px;
+  width: 56px;
+  height: 40px;
   border-radius: 4px;
   box-shadow: inset 0 0 0 1px
     color-mix(in srgb, var(--palette-common-black) 12%, transparent);
@@ -82,7 +82,6 @@
 }
 
 .ic-theme-preview-inner {
-  position: relative;
   display: flex;
   align-items: center;
   align-self: stretch;
@@ -91,46 +90,30 @@
   margin: 4px;
   padding-left: 4px;
   gap: 4px;
-  background: linear-gradient(
-    to bottom,
-    transparent calc(30% - 0.5px),
-    color-mix(in srgb, var(--palette-grey-900) 10%, transparent)
-      calc(30% - 0.5px),
-    color-mix(in srgb, var(--palette-grey-900) 10%, transparent)
-      calc(30% + 0.5px),
-    transparent calc(30% + 0.5px),
-    transparent calc(70% - 0.5px),
-    color-mix(in srgb, var(--palette-grey-900) 10%, transparent)
-      calc(70% - 0.5px),
-    color-mix(in srgb, var(--palette-grey-900) 10%, transparent)
-      calc(70% + 0.5px),
-    transparent calc(70% + 0.5px)
-  );
-  outline: 1px solid
-    color-mix(in srgb, var(--palette-grey-900) 10%, transparent);
-}
-
-.ic-theme-preview-inner::before,
-.ic-theme-preview-inner::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 1px;
-  background: color-mix(in srgb, var(--palette-grey-900) 10%, transparent);
-}
-
-.ic-theme-preview-inner::before {
-  left: 33%;
-}
-
-.ic-theme-preview-inner::after {
-  left: 67%;
-}
-
-.ic-theme-preview-inner > * {
-  position: relative;
-  z-index: 1;
+  background:
+    linear-gradient(
+      to bottom,
+      transparent calc(30% - 0.5px),
+      color-mix(in srgb, currentColor 10%, transparent) calc(30% - 0.5px),
+      color-mix(in srgb, currentColor 10%, transparent) calc(30% + 0.5px),
+      transparent calc(30% + 0.5px),
+      transparent calc(70% - 0.5px),
+      color-mix(in srgb, currentColor 10%, transparent) calc(70% - 0.5px),
+      color-mix(in srgb, currentColor 10%, transparent) calc(70% + 0.5px),
+      transparent calc(70% + 0.5px)
+    ),
+    linear-gradient(
+      to right,
+      transparent calc(33% - 0.5px),
+      color-mix(in srgb, currentColor 10%, transparent) calc(33% - 0.5px),
+      color-mix(in srgb, currentColor 10%, transparent) calc(33% + 0.5px),
+      transparent calc(33% + 0.5px),
+      transparent calc(67% - 0.5px),
+      color-mix(in srgb, currentColor 10%, transparent) calc(67% - 0.5px),
+      color-mix(in srgb, currentColor 10%, transparent) calc(67% + 0.5px),
+      transparent calc(67% + 0.5px)
+    );
+  outline: 1px solid color-mix(in srgb, currentColor 10%, transparent);
 }
 
 .ic-theme-preview-pie {

--- a/webapp/IronCalc/src/components/RightDrawer/Themes/themes.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/Themes/themes.tsx
@@ -163,18 +163,20 @@ const Themes = ({
               className="ic-themes-list-item-preview"
             />
             <div className="ic-themes-list-item-name">{theme.name}</div>
-            <div className="ic-themes-list-item-icons">
-              <Tooltip title={t("themes.edit_theme")}>
-                <IconButton
-                  icon={<PencilLine />}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setEditing(theme);
-                  }}
-                  aria-label={t("themes.edit_theme")}
-                />
-              </Tooltip>
-            </div>
+            {selectedIndex === i && (
+              <div className="ic-themes-list-item-icons">
+                <Tooltip title={t("themes.edit_theme")}>
+                  <IconButton
+                    icon={<PencilLine />}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setEditing(theme);
+                    }}
+                    aria-label={t("themes.edit_theme")}
+                  />
+                </Tooltip>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/webapp/IronCalc/src/components/RightDrawer/Themes/themes.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/Themes/themes.tsx
@@ -42,14 +42,20 @@ const Themes = ({
 }: ThemesProps) => {
   const { t } = useTranslation();
   const [themes, setThemes] = useState<IronCalcTheme[]>(builtinThemes);
+  let allThemes = themes;
+  if (!themes.some((theme) => themeEquals(theme, currentTheme))) {
+    allThemes = [...themes, currentTheme];
+  }
   const [selectedIndex, setSelectedIndex] = useState(() => {
-    const index = themes.findIndex((theme) => themeEquals(theme, currentTheme));
+    const index = allThemes.findIndex((theme) =>
+      themeEquals(theme, currentTheme),
+    );
     return index === -1 ? 0 : index;
   });
 
   const selectTheme = (index: number) => {
     setSelectedIndex(index);
-    onThemePicked(themes[index]);
+    onThemePicked(allThemes[index]);
   };
   const [editing, setEditing] = useState<IronCalcTheme | null>(null);
 
@@ -141,7 +147,7 @@ const Themes = ({
         role="listbox"
         aria-label={t("themes.panel_title")}
       >
-        {themes.map((theme, i) => (
+        {allThemes.map((theme, i) => (
           <div
             // biome-ignore lint/suspicious/noArrayIndexKey: themes list has stable order
             key={i}


### PR DESCRIPTION
This PR includes 4 fixes to themes drawer:

1. **Theme preview stacking**: The "Aa" text and pie chart in theme previews used `z-index: 1`, which caused undisired overlay with other elements. 

<img width="599" height="376" alt="image" src="https://github.com/user-attachments/assets/2c4258c6-177f-414a-9245-589c6f85a5e4" />

2. **Preview visibility on dark themes**: The preview grid lines and outline used a fixed `grey-900` at 10% opacity, making them invisible over dark theme backgrounds. They now use `currentColor` (the theme's text color), so they adapt to any background. Light themes look the same as before.

<img width="239" height="108" alt="image" src="https://github.com/user-attachments/assets/5037c4e2-0ab1-4464-89fe-4ad02e0a080d" />

3. **Imported themes missing from the panel**: A workbook's imported theme would show in the toolbar ThemeMenu but not in the right-drawer themes list. This is fixed now.

4. **Edit button only visible on current theme**: Until now we showed it in every row.