### PR TITLE
fix: accept booleans as arguments in GAUSS function

### DIFF
--- a/base/src/functions/statistical/gauss.rs
+++ b/base/src/functions/statistical/gauss.rs
@@ -9,7 +9,7 @@ impl<'a> Model<'a> {
         if args.len() != 1 {
             return CalcResult::new_args_number_error(cell);
         }
-        let z = match self.get_number_no_bools(&args[0], cell) {
+        let z = match self.get_number(&args[0], cell) {
             Ok(f) => f,
             Err(s) => return s,
         };


### PR DESCRIPTION
Small fix to handle booleans as arguments for the GAUSS function to match Excel's behavior.