### PR TITLE
update: Color picker cleanup and improvements

### DIFF
--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -2,6 +2,7 @@ import type { Color, IronCalcTheme } from "@ironcalc/wasm";
 import { getThemeList } from "@ironcalc/wasm";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { init } from "../../index";
 import ColorPicker from "./ColorPicker";
 
@@ -29,6 +30,7 @@ function ColorPickerStory({ theme: themeName }: ColorPickerStoryProps) {
   // must be initialized before rendering the picker.
   const [themes, setThemes] = useState<IronCalcTheme[] | null>(null);
   const anchorRef = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation();
 
   useEffect(() => {
     let cancelled = false;
@@ -64,7 +66,7 @@ function ColorPickerStory({ theme: themeName }: ColorPickerStoryProps) {
       <ColorPicker
         color={color}
         defaultColor="#000000"
-        title="Default"
+        title={t("color_picker.default")}
         onChange={setColor}
         onClose={() => {}}
         anchorEl={anchorRef}

--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,0 +1,100 @@
+import type { Color, IronCalcTheme } from "@ironcalc/wasm";
+import { getThemeList } from "@ironcalc/wasm";
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useRef, useState } from "react";
+import { init } from "../../index";
+import ColorPicker from "./ColorPicker";
+
+// Names of the builtin themes returned by getThemeList()
+const THEME_NAMES = [
+  "IronCalc",
+  "Office",
+  "Greyscale",
+  "Cold",
+  "Warm",
+  "Ocean",
+  "Pastel",
+  "Dark",
+  "Forest",
+] as const;
+
+interface ColorPickerStoryProps {
+  theme: (typeof THEME_NAMES)[number];
+}
+
+function ColorPickerStory({ theme: themeName }: ColorPickerStoryProps) {
+  // A theme tuple (accent1), so the selected swatch follows the theme
+  const [color, setColor] = useState<Color>([4, 0]);
+  // The color grid is computed with wasm (hexWithTintToRgb), so the module
+  // must be initialized before rendering the picker.
+  const [themes, setThemes] = useState<IronCalcTheme[] | null>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    init().then(() => {
+      if (!cancelled) {
+        setThemes(getThemeList());
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!themes) {
+    return <div>Loading...</div>;
+  }
+
+  const theme = themes.find((t) => t.name === themeName) ?? themes[0];
+
+  return (
+    <>
+      {/* Invisible anchor placed so the picker (~220x360px) lands centered */}
+      <div
+        ref={anchorRef}
+        style={{
+          position: "fixed",
+          left: "calc(50% - 110px)",
+          top: "calc(50% - 184px)",
+          width: 0,
+          height: 0,
+        }}
+      />
+      <ColorPicker
+        color={color}
+        defaultColor="#000000"
+        title="Default"
+        onChange={setColor}
+        onClose={() => {}}
+        anchorEl={anchorRef}
+        open={true}
+        theme={theme}
+      />
+    </>
+  );
+}
+
+const meta = {
+  title: "Components/ColorPicker",
+  component: ColorPickerStory,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    theme: "IronCalc",
+  },
+  argTypes: {
+    theme: {
+      control: "select",
+      options: THEME_NAMES,
+      description: "Builtin workbook theme used for the themed colors grid",
+    },
+  },
+} satisfies Meta<typeof ColorPickerStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
@@ -199,7 +199,7 @@ const ColorPicker = ({
       recentColors.current = [
         { color: colorValue, hex: displayHex },
         ...recentColors.current,
-      ].slice(0, 14);
+      ];
     }
 
     setSelectedColor(colorValue ?? FALLBACK_COLOR);
@@ -286,105 +286,112 @@ const ColorPicker = ({
           event.stopPropagation();
         }}
       >
-        <button
-          type="button"
-          className="ic-color-picker__menu-item"
-          onClick={() => handleColorSelect(defaultColor, defaultColor)}
-          data-nav-row={0}
-          data-nav-col={0}
-        >
-          <span
-            className="ic-color-picker__menu-item-square"
-            style={{ backgroundColor: defaultColor }}
-            aria-hidden="true"
-          />
-          <span className="ic-color-picker__menu-item-text">{title}</span>
-        </button>
-
-        <div className="ic-color-picker__divider" />
-
-        <div className="ic-color-picker__recent-label">
-          {t("color_picker.themed_colors")}
-        </div>
-
-        <div className="ic-color-picker__colors-wrapper">
-          <div className="ic-color-picker__color-list">
-            {themeColors.map((hex, col) =>
-              renderColorSwatch(hex, [col, 0], 1, col),
-            )}
-          </div>
-
-          <div className="ic-color-picker__color-grid">
-            {themeGrid.map((col, colIndex) => (
-              <div
-                className="ic-color-picker__color-grid-col"
-                key={col.map((c) => c.hex).join("-")}
-              >
-                {col.map(({ hex, color }, toneIndex) =>
-                  renderColorSwatch(hex, color, 2 + toneIndex, colIndex),
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <div className="ic-color-picker__recent-label">
-          {t("color_picker.standard_colors")}
-        </div>
-
-        <div
-          className="ic-color-picker__color-list"
-          style={{ marginLeft: "13px" }}
-        >
-          {standardColors.map((hex, col) =>
-            renderColorSwatch(hex, hex, 8, col),
-          )}
-        </div>
-
-        <div className="ic-color-picker__divider" />
-
-        <div className="ic-color-picker__recent-label">
-          {t("color_picker.recent")}
-        </div>
-
-        <div className="ic-color-picker__recent-colors-list">
-          {recentColors.current.length > 0 ? (
-            recentColors.current.map(
-              ({ color: recentColor, hex: recentHex }, col) => (
-                <button
-                  key={recentHex}
-                  type="button"
-                  className={[
-                    "ic-color-picker__swatch",
-                    isWhiteColor(recentHex)
-                      ? "ic-color-picker__swatch--white"
-                      : "",
-                  ]
-                    .filter(Boolean)
-                    .join(" ")}
-                  style={{ backgroundColor: recentHex }}
-                  onClick={() => handleColorSelect(recentColor, recentHex)}
-                  aria-label={recentHex}
-                  data-nav-row={7}
-                  data-nav-col={col}
-                />
-              ),
-            )
-          ) : (
-            <div className="ic-color-picker__empty" />
-          )}
-
+        <div className="ic-color-picker__section">
           <button
             type="button"
-            className="ic-color-picker__plus-button"
-            onClick={() => setPickerOpen(true)}
-            title={t("color_picker.add")}
-            aria-label={t("color_picker.add")}
-            data-nav-row={7}
-            data-nav-col={recentColors.current.length}
+            className="ic-color-picker__menu-item"
+            onClick={() => handleColorSelect(defaultColor, defaultColor)}
+            data-nav-row={0}
+            data-nav-col={0}
           >
-            <Plus />
+            <span
+              className="ic-color-picker__menu-item-square"
+              style={{ backgroundColor: defaultColor }}
+              aria-hidden="true"
+            />
+            <span className="ic-color-picker__menu-item-text">{title}</span>
           </button>
+        </div>
+
+        <div className="ic-color-picker__divider" />
+
+        <div className="ic-color-picker__section">
+          <div className="ic-color-picker__label">
+            {t("color_picker.themed_colors")}
+          </div>
+
+          <div className="ic-color-picker__colors-wrapper">
+            <div className="ic-color-picker__color-list">
+              {themeColors.map((hex, col) =>
+                renderColorSwatch(hex, [col, 0], 1, col),
+              )}
+            </div>
+
+            <div className="ic-color-picker__color-grid">
+              {themeGrid.map((col, colIndex) => (
+                <div
+                  className="ic-color-picker__color-grid-col"
+                  key={col.map((c) => c.hex).join("-")}
+                >
+                  {col.map(({ hex, color }, toneIndex) =>
+                    renderColorSwatch(hex, color, 2 + toneIndex, colIndex),
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="ic-color-picker__divider" />
+
+        <div className="ic-color-picker__section">
+          <div className="ic-color-picker__label">
+            {t("color_picker.standard_colors")}
+          </div>
+
+          <div className="ic-color-picker__color-list">
+            {standardColors.map((hex, col) =>
+              renderColorSwatch(hex, hex, 8, col),
+            )}
+          </div>
+        </div>
+
+        <div className="ic-color-picker__divider" />
+
+        <div className="ic-color-picker__section">
+          <div className="ic-color-picker__label">
+            {t("color_picker.recent")}
+          </div>
+
+          <div className="ic-color-picker__color-list">
+            {recentColors.current.length > 0 ? (
+              recentColors.current.map(
+                ({ color: recentColor, hex: recentHex }, col) => (
+                  <button
+                    key={recentHex}
+                    type="button"
+                    className={[
+                      "ic-color-picker__swatch",
+                      isWhiteColor(recentHex)
+                        ? "ic-color-picker__swatch--white"
+                        : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                    style={{ backgroundColor: recentHex }}
+                    onClick={() => handleColorSelect(recentColor, recentHex)}
+                    aria-label={recentHex}
+                    data-nav-row={7}
+                    data-nav-col={col}
+                  />
+                ),
+              )
+            ) : (
+              <div className="ic-color-picker__empty" />
+            )}
+
+            <button
+              type="button"
+              className="ic-color-picker__plus-button"
+              onClick={() => setPickerOpen(true)}
+              title={t("color_picker.add")}
+              aria-label={t("color_picker.add")}
+              data-nav-row={7}
+              data-nav-col={recentColors.current.length}
+            >
+              <Plus />
+            </button>
+          </div>
         </div>
       </div>
     </div>,

--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
@@ -1,12 +1,6 @@
 import { Check, Plus } from "lucide-react";
-import React, {
-  type CSSProperties,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import AdvancedColorPicker from "../AdvancedColorPicker.tsx/AdvancedColorPicker";
 import { getFocusableElements } from "../util";
@@ -14,6 +8,7 @@ import "./color-picker.css";
 import type { Color, IronCalcTheme } from "@ironcalc/wasm";
 import { createPortal } from "react-dom";
 import { Tooltip } from "../Tooltip/Tooltip";
+import useAnchorPosition, { type Placement } from "./useAnchorPosition";
 import useKeyDown from "./useKeyDown";
 import {
   computeThemeGrid,
@@ -51,59 +46,6 @@ function colorsEqual(a: Color, b: Color): boolean {
   return false;
 }
 
-type Placement = "bottom" | "top" | "right" | "left";
-
-function getMenuPosition(
-  anchor: HTMLElement,
-  panel: HTMLElement,
-  placement: Placement,
-) {
-  const anchorRect = anchor.getBoundingClientRect();
-  const panelWidth = panel.offsetWidth;
-  const panelHeight = panel.offsetHeight;
-  const viewportWidth = window.innerWidth;
-  const viewportHeight = window.innerHeight;
-
-  const offset = 4;
-  const margin = 8;
-
-  let left = 0;
-  let top = 0;
-
-  if (placement === "bottom") {
-    left = anchorRect.left;
-    top = anchorRect.bottom + offset;
-  } else if (placement === "top") {
-    left = anchorRect.left;
-    top = anchorRect.top - panelHeight - offset;
-  } else if (placement === "right") {
-    // This is used in the BorderPicker to be aligned with the line picker
-    left = anchorRect.right;
-    top = anchorRect.top;
-  } else {
-    left = anchorRect.left - panelWidth - offset;
-    top = anchorRect.top;
-  }
-
-  if (left + panelWidth > viewportWidth - margin) {
-    left = viewportWidth - panelWidth - margin;
-  }
-
-  if (left < margin) {
-    left = margin;
-  }
-
-  if (top + panelHeight > viewportHeight - margin) {
-    top = viewportHeight - panelHeight - margin;
-  }
-
-  if (top < margin) {
-    top = margin;
-  }
-
-  return { top, left };
-}
-
 const ColorPicker = ({
   color,
   defaultColor,
@@ -117,10 +59,14 @@ const ColorPicker = ({
 }: ColorPickerProps) => {
   const [selectedColor, setSelectedColor] = useState<Color>(color);
   const [isPickerOpen, setPickerOpen] = useState(false);
-  const [position, setPosition] = useState({ top: 0, left: 0 });
+
+  const { panelRef, position } = useAnchorPosition(
+    open && !isPickerOpen,
+    anchorEl,
+    placement,
+  );
 
   const recentColors = useRef<{ color: Color; hex: string }[]>([]);
-  const panelRef = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslation();
 
   const themeColors = themeBaseColors(theme);
@@ -144,56 +90,38 @@ const ColorPicker = ({
     if (open && !isPickerOpen) {
       panelRef.current?.querySelector<HTMLButtonElement>("button")?.focus();
     }
-  }, [open, isPickerOpen]);
+  }, [open, isPickerOpen, panelRef]);
 
-  useLayoutEffect(() => {
+  // Close on presses outside the panel without swallowing them, so the
+  // pressed element (e.g. another toolbar menu) reacts in the same click
+  useEffect(() => {
     if (!open || isPickerOpen) {
       return;
     }
 
-    const anchor = anchorEl.current;
-    const panel = panelRef.current;
-
-    if (!anchor || !panel) {
-      return;
-    }
-
-    const updatePosition = () => {
-      setPosition(getMenuPosition(anchor, panel, placement));
-    };
-
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [anchorEl, open, isPickerOpen, placement]);
-
-  const onPointerDown = useCallback(
-    (event: React.PointerEvent) => {
+    const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as Node | null;
-      const panel = panelRef.current;
-      const anchor = anchorEl.current;
 
-      if (!target || !panel) {
+      if (!target) {
         return;
       }
 
-      if (panel.contains(target)) {
+      if (panelRef.current?.contains(target)) {
         return;
       }
 
-      if (anchor?.contains(target)) {
+      if (anchorEl.current?.contains(target)) {
         return;
       }
 
       onClose();
-    },
-    [onClose, anchorEl],
-  );
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [open, isPickerOpen, onClose, anchorEl, panelRef]);
 
   const handleColorSelect = (colorValue: Color, displayHex: string) => {
     if (!recentColors.current.some((r) => colorsEqual(r.color, colorValue))) {
@@ -262,138 +190,117 @@ const ColorPicker = ({
   }
 
   return createPortal(
-    <div className="ic-menu-layer">
-      <div
-        className="ic-menu-backdrop"
-        onPointerDown={onClose}
-        aria-hidden="true"
-      />
-      <div
-        ref={panelRef}
-        className="ic-color-picker"
-        style={
-          {
-            top: `${position.top}px`,
-            left: `${position.left}px`,
-          } as CSSProperties
-        }
-        role="dialog"
-        aria-modal="true"
-        aria-label={t("color_picker.add")}
-        onKeyDown={onKeyDown}
-        onPointerDown={onPointerDown}
-        onClick={(event) => {
-          // Otherwise the sheet would grab the keyboard focus
-          event.stopPropagation();
-        }}
-      >
-        <div className="ic-color-picker__section">
-          <button
-            type="button"
-            className="ic-color-picker__menu-item"
-            onClick={() => handleColorSelect(defaultColor, defaultColor)}
-            data-nav-row={0}
-            data-nav-col={0}
-          >
-            <span
-              className="ic-color-picker__menu-item-square"
-              style={{ backgroundColor: defaultColor }}
-              aria-hidden="true"
-            />
-            <span className="ic-color-picker__menu-item-text">{title}</span>
-          </button>
+    <div
+      ref={panelRef}
+      className="ic-color-picker"
+      style={position}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("color_picker.add")}
+      onKeyDown={onKeyDown}
+      onClick={(event) => {
+        // Otherwise the sheet would grab the keyboard focus
+        event.stopPropagation();
+      }}
+    >
+      <div className="ic-color-picker__section">
+        <button
+          type="button"
+          className="ic-color-picker__menu-item"
+          onClick={() => handleColorSelect(defaultColor, defaultColor)}
+          data-nav-row={0}
+          data-nav-col={0}
+        >
+          <span
+            className="ic-color-picker__menu-item-square"
+            style={{ backgroundColor: defaultColor }}
+            aria-hidden="true"
+          />
+          <span className="ic-color-picker__menu-item-text">{title}</span>
+        </button>
+      </div>
+
+      <div className="ic-color-picker__divider" />
+
+      <div className="ic-color-picker__section">
+        <div className="ic-color-picker__label">
+          {t("color_picker.themed_colors")}
         </div>
 
-        <div className="ic-color-picker__divider" />
+        <div className="ic-color-picker__color-list">
+          {themeColors.map((hex, col) =>
+            renderColorSwatch(hex, [col, 0], 1, col),
+          )}
+        </div>
 
-        <div className="ic-color-picker__section">
-          <div className="ic-color-picker__label">
-            {t("color_picker.themed_colors")}
-          </div>
-
-          <div className="ic-color-picker__colors-wrapper">
-            <div className="ic-color-picker__color-list">
-              {themeColors.map((hex, col) =>
-                renderColorSwatch(hex, [col, 0], 1, col),
+        <div className="ic-color-picker__color-grid">
+          {themeGrid.map((col, colIndex) => (
+            <div
+              className="ic-color-picker__color-grid-col"
+              key={col.map((c) => c.hex).join("-")}
+            >
+              {col.map(({ hex, color }, toneIndex) =>
+                renderColorSwatch(hex, color, 2 + toneIndex, colIndex),
               )}
             </div>
+          ))}
+        </div>
+      </div>
 
-            <div className="ic-color-picker__color-grid">
-              {themeGrid.map((col, colIndex) => (
-                <div
-                  className="ic-color-picker__color-grid-col"
-                  key={col.map((c) => c.hex).join("-")}
-                >
-                  {col.map(({ hex, color }, toneIndex) =>
-                    renderColorSwatch(hex, color, 2 + toneIndex, colIndex),
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
+      <div className="ic-color-picker__divider" />
+
+      <div className="ic-color-picker__section">
+        <div className="ic-color-picker__label">
+          {t("color_picker.standard_colors")}
         </div>
 
-        <div className="ic-color-picker__divider" />
-
-        <div className="ic-color-picker__section">
-          <div className="ic-color-picker__label">
-            {t("color_picker.standard_colors")}
-          </div>
-
-          <div className="ic-color-picker__color-list">
-            {standardColors.map((hex, col) =>
-              renderColorSwatch(hex, hex, 8, col),
-            )}
-          </div>
+        <div className="ic-color-picker__color-list">
+          {standardColors.map((hex, col) =>
+            renderColorSwatch(hex, hex, 7, col),
+          )}
         </div>
+      </div>
 
-        <div className="ic-color-picker__divider" />
+      <div className="ic-color-picker__divider" />
 
-        <div className="ic-color-picker__section">
-          <div className="ic-color-picker__label">
-            {t("color_picker.recent")}
-          </div>
+      <div className="ic-color-picker__section">
+        <div className="ic-color-picker__label">{t("color_picker.recent")}</div>
 
-          <div className="ic-color-picker__color-list">
-            {recentColors.current.length > 0 ? (
-              recentColors.current.map(
-                ({ color: recentColor, hex: recentHex }, col) => (
-                  <button
-                    key={recentHex}
-                    type="button"
-                    className={[
-                      "ic-color-picker__swatch",
-                      isWhiteColor(recentHex)
-                        ? "ic-color-picker__swatch--white"
-                        : "",
-                    ]
-                      .filter(Boolean)
-                      .join(" ")}
-                    style={{ backgroundColor: recentHex }}
-                    onClick={() => handleColorSelect(recentColor, recentHex)}
-                    aria-label={recentHex}
-                    data-nav-row={7}
-                    data-nav-col={col}
-                  />
-                ),
-              )
-            ) : (
-              <div className="ic-color-picker__empty" />
-            )}
-
-            <Tooltip title={t("color_picker.add")} container={panelRef.current}>
+        <div className="ic-color-picker__color-list">
+          {recentColors.current.map(
+            ({ color: recentColor, hex: recentHex }, col) => (
               <button
+                key={recentHex}
                 type="button"
-                className="ic-color-picker__plus-button"
-                onClick={() => setPickerOpen(true)}
-                aria-label={t("color_picker.add")}
-                data-nav-row={7}
-                data-nav-col={recentColors.current.length}
-              >
-                <Plus />
-              </button>
-            </Tooltip>
-          </div>
+                className={[
+                  "ic-color-picker__swatch",
+                  isWhiteColor(recentHex)
+                    ? "ic-color-picker__swatch--white"
+                    : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+                style={{ backgroundColor: recentHex }}
+                onClick={() => handleColorSelect(recentColor, recentHex)}
+                aria-label={recentHex}
+                data-nav-row={8}
+                data-nav-col={col}
+              />
+            ),
+          )}
+
+          <Tooltip title={t("color_picker.add")} container={panelRef.current}>
+            <button
+              type="button"
+              className="ic-color-picker__plus-button"
+              onClick={() => setPickerOpen(true)}
+              aria-label={t("color_picker.add")}
+              data-nav-row={8}
+              data-nav-col={recentColors.current.length}
+            >
+              <Plus />
+            </button>
+          </Tooltip>
         </div>
       </div>
     </div>,

--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
@@ -7,7 +7,6 @@ import { getFocusableElements } from "../util";
 import "./color-picker.css";
 import type { Color, IronCalcTheme } from "@ironcalc/wasm";
 import { createPortal } from "react-dom";
-import { Tooltip } from "../Tooltip/Tooltip";
 import useAnchorPosition, { type Placement } from "./useAnchorPosition";
 import useKeyDown from "./useKeyDown";
 import {
@@ -289,18 +288,17 @@ const ColorPicker = ({
             ),
           )}
 
-          <Tooltip title={t("color_picker.add")} container={panelRef.current}>
-            <button
-              type="button"
-              className="ic-color-picker__plus-button"
-              onClick={() => setPickerOpen(true)}
-              aria-label={t("color_picker.add")}
-              data-nav-row={8}
-              data-nav-col={recentColors.current.length}
-            >
-              <Plus />
-            </button>
-          </Tooltip>
+          <button
+            type="button"
+            className="ic-color-picker__plus-button"
+            onClick={() => setPickerOpen(true)}
+            title={t("color_picker.add")}
+            aria-label={t("color_picker.add")}
+            data-nav-row={8}
+            data-nav-col={recentColors.current.length}
+          >
+            <Plus />
+          </button>
         </div>
       </div>
     </div>,

--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
@@ -32,6 +32,8 @@ type ColorPickerProps = {
 
 const FALLBACK_COLOR = "#272525"; // --palette-common-black
 
+const MAX_RECENT_COLORS = 29;
+
 function colorsEqual(a: Color, b: Color): boolean {
   if (a === undefined || b === undefined) {
     return a === b;
@@ -127,7 +129,7 @@ const ColorPicker = ({
       recentColors.current = [
         { color: colorValue, hex: displayHex },
         ...recentColors.current,
-      ];
+      ].slice(0, MAX_RECENT_COLORS);
     }
 
     setSelectedColor(colorValue ?? FALLBACK_COLOR);
@@ -194,7 +196,6 @@ const ColorPicker = ({
       className="ic-color-picker"
       style={position}
       role="dialog"
-      aria-modal="true"
       aria-label={t("color_picker.add")}
       onKeyDown={onKeyDown}
       onClick={(event) => {

--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
@@ -13,6 +13,7 @@ import { getFocusableElements } from "../util";
 import "./color-picker.css";
 import type { Color, IronCalcTheme } from "@ironcalc/wasm";
 import { createPortal } from "react-dom";
+import { Tooltip } from "../Tooltip/Tooltip";
 import useKeyDown from "./useKeyDown";
 import {
   computeThemeGrid,
@@ -380,17 +381,18 @@ const ColorPicker = ({
               <div className="ic-color-picker__empty" />
             )}
 
-            <button
-              type="button"
-              className="ic-color-picker__plus-button"
-              onClick={() => setPickerOpen(true)}
-              title={t("color_picker.add")}
-              aria-label={t("color_picker.add")}
-              data-nav-row={7}
-              data-nav-col={recentColors.current.length}
-            >
-              <Plus />
-            </button>
+            <Tooltip title={t("color_picker.add")} container={panelRef.current}>
+              <button
+                type="button"
+                className="ic-color-picker__plus-button"
+                onClick={() => setPickerOpen(true)}
+                aria-label={t("color_picker.add")}
+                data-nav-row={7}
+                data-nav-col={recentColors.current.length}
+              >
+                <Plus />
+              </button>
+            </Tooltip>
           </div>
         </div>
       </div>

--- a/webapp/IronCalc/src/components/ColorPicker/color-picker.css
+++ b/webapp/IronCalc/src/components/ColorPicker/color-picker.css
@@ -3,7 +3,6 @@
   z-index: 1300;
   max-width: 220px;
   min-width: 180px;
-  padding: 4px 0;
   margin: 0;
   border-radius: 8px;
   background: var(--palette-common-white);
@@ -30,16 +29,28 @@
   outline-offset: 2px;
 }
 
+.ic-color-picker__section {
+  display: flex;
+  flex-direction: column;
+  margin: 4px;
+  padding: 8px;
+  gap: 8px;
+}
+
+.ic-color-picker__section:first-child {
+  margin: 4px;
+  padding: 0;
+}
+
 .ic-color-picker__menu-item {
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
   gap: 8px;
-  width: calc(100% - 8px);
+  width: 100%;
   min-width: 172px;
   height: 32px;
-  margin: 0 4px 4px;
   padding: 8px;
   border: none;
   border-radius: 4px;
@@ -76,7 +87,7 @@
 .ic-color-picker__colors-wrapper {
   display: flex;
   flex-direction: column;
-  margin: 4px;
+  gap: 8px;
 }
 
 .ic-color-picker__color-list {
@@ -85,7 +96,6 @@
   flex-direction: row;
   justify-content: flex-start;
   gap: 4px;
-  margin: 8px 8px 0;
 }
 
 .ic-color-picker__color-grid {
@@ -93,7 +103,6 @@
   flex-direction: row;
   justify-content: flex-start;
   gap: 4px;
-  margin: 8px;
 }
 
 .ic-color-picker__color-grid-col {
@@ -136,8 +145,7 @@
   pointer-events: none;
 }
 
-.ic-color-picker__recent-label {
-  margin: 8px 12px 0;
+.ic-color-picker__label {
   color: var(--palette-grey-600);
   font-family: var(--typography-font-family);
   font-size: var(--typography-font-size);
@@ -149,8 +157,6 @@
   flex-direction: row;
   justify-content: flex-start;
   gap: 4px;
-  margin: 0 4px;
-  padding: 8px;
 }
 
 .ic-color-picker__plus-button {

--- a/webapp/IronCalc/src/components/ColorPicker/color-picker.css
+++ b/webapp/IronCalc/src/components/ColorPicker/color-picker.css
@@ -84,12 +84,6 @@
   border-top: 1px solid var(--palette-grey-200);
 }
 
-.ic-color-picker__colors-wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
 .ic-color-picker__color-list {
   display: flex;
   flex-wrap: wrap;
@@ -151,14 +145,6 @@
   font-size: var(--typography-font-size);
 }
 
-.ic-color-picker__recent-colors-list {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  justify-content: flex-start;
-  gap: 4px;
-}
-
 .ic-color-picker__plus-button {
   display: flex;
   flex-wrap: wrap;
@@ -183,8 +169,4 @@
 .ic-color-picker__plus-button svg {
   width: 16px;
   height: 16px;
-}
-
-.ic-color-picker__empty {
-  display: none;
 }

--- a/webapp/IronCalc/src/components/ColorPicker/useAnchorPosition.ts
+++ b/webapp/IronCalc/src/components/ColorPicker/useAnchorPosition.ts
@@ -1,0 +1,104 @@
+import {
+  type CSSProperties,
+  type RefObject,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+export type Placement = "bottom" | "top" | "right";
+
+function getPanelPosition(
+  anchor: HTMLElement,
+  panel: HTMLElement,
+  placement: Placement,
+) {
+  const anchorRect = anchor.getBoundingClientRect();
+  const panelWidth = panel.offsetWidth;
+  const panelHeight = panel.offsetHeight;
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  const offset = 4; // Distance between anchor and panel
+  const margin = 8; // Safety margin from viewport edges
+
+  let left: number;
+  let top: number;
+
+  if (placement === "right") {
+    // Aligned with the anchor's top edge, used by submenus (e.g. BorderPicker)
+    left = anchorRect.right;
+    top = anchorRect.top;
+  } else {
+    // Preferred side by default, falls back to the other side when it has more space
+    const spaceBelow = viewportHeight - anchorRect.bottom - margin;
+    const spaceAbove = anchorRect.top - margin;
+    const openBelow =
+      placement === "top"
+        ? spaceAbove < panelHeight + offset && spaceBelow > spaceAbove
+        : spaceBelow >= panelHeight + offset || spaceBelow >= spaceAbove;
+
+    // Left-aligned with the anchor by default, right-aligned when it would overflow
+    const leftAligned = anchorRect.left;
+    const overflowsRight = leftAligned + panelWidth > viewportWidth - margin;
+
+    left = overflowsRight ? anchorRect.right - panelWidth : leftAligned;
+    top = openBelow
+      ? anchorRect.bottom + offset
+      : anchorRect.top - panelHeight - offset;
+  }
+
+  // Keep the panel within the viewport edges
+  if (left + panelWidth > viewportWidth - margin) {
+    left = viewportWidth - panelWidth - margin;
+  }
+  if (left < margin) {
+    left = margin;
+  }
+  if (top + panelHeight > viewportHeight - margin) {
+    top = viewportHeight - panelHeight - margin;
+  }
+  if (top < margin) {
+    top = margin;
+  }
+
+  return { top, left };
+}
+
+export default function useAnchorPosition(
+  open: boolean,
+  anchorEl: RefObject<HTMLElement | null>,
+  placement: Placement = "bottom",
+) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<CSSProperties>({});
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function updatePosition() {
+      const anchor = anchorEl.current;
+      const panel = panelRef.current;
+      if (!anchor || !panel) {
+        return;
+      }
+
+      const { top, left } = getPanelPosition(anchor, panel, placement);
+      setPosition({ top, left });
+    }
+
+    updatePosition();
+
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [open, anchorEl, placement]);
+
+  return { panelRef, position };
+}

--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -412,7 +412,7 @@ function Toolbar(properties: ToolbarProperties) {
           <Tooltip title={t("toolbar.font_color")}>
             <IconButton
               type="button"
-              pressed={false}
+              pressed={fontColorPickerOpen}
               disabled={!canEdit}
               ref={fontColorButton}
               aria-label={t("toolbar.font_color")}
@@ -431,7 +431,7 @@ function Toolbar(properties: ToolbarProperties) {
           <Tooltip title={t("toolbar.fill_color")}>
             <IconButton
               type="button"
-              pressed={false}
+              pressed={fillColorPickerOpen}
               disabled={!canEdit}
               ref={fillColorButton}
               aria-label={t("toolbar.fill_color")}

--- a/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
+++ b/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
@@ -12,11 +12,9 @@ import { useTooltipPosition } from "./useTooltipPosition";
 export interface TooltipProperties {
   title: string;
   children: ReactElement;
-  /** Portal target; pass an elevated container (menu, dialog) to paint above it */
-  container?: Element | null;
 }
 
-export function Tooltip({ title, children, container }: TooltipProperties) {
+export function Tooltip({ title, children }: TooltipProperties) {
   const tooltipId = useId();
   const [visible, setVisible] = useState(false);
   const { triggerRef, tooltipRef, position } = useTooltipPosition(visible);
@@ -60,7 +58,7 @@ export function Tooltip({ title, children, container }: TooltipProperties) {
         >
           {title}
         </div>,
-        container ?? document.body,
+        document.body,
       )}
     </>
   );

--- a/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
+++ b/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
@@ -12,9 +12,11 @@ import { useTooltipPosition } from "./useTooltipPosition";
 export interface TooltipProperties {
   title: string;
   children: ReactElement;
+  /** Portal target; pass an elevated container (menu, dialog) to paint above it */
+  container?: Element | null;
 }
 
-export function Tooltip({ title, children }: TooltipProperties) {
+export function Tooltip({ title, children, container }: TooltipProperties) {
   const tooltipId = useId();
   const [visible, setVisible] = useState(false);
   const { triggerRef, tooltipRef, position } = useTooltipPosition(visible);
@@ -58,7 +60,7 @@ export function Tooltip({ title, children }: TooltipProperties) {
         >
           {title}
         </div>,
-        document.body,
+        container ?? document.body,
       )}
     </>
   );

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -3,7 +3,7 @@
     "add": "Neue Farbe hinzufügen",
     "apply": "Farbe hinzufügen",
     "cancel": "Abbrechen",
-    "default": "Standardfarbe",
+    "default": "Standard",
     "no_fill": "Keine Füllung",
     "recent": "Zuletzt verwendet",
     "standard_colors": "Standardfarben",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -3,7 +3,7 @@
     "add": "Add new color",
     "apply": "Add color",
     "cancel": "Cancel",
-    "default": "Default color",
+    "default": "Default",
     "no_fill": "No fill",
     "recent": "Recent",
     "standard_colors": "Standard colors",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -3,7 +3,7 @@
     "add": "Añadir nuevo color",
     "apply": "Añadir color",
     "cancel": "Cancelar",
-    "default": "Color predeterminado",
+    "default": "Predeterminado",
     "no_fill": "Sin relleno",
     "recent": "Recientes",
     "standard_colors": "Colores estándar",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -3,7 +3,7 @@
     "add": "Ajouter une nouvelle couleur",
     "apply": "Ajouter la couleur",
     "cancel": "Annuler",
-    "default": "Couleur par défaut",
+    "default": "Par défaut",
     "no_fill": "Sans remplissage",
     "recent": "Récentes",
     "standard_colors": "Couleurs standard",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -3,7 +3,7 @@
     "add": "Aggiungi nuovo colore",
     "apply": "Aggiungi colore",
     "cancel": "Annulla",
-    "default": "Colore predefinito",
+    "default": "Predefinito",
     "no_fill": "Nessun riempimento",
     "recent": "Recenti",
     "standard_colors": "Colori standard",


### PR DESCRIPTION
This PR includes a round of improvements to the `ColorPicker` component, listed below:

<img width="681" height="387" alt="image" src="https://github.com/user-attachments/assets/ed91d21e-b45d-49a0-a8c8-1979a6a7711b" />

### Storybook
- Added a new story for `ColorPicker`: theme can be switched from the Storybook settings.

### Css cleanup
- Structure cleanup: sections are now consistent in terms of margin and padding, all styling is placed in classes now. We don't rely on individual margins or paddings as before
- Removed some dead css

### Consistency improvements
- The toolbar font/fill color buttons now show the active (pressed) state while their picker is open
- Removed the full-screen backdrop: the picker closes via a document-level `pointerdown` listener, so clicking another toolbar menu closes the picker and opens the target menu in a single click
- Positioning now lives in a dedicated `useAnchorPosition` hook (same as in the `Menu` component)

### Fixes
- "Add new color" button now uses the shared `Tooltip` component
- Keyboard navigation works smoothly and no longer skips the standard colors row
- Removed the 14-color limit on recent colors
- Added language keys to the text in the 'Default' button
