### PR TITLE
fix: accept booleans as arguments in GAMMALN and GAMMALN.PRECISE

### DIFF
--- a/base/src/functions/statistical/gamma.rs
+++ b/base/src/functions/statistical/gamma.rs
@@ -162,7 +162,7 @@ impl<'a> Model<'a> {
         if args.len() != 1 {
             return CalcResult::new_args_number_error(cell);
         }
-        let x = match self.get_number_no_bools(&args[0], cell) {
+        let x = match self.get_number(&args[0], cell) {
             Ok(f) => f,
             Err(s) => return s,
         };


### PR DESCRIPTION
Small fix to handle booleans as arguments for the GAMMALN and GAMMALN.PRECISE functions to match Excel's behavior.