### PR TITLE
webapp: read-only mode via canEdit

### DIFF
--- a/webapp/IronCalc/src/IronCalc.tsx
+++ b/webapp/IronCalc/src/IronCalc.tsx
@@ -11,6 +11,8 @@ import { type PartialIronCalcThemeVariables, setThemeVariables } from "./theme";
 interface IronCalcProperties {
   model: Model;
   themeVariables?: PartialIronCalcThemeVariables;
+  /** When false, renders without the toolbar/formula bar and blocks all edits. */
+  canEdit?: boolean;
 }
 
 export interface IronCalcHandle {
@@ -18,7 +20,7 @@ export interface IronCalcHandle {
 }
 
 const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
-  ({ themeVariables, model }, ref) => {
+  ({ themeVariables, model, canEdit = true }, ref) => {
     const rootRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -40,7 +42,11 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
     return (
       <div ref={rootRef} className="ic-root">
         <I18nextProvider i18n={i18n}>
-          <Workbook model={model} workbookState={new WorkbookState()} />
+          <Workbook
+            model={model}
+            workbookState={new WorkbookState()}
+            canEdit={canEdit}
+          />
         </I18nextProvider>
       </div>
     );

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTab.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTab.tsx
@@ -15,6 +15,7 @@ interface SheetTabProps {
   color: string;
   selected: boolean;
   onSelected: () => void;
+  canEdit: boolean;
   onColorChanged: (color: Color) => void;
   onRenamed: (name: string) => void;
   canDelete: boolean;
@@ -73,6 +74,7 @@ function SheetTab(props: SheetTabProps) {
   }
 
   const handleOpenMenu = (event: React.MouseEvent) => {
+    if (!props.canEdit) return;
     event.stopPropagation();
     event.preventDefault();
     if (menuOpen) {
@@ -86,6 +88,7 @@ function SheetTab(props: SheetTabProps) {
   };
 
   const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!props.canEdit) return;
     event.preventDefault();
     event.stopPropagation();
     onSelected();
@@ -99,6 +102,7 @@ function SheetTab(props: SheetTabProps) {
   };
 
   const handleStartEditing = () => {
+    if (!props.canEdit) return;
     setEditingName(name);
     setInputWidth(Math.max(name.length * 7 + 8, 6));
     setIsEditing(true);
@@ -193,6 +197,7 @@ function SheetTab(props: SheetTabProps) {
         ) : (
           <>
             <div className="ic-sheet-tab-name">{name}</div>
+            {props.canEdit && (
             <button
               ref={menuButtonRef}
               className={`ic-sheet-tab-menu-button${menuOpen ? " ic-sheet-tab-menu-button--active" : ""}`}
@@ -204,6 +209,7 @@ function SheetTab(props: SheetTabProps) {
             >
               <ChevronDown />
             </button>
+            )}
           </>
         )}
       </div>

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
@@ -24,6 +24,8 @@ export interface SheetTabBarProps {
   onHideSheet: () => void;
   model: Model;
   onOpenRegionalSettings: () => void;
+  /** When false, sheet add/rename/delete affordances are hidden. */
+  canEdit: boolean;
 }
 
 function SheetTabBar(props: SheetTabBarProps) {
@@ -44,13 +46,15 @@ function SheetTabBar(props: SheetTabBarProps) {
   return (
     <div className="ic-sheet-tab-bar-container">
       <div className="ic-sheet-tab-bar-left-buttons-container">
-        <Tooltip title={t("navigation.add_sheet")}>
-          <IconButton
-            aria-label={t("navigation.add_sheet")}
-            icon={<Plus />}
-            onClick={props.onAddBlankSheet}
-          />
-        </Tooltip>
+        {props.canEdit && (
+          <Tooltip title={t("navigation.add_sheet")}>
+            <IconButton
+              aria-label={t("navigation.add_sheet")}
+              icon={<Plus />}
+              onClick={props.onAddBlankSheet}
+            />
+          </Tooltip>
+        )}
         <Tooltip title={t("navigation.sheet_list")}>
           <Menu
             trigger={
@@ -74,6 +78,7 @@ function SheetTabBar(props: SheetTabBarProps) {
           {nonHiddenSheets.map((tab) => (
             <SheetTab
               key={tab.sheetId}
+              canEdit={props.canEdit}
               name={tab.name}
               color={tab.color}
               selected={tab.index === selectedIndex}

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -49,8 +49,13 @@ function colorToParam(color: Color): string {
   return `[${color[0]}, ${color[1]}]`;
 }
 
-const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
-  const { model, workbookState } = props;
+const Workbook = (props: {
+  model: Model;
+  workbookState: WorkbookState;
+  /** When false, the toolbar/formula bar are hidden and all edits are blocked. */
+  canEdit?: boolean;
+}) => {
+  const { model, workbookState, canEdit = true } = props;
   const { t } = useTranslation();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const worksheetRef = useRef<{
@@ -274,6 +279,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
   // FIXME: I *think* we should have only one on onKeyPressed function that goes to
   // the Rust backend
   const { onKeyDown } = useKeyboardNavigation({
+    canEdit,
     onCellsDeleted: (): void => {
       const {
         sheet,
@@ -523,6 +529,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         }
       }}
       onPaste={(event: React.ClipboardEvent) => {
+        if (!canEdit) return;
         workbookState.clearCutRange();
         const { items } = event.clipboardData;
         if (!items) {
@@ -640,6 +647,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         event.stopPropagation();
       }}
       onCut={(event: React.ClipboardEvent) => {
+        if (!canEdit) return;
         const data = model.copyToClipboard();
         const sheet = model.getSelectedSheet();
         // '2024-10-18T14:07:37.599Z'
@@ -687,6 +695,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         setRedrawId((id) => id + 1);
       }}
     >
+      {canEdit && (
       <Toolbar
         canUndo={model.canUndo()}
         canRedo={model.canRedo()}
@@ -826,6 +835,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         onThemePicked={handleThemePicked}
         onOpenThemes={() => openDrawer("themes")}
       />
+      )}
       <div
         className="ic-workbook-worksheet-area-left"
         style={{
@@ -847,7 +857,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
           openDrawer={() => {
             openDrawer("namedRanges");
           }}
-          canEdit={isArrayFormula}
+          canEdit={canEdit && isArrayFormula}
         />
         <Worksheet
           model={model}
@@ -856,7 +866,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
             setRedrawId((id) => id + 1);
           }}
           ref={worksheetRef}
-          canEdit={isArrayFormula}
+          canEdit={canEdit && isArrayFormula}
           onCut={(): void => {
             focusWorkbook();
             document.execCommand("cut");
@@ -869,6 +879,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         />
 
         <SheetTabBar
+          canEdit={canEdit}
           sheets={info}
           selectedIndex={model.getSelectedSheet()}
           workbookState={workbookState}

--- a/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
+++ b/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
@@ -34,6 +34,8 @@ interface Options {
   onEscape: () => void;
   onSelectColumn: () => void;
   onSelectRow: () => void;
+  /** When false, editing/mutation keys are ignored (navigation still works). */
+  canEdit: boolean;
   root: RefObject<HTMLDivElement | null>;
 }
 
@@ -103,19 +105,19 @@ const useKeyboardNavigation = (
             break;
           }
           case "b": {
-            options.onBold();
+            if (options.canEdit) options.onBold();
             event.stopPropagation();
             event.preventDefault();
             break;
           }
           case "i": {
-            options.onItalic();
+            if (options.canEdit) options.onItalic();
             event.stopPropagation();
             event.preventDefault();
             break;
           }
           case "u": {
-            options.onUnderline();
+            if (options.canEdit) options.onUnderline();
             event.stopPropagation();
             event.preventDefault();
             break;
@@ -204,7 +206,7 @@ const useKeyboardNavigation = (
         return;
       }
 
-      if (isEditingKey(key) || key === "Backspace") {
+      if (options.canEdit && (isEditingKey(key) || key === "Backspace")) {
         const initText = key === "Backspace" ? "" : key;
         options.onEditKeyPressStart(initText);
         event.stopPropagation();
@@ -215,7 +217,7 @@ const useKeyboardNavigation = (
         // Other combinations with Shift are not handled
         return;
       }
-      if (key === "F2") {
+      if (key === "F2" && options.canEdit) {
         options.onCellEditStart();
         event.stopPropagation();
         event.preventDefault();
@@ -250,7 +252,7 @@ const useKeyboardNavigation = (
           break;
         }
         case "Delete": {
-          options.onCellsDeleted();
+          if (options.canEdit) options.onCellsDeleted();
           break;
         }
         case "PageDown": {


### PR DESCRIPTION
Adds an optional canEdit prop (default true) to <IronCalc>, threaded down to Workbook. When false, the toolbar and formula-bar editor are hidden, paste/cut and editing/Delete/F2 key handlers are gated, and sheet add/rename/delete affordances are removed — while keeping the canvas, keyboard navigation, and sheet tabs for browsing. Useful for embedding IronCalc as a viewer. Reuses the existing canEdit plumbing already present on Toolbar/FormulaBar/Worksheet.