### PR TITLE
wasm: load xlsx in the browser

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 # the inicated version from crates.io when published.
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
 ironcalc_base = { path = "../../base", version = "0.7" }
+ironcalc = { path = "../../xlsx", version = "0.7" }
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = "0.2.100"
 serde-wasm-bindgen = "0.4"

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -134,6 +134,50 @@ impl Model {
         Ok(Model { model })
     }
 
+    /// Loads a model directly from the bytes of an xlsx file, in the browser.
+    #[wasm_bindgen(js_name = "loadFromXlsx")]
+    pub fn load_from_xlsx(
+        bytes: &[u8],
+        name: &str,
+        locale: &str,
+        timezone: &str,
+        language_id: &str,
+    ) -> Result<Model, JsError> {
+        let language_id = leak_str(language_id);
+        let workbook = ironcalc::import::load_from_xlsx_bytes(bytes, name, locale, timezone)
+            .map_err(|e| to_js_error(e.to_string()))?;
+        let model =
+            ironcalc_base::Model::from_workbook(workbook, language_id).map_err(to_js_error)?;
+        Ok(Model {
+            model: BaseModel::from_model(model),
+        })
+    }
+
+    /// Bounding box of cells with data: `[min_row, min_col, max_row, max_col]`.
+    #[wasm_bindgen(js_name = "getDimension")]
+    pub fn get_dimension(&self, sheet: u32) -> Result<Vec<i32>, JsError> {
+        let worksheet = self
+            .model
+            .get_model()
+            .workbook
+            .worksheet(sheet)
+            .map_err(to_js_error)?;
+        let d = worksheet.dimension();
+        Ok(vec![d.min_row, d.min_column, d.max_row, d.max_column])
+    }
+
+    /// Merged cell ranges (e.g. `"A1:B2"`) for the given sheet.
+    #[wasm_bindgen(js_name = "getMergeCells")]
+    pub fn get_merge_cells(&self, sheet: u32) -> Result<Vec<String>, JsError> {
+        let worksheet = self
+            .model
+            .get_model()
+            .workbook
+            .worksheet(sheet)
+            .map_err(to_js_error)?;
+        Ok(worksheet.merge_cells.clone())
+    }
+
     pub fn undo(&mut self) -> Result<(), JsError> {
         self.model.undo().map_err(to_js_error)
     }

--- a/xlsx/Cargo.toml
+++ b/xlsx/Cargo.toml
@@ -12,7 +12,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zip = "0.6"
+# Default features pull in bzip2 (a C library) which can't target wasm32.
+# xlsx archives use DEFLATE, so that's all we need.
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 roxmltree = "0.19"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Adds Model.loadFromXlsx(bytes, name, locale, timezone, language_id) to the wasm binding so xlsx files can be parsed entirely client-side, plus getDimension and getMergeCells helpers. The ironcalc (xlsx) crate is added as a dependency of bindings/wasm, and xlsx's zip dependency drops default features (keeping only deflate) — the default pulls in bzip2, a C library that can't target wasm32. xlsx archives only use DEFLATE.