### PR TITLE
update: WelcomeDialog mobile improvements, CSS cleanup

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/TemplatesDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, IconButton } from "@ironcalc/workbook";
+import { IconButton } from "@ironcalc/workbook";
 import { X } from "lucide-react";
 import { useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -23,21 +23,18 @@ function TemplatesDialog({
 }: TemplatesDialogProperties) {
   const { t } = useTranslation();
   const titleId = useId();
-  const [selectedTemplate, setSelectedTemplate] = useState(
-    "mortgage_calculator",
-  );
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [gridScrolled, setGridScrolled] = useState(false);
   const dialogRef = useDialogFocus(open);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const lastTemplateRef = useRef<HTMLButtonElement>(null);
 
   const handleClose = () => {
     onClose();
   };
 
   const { onKeyDown } = useDialogKeyDown({
-    focusableElements: [closeButtonRef, confirmButtonRef],
+    focusableElements: [closeButtonRef, lastTemplateRef],
     onClose: handleClose,
   });
 
@@ -91,19 +88,12 @@ function TemplatesDialog({
         </div>
         <div className="app-ic-wd-content">
           <TemplatesList
-            selectedTemplate={selectedTemplate}
-            handleTemplateSelect={setSelectedTemplate}
+            selectedTemplate=""
+            handleTemplateSelect={onSelectTemplate}
             categoryFilter={selectedCategory}
             onScroll={(e) => setGridScrolled(e.currentTarget.scrollTop > 0)}
+            lastItemRef={lastTemplateRef}
           />
-        </div>
-        <div className="app-ic-wd-footer">
-          <Button
-            ref={confirmButtonRef}
-            onClick={() => onSelectTemplate(selectedTemplate)}
-          >
-            {t("welcome_dialog.create_workbook")}
-          </Button>
         </div>
       </div>
     </div>,

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/WelcomeDialog.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/WelcomeDialog.tsx
@@ -2,7 +2,7 @@ import {
   IconButton,
   IronCalcIconWhite as IronCalcIcon,
 } from "@ironcalc/workbook";
-import { LayoutTemplate, Plus, TriangleAlert, Upload, X } from "lucide-react";
+import { LayoutTemplate, Plus, Upload, X } from "lucide-react";
 import { useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Trans, useTranslation } from "react-i18next";
@@ -88,7 +88,9 @@ function WelcomeDialog({
                   className="app-ic-wd-action-button"
                   onClick={() => onSelectTemplate("blank")}
                 >
-                  <Plus />
+                  <span className="app-ic-wd-action-button-icon">
+                    <Plus />
+                  </span>
                   {t("welcome_dialog.blank_workbook")}
                 </button>
                 <button
@@ -96,7 +98,9 @@ function WelcomeDialog({
                   className="app-ic-wd-action-button"
                   onClick={() => fileInputRef.current?.click()}
                 >
-                  <Upload />
+                  <span className="app-ic-wd-action-button-icon">
+                    <Upload />
+                  </span>
                   {t("welcome_dialog.import_workbook")}
                 </button>
                 <button
@@ -104,13 +108,14 @@ function WelcomeDialog({
                   className="app-ic-wd-action-button app-ic-wd-action-button--mobile-only"
                   onClick={onOpenTemplates}
                 >
-                  <LayoutTemplate />
+                  <span className="app-ic-wd-action-button-icon">
+                    <LayoutTemplate />
+                  </span>
                   {t("welcome_dialog.templates.templates")}
                 </button>
               </div>
             </div>
             <div className="app-ic-wd-storage-warning">
-              <TriangleAlert className="app-ic-wd-storage-warning-icon" />
               <div>
                 <Trans
                   i18nKey="welcome_dialog.storage_warning"

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/templates-dialog.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/templates-dialog.css
@@ -11,7 +11,7 @@
 }
 
 .app-ic-wd-paper--templates .app-ic-wd-templates-list {
-  gap: 12px;
+  gap: 20px;
   padding: 8px 12px 12px 12px;
 }
 
@@ -41,7 +41,7 @@
 .app-ic-wd-filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 4px;
   padding: 0 12px 8px;
   border-bottom: 1px solid transparent;
   transition:
@@ -58,7 +58,7 @@
 .app-ic-wd-filter-pill {
   display: inline-flex;
   align-items: center;
-  padding: 4px 12px;
+  padding: 4px 10px;
   border-radius: 999px;
   border: 1px solid transparent;
   background: none;
@@ -87,17 +87,18 @@
   outline-offset: 2px;
 }
 
-/* Footer */
+@media (max-width: 768px) {
+  .app-ic-wd-paper--templates .app-ic-wd-templates-list {
+    grid-template-columns: repeat(2, 1fr);
+  }
 
-.app-ic-wd-footer {
-  display: flex;
-  justify-content: flex-end;
-  padding: 8px 12px;
-  border-top: 1px solid var(--palette-grey-200);
-}
+  .app-ic-wd-filters {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
 
-@media (max-width: 600px) {
-  .app-ic-wd-footer button {
-    width: 100%;
+  .app-ic-wd-filters::-webkit-scrollbar {
+    display: none;
   }
 }

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/welcome-dialog.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/welcome-dialog.css
@@ -11,8 +11,8 @@
 
 .app-ic-wd-paper {
   position: relative;
-  width: 720px;
-  height: 420px;
+  width: 760px;
+  height: 460px;
   max-width: calc(100% - 32px);
   max-height: calc(100vh - 32px);
   display: flex;
@@ -47,7 +47,7 @@
 
 /* Mobile-only controls are hidden on wider viewports */
 
-.app-ic-wd-action-button--mobile-only,
+.app-ic-wd-action-button.app-ic-wd-action-button--mobile-only,
 .app-ic-wd-mobile-close {
   display: none;
 }
@@ -57,7 +57,7 @@
   flex-direction: column;
   justify-content: space-between;
   padding: 16px;
-  width: 140px;
+  width: 160px;
   flex-shrink: 0;
   background: var(--palette-grey-50);
   border-right: 1px solid var(--palette-grey-200);
@@ -104,18 +104,27 @@
   flex-shrink: 0;
 }
 
+.app-ic-wd-action-button-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
 .app-ic-wd-storage-warning {
   display: flex;
   flex-direction: column;
   gap: 6px;
   background-color: var(--palette-grey-200);
-  border: 1px solid var(--palette-grey-300);
+  border: 1px solid
+    color-mix(in srgb, var(--palette-common-black) 8%, transparent);
   box-shadow: var(--shadow-sm);
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 8px;
   font-size: calc(var(--typography-font-size) - 1px);
   color: var(--palette-grey-900);
   line-height: 128%;
+  margin: -4px;
 }
 
 .app-ic-wd-storage-warning svg {
@@ -130,11 +139,16 @@
 }
 
 .app-ic-wd-storage-warning-title {
-  color: var(--palette-error-main);
+  font-weight: 600;
 }
 
 .app-ic-wd-storage-warning a {
   color: var(--palette-primary-main);
+  text-decoration: none;
+}
+
+.app-ic-wd-storage-warning a:hover {
+  text-decoration: underline;
 }
 
 .app-ic-wd-action-group {
@@ -152,21 +166,13 @@
   min-height: 0;
 }
 
-/* Section wrapper (title + list) */
-
-.app-ic-wd-section {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
 /* Templates list */
 
 .app-ic-wd-templates-list {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 20px;
-  padding: 8px 24px 24px 24px;
+  padding: 8px 20px 20px 20px;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -177,7 +183,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 18px 24px 10px 24px;
+  padding: 18px 20px 10px 20px;
   font-size: 14px;
   font-weight: 600;
   font-family: var(--typography-font-family);
@@ -195,7 +201,7 @@
     color-mix(in srgb, var(--palette-common-black) 6%, transparent);
 }
 
-/* List item — uses --item-color and --item-color-alpha for dynamic per-item colors */
+/* List item */
 
 .app-ic-wd-list-item {
   flex: 1;
@@ -211,12 +217,7 @@
   cursor: pointer;
   outline: none;
   border: none;
-  transition: border 0.1s ease-in-out;
   user-select: none;
-}
-
-.app-ic-wd-list-item:hover {
-  border-color: var(--item-color);
 }
 
 .app-ic-wd-list-item-thumbnail {
@@ -245,7 +246,8 @@
 .app-ic-wd-list-item:hover .app-ic-wd-list-item-thumbnail,
 .app-ic-wd-list-item:focus-visible .app-ic-wd-list-item-thumbnail,
 .app-ic-wd-list-item--active .app-ic-wd-list-item-thumbnail {
-  border: 1px solid var(--palette-grey-600);
+  outline: 2px solid var(--palette-grey-700);
+  outline-offset: 1px;
 }
 
 .app-ic-wd-list-item:focus-visible .app-ic-wd-list-item-thumbnail {
@@ -267,51 +269,6 @@
 
 .app-ic-wd-list-item-description {
   color: var(--palette-grey-500);
-}
-
-/* Radio indicator */
-
-.app-ic-wd-radio {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  min-width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  margin-top: -4px;
-  margin-right: -4px;
-  background-color: var(--palette-common-white);
-  border: 1px solid var(--palette-grey-300);
-}
-
-.app-ic-wd-radio--active {
-  background-color: var(--palette-primary-main);
-  border: none;
-}
-
-.app-ic-wd-radio-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background-color: var(--palette-common-white);
-}
-
-/* WelcomeDialog header */
-
-.app-ic-wd-welcome-header {
-  display: flex;
-  align-items: flex-start;
-  padding: 16px;
-}
-
-.app-ic-wd-header-body {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
-  width: 100%;
-  padding: 16px 0;
 }
 
 .app-ic-wd-logo-wrapper {
@@ -342,17 +299,6 @@
   font-weight: 600;
 }
 
-.app-ic-wd-header-title {
-  font-size: calc(var(--typography-font-size) + 6px);
-  font-weight: 600;
-  color: var(--palette-grey-900);
-}
-
-.app-ic-wd-header-subtitle {
-  font-size: calc(var(--typography-font-size) + 2px);
-  color: var(--palette-grey-600);
-}
-
 /* Mobile: only show the actions column, the templates grid moves behind
    a dedicated "Templates" button that opens the full templates dialog. */
 
@@ -373,10 +319,36 @@
     border-right: none;
     justify-content: flex-start;
     gap: 20px;
+    box-sizing: border-box;
+    background: var(--palette-common-white);
   }
 
-  .app-ic-wd-action-button--mobile-only {
+  .app-ic-wd-col-actions-top {
+    gap: 20px;
+  }
+
+  .app-ic-wd-action-button.app-ic-wd-action-button--mobile-only {
     display: flex;
+  }
+
+  .app-ic-wd-action-button {
+    height: auto;
+    padding: 8px;
+    gap: 12px;
+  }
+
+  .app-ic-wd-action-button:hover {
+    background-color: var(--palette-grey-100);
+  }
+
+  .app-ic-wd-action-button:hover .app-ic-wd-action-button-icon {
+    background-color: var(--palette-grey-300);
+  }
+
+  .app-ic-wd-action-button-icon {
+    padding: 8px;
+    border-radius: 6px;
+    background-color: var(--palette-grey-100);
   }
 
   .app-ic-wd-mobile-close {

--- a/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/welcome-dialog.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/WelcomeDialog/welcome-dialog.css
@@ -11,7 +11,7 @@
 
 .app-ic-wd-paper {
   position: relative;
-  width: 760px;
+  width: 780px;
   height: 460px;
   max-width: calc(100% - 32px);
   max-height: calc(100vh - 32px);
@@ -57,7 +57,7 @@
   flex-direction: column;
   justify-content: space-between;
   padding: 16px;
-  width: 160px;
+  width: 174px;
   flex-shrink: 0;
   background: var(--palette-grey-50);
   border-right: 1px solid var(--palette-grey-200);
@@ -115,10 +115,11 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  background-color: var(--palette-grey-200);
-  border: 1px solid
-    color-mix(in srgb, var(--palette-common-black) 8%, transparent);
-  box-shadow: var(--shadow-sm);
+  background: var(--palette-grey-200);
+  box-shadow:
+    inset 0 0 0 1px
+    color-mix(in srgb, var(--palette-common-black) 8%, transparent),
+    var(--shadow-sm);
   border-radius: 6px;
   padding: 8px;
   font-size: calc(var(--typography-font-size) - 1px);
@@ -139,6 +140,7 @@
 }
 
 .app-ic-wd-storage-warning-title {
+  color: var(--palette-error-main);
   font-weight: 600;
 }
 
@@ -149,6 +151,12 @@
 
 .app-ic-wd-storage-warning a:hover {
   text-decoration: underline;
+}
+
+.app-ic-wd-storage-warning a:focus-visible {
+  outline: 2px solid var(--palette-primary-main);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .app-ic-wd-action-group {

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -16,7 +16,7 @@
     "blank_workbook_description": "Von Grund auf erstellen oder eigene Datei hochladen.",
     "import_workbook": "Arbeitsmappe importieren",
     "import_workbook_description": "Eine vorhandene Tabellendatei öffnen.",
-    "storage_warning": "<warn>Achtung!</warn> Diese App ist ein Proof of Concept und kein fertiges Produkt. Sie können gerne experimentieren, Modelle teilen sowie herunter- und hochladen, aber teilen oder laden Sie keine Modelle mit sensiblen oder privaten Daten hoch. Daten werden regelmäßig gelöscht. <docsLink>Mehr erfahren</docsLink>",
+    "storage_warning": "<warn>Achtung!</warn> Diese App ist ein Proof of Concept und kein fertiges Produkt. Experimentieren, teilen sowie hoch- und herunterladen Sie Modelle gerne. Bitte vermeiden Sie sensible oder private Daten, da regelmäßig alles gelöscht wird. <docsLink>Mehr erfahren</docsLink>",
     "templates": {
       "choose_template": "Vorlage auswählen",
       "templates": "Vorlagen",

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -13,10 +13,8 @@
     "close_dialog": "Dialog schließen",
     "new": "Neu",
     "blank_workbook": "Leere Arbeitsmappe",
-    "blank_workbook_description": "Von Grund auf erstellen oder eigene Datei hochladen.",
     "import_workbook": "Arbeitsmappe importieren",
-    "import_workbook_description": "Eine vorhandene Tabellendatei öffnen.",
-    "storage_warning": "<warn>Achtung!</warn> Diese App ist ein Proof of Concept und kein fertiges Produkt. Experimentieren, teilen sowie hoch- und herunterladen Sie Modelle gerne. Bitte vermeiden Sie sensible oder private Daten, da regelmäßig alles gelöscht wird. <docsLink>Mehr erfahren</docsLink>",
+    "storage_warning": "<warn>Achtung!</warn> Diese App ist ein Proof of Concept und kein fertiges Produkt. Experimentieren, teilen sowie hoch- und herunterladen Sie Modelle gerne, aber teilen oder laden Sie keine Modelle mit sensiblen oder privaten Daten hoch. Daten werden regelmäßig gelöscht. <docsLink>Mehr erfahren</docsLink>",
     "templates": {
       "choose_template": "Vorlage auswählen",
       "templates": "Vorlagen",

--- a/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
@@ -13,10 +13,8 @@
     "close_dialog": "Close dialog",
     "new": "New",
     "blank_workbook": "Blank workbook",
-    "blank_workbook_description": "An empty grid, ready when you are.",
     "import_workbook": "Import .xlsx",
-    "import_workbook_description": "Open a spreadsheet from your computer.",
-    "storage_warning": "<warn>Heads up!</warn>  This app is a proof of concept, not a finished product. Feel free to explore, share, and upload/download models. Please avoid sensitive or private data, since everything gets deleted periodically. <docsLink>Read more</docsLink>",
+    "storage_warning": "<warn>Warning!</warn> This app is a proof of concept, not a finished product. Feel free to explore, share, and upload/download models, but don't share or upload models with sensitive or private data. Data will be deleted periodically. <docsLink>Read more</docsLink>",
     "templates": {
       "choose_template": "Choose a template",
       "templates": "Templates",

--- a/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
@@ -16,7 +16,7 @@
     "blank_workbook_description": "An empty grid, ready when you are.",
     "import_workbook": "Import .xlsx",
     "import_workbook_description": "Open a spreadsheet from your computer.",
-    "storage_warning": "<warn>Achtung!</warn> This app is a proof of concept and not a finished product. You are free to play around, share models, and download and upload models, but don't share or upload models with sensitive or private data. Data will be deleted periodically. <docsLink>Read more</docsLink>",
+    "storage_warning": "<warn>Heads up!</warn>  This app is a proof of concept, not a finished product. Feel free to explore, share, and upload/download models. Please avoid sensitive or private data, since everything gets deleted periodically. <docsLink>Read more</docsLink>",
     "templates": {
       "choose_template": "Choose a template",
       "templates": "Templates",

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -13,10 +13,8 @@
     "close_dialog": "Cerrar diálogo",
     "new": "Nuevo",
     "blank_workbook": "Libro en blanco",
-    "blank_workbook_description": "Crea desde cero o sube tu propio archivo.",
     "import_workbook": "Importar libro",
-    "import_workbook_description": "Abre un archivo de hoja de cálculo existente.",
-    "storage_warning": "<warn>¡Atención!</warn> Esta aplicación es una prueba de concepto y no un producto terminado. Siéntete libre de explorar, compartir y subir/descargar modelos. Evita los datos sensibles o privados, ya que todo se elimina periódicamente. <docsLink>Leer más</docsLink>",
+    "storage_warning": "<warn>¡Atención!</warn> Esta aplicación es una prueba de concepto y no un producto terminado. Siéntete libre de explorar, compartir y subir/descargar modelos, pero no compartas ni subas modelos con datos sensibles o privados. Los datos se eliminarán periódicamente. <docsLink>Leer más</docsLink>",
     "templates": {
       "choose_template": "Elegir una plantilla",
       "templates": "Plantillas",

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -16,7 +16,7 @@
     "blank_workbook_description": "Crea desde cero o sube tu propio archivo.",
     "import_workbook": "Importar libro",
     "import_workbook_description": "Abre un archivo de hoja de cálculo existente.",
-    "storage_warning": "<warn>Achtung!</warn> Esta aplicación es una prueba de concepto y no un producto terminado. Puedes experimentar libremente, compartir modelos y descargarlos o subirlos, pero no compartas ni subas modelos con datos sensibles o privados. Los datos se eliminarán periódicamente. <docsLink>Leer más</docsLink>",
+    "storage_warning": "<warn>¡Atención!</warn> Esta aplicación es una prueba de concepto y no un producto terminado. Siéntete libre de explorar, compartir y subir/descargar modelos. Evita los datos sensibles o privados, ya que todo se elimina periódicamente. <docsLink>Leer más</docsLink>",
     "templates": {
       "choose_template": "Elegir una plantilla",
       "templates": "Plantillas",

--- a/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
@@ -13,10 +13,8 @@
     "close_dialog": "Fermer la boîte de dialogue",
     "new": "Nouveau",
     "blank_workbook": "Classeur vierge",
-    "blank_workbook_description": "Créez à partir de zéro ou téléchargez votre propre fichier.",
     "import_workbook": "Importer un classeur",
-    "import_workbook_description": "Ouvrir un fichier tableur existant.",
-    "storage_warning": "<warn>Attention !</warn> Cette application est une preuve de concept et non un produit fini. N'hésitez pas à explorer, partager et importer/télécharger des modèles. Veuillez éviter les données sensibles ou privées, car tout est supprimé périodiquement. <docsLink>En savoir plus</docsLink>",
+    "storage_warning": "<warn>Attention !</warn> Cette application est une preuve de concept et non un produit fini. N'hésitez pas à explorer, partager et importer/télécharger des modèles, mais ne partagez pas et n'importez pas de modèles contenant des données sensibles ou privées. Les données seront supprimées périodiquement. <docsLink>En savoir plus</docsLink>",
     "templates": {
       "choose_template": "Choisir un modèle",
       "templates": "Modèles",

--- a/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
@@ -16,7 +16,7 @@
     "blank_workbook_description": "Créez à partir de zéro ou téléchargez votre propre fichier.",
     "import_workbook": "Importer un classeur",
     "import_workbook_description": "Ouvrir un fichier tableur existant.",
-    "storage_warning": "<warn>Achtung!</warn> Cette application est une preuve de concept et non un produit fini. Vous êtes libre d'expérimenter, de partager des modèles et de les télécharger ou les importer, mais ne partagez pas et n'importez pas de modèles contenant des données sensibles ou privées. Les données seront supprimées périodiquement. <docsLink>En savoir plus</docsLink>",
+    "storage_warning": "<warn>Attention !</warn> Cette application est une preuve de concept et non un produit fini. N'hésitez pas à explorer, partager et importer/télécharger des modèles. Veuillez éviter les données sensibles ou privées, car tout est supprimé périodiquement. <docsLink>En savoir plus</docsLink>",
     "templates": {
       "choose_template": "Choisir un modèle",
       "templates": "Modèles",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -16,7 +16,7 @@
     "blank_workbook_description": "Crea da zero o carica il tuo file.",
     "import_workbook": "Importa cartella di lavoro",
     "import_workbook_description": "Apri un file foglio di calcolo esistente.",
-    "storage_warning": "<warn>Achtung!</warn> Questa applicazione è una prova di concetto e non un prodotto finito. Sei libero di sperimentare, condividere modelli e scaricarli o caricarli, ma non condividere o caricare modelli con dati sensibili o privati. I dati verranno eliminati periodicamente. <docsLink>Scopri di più</docsLink>",
+    "storage_warning": "<warn>Attenzione!</warn> Questa applicazione è una prova di concetto e non un prodotto finito. Sentiti libero di esplorare, condividere e caricare/scaricare modelli. Evita dati sensibili o privati, poiché tutto viene eliminato periodicamente. <docsLink>Scopri di più</docsLink>",
     "templates": {
       "choose_template": "Scegli un modello",
       "templates": "Modelli",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -13,10 +13,8 @@
     "close_dialog": "Chiudi finestra",
     "new": "Nuovo",
     "blank_workbook": "Cartella di lavoro vuota",
-    "blank_workbook_description": "Crea da zero o carica il tuo file.",
     "import_workbook": "Importa cartella di lavoro",
-    "import_workbook_description": "Apri un file foglio di calcolo esistente.",
-    "storage_warning": "<warn>Attenzione!</warn> Questa applicazione è una prova di concetto e non un prodotto finito. Sentiti libero di esplorare, condividere e caricare/scaricare modelli. Evita dati sensibili o privati, poiché tutto viene eliminato periodicamente. <docsLink>Scopri di più</docsLink>",
+    "storage_warning": "<warn>Attenzione!</warn> Questa applicazione è una prova di concetto e non un prodotto finito. Sentiti libero di esplorare, condividere e caricare/scaricare modelli, ma non condividere o caricare modelli con dati sensibili o privati. I dati verranno eliminati periodicamente. <docsLink>Scopri di più</docsLink>",
     "templates": {
       "choose_template": "Scegli un modello",
       "templates": "Modelli",


### PR DESCRIPTION
This PR polishes the Welcome and Template dialogs on mobile.

`before/after`

<img width="auto" height="280" alt="image" src="https://github.com/user-attachments/assets/644c23b9-b59e-4a33-82c8-ce9fa94a181d" /> <img width="auto" height="280" alt="image" src="https://github.com/user-attachments/assets/2072691d-ea4a-4f56-9569-63391f8bf6e4" />

<img width="auto" height="400" alt="image" src="https://github.com/user-attachments/assets/9506536b-44c7-4f14-a69b-10279be10a47" /> <img width="auto" height="400" alt="image" src="https://github.com/user-attachments/assets/0410cdae-f61e-4ced-9eec-995c31227b79" />

---

### Changes

- **TemplatesDialog**: Remove footer "Create workbook" button. Templates now open immediately on click on both dialogs.
- **Mobile layout**: Polishing on the left actions column and action buttons
- **Mobile-only Templates button**: Hidden on on desktop
- **Thumbnail hover**: increased contras and thinkness
- **Storage warning**: Shortened text on all locales
- **TemplatesDialog mobile**: the previous 3-column grid is now a 2-col grid
- **CSS cleanup**: Removed dead rules