### PR TITLE
fix: accept booleans as arguments in EXPON.DIST

### DIFF
--- a/base/src/functions/statistical/exponential.rs
+++ b/base/src/functions/statistical/exponential.rs
@@ -10,12 +10,12 @@ impl<'a> Model<'a> {
             return CalcResult::new_args_number_error(cell);
         }
 
-        let x = match self.get_number_no_bools(&args[0], cell) {
+        let x = match self.get_number(&args[0], cell) {
             Ok(f) => f,
             Err(e) => return e,
         };
 
-        let lambda = match self.get_number_no_bools(&args[1], cell) {
+        let lambda = match self.get_number(&args[1], cell) {
             Ok(f) => f,
             Err(e) => return e,
         };


### PR DESCRIPTION
Small fix to handle booleans as arguments for the EXPON.DIST function to match Excel's behavior.