### PR TITLE
update: add NumberInput variant to Input, use it for column/row size dialogs

### DIFF
--- a/webapp/IronCalc/src/components/Input/Input.stories.tsx
+++ b/webapp/IronCalc/src/components/Input/Input.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { AlertCircle, Mail, Search } from "lucide-react";
+import { useState } from "react";
 import type { InputProperties } from "./Input";
 import { Input } from "./Input";
 
@@ -159,4 +160,43 @@ export const WithBothAdornments: Story = {
     endAdornmentName: "alertCircle",
     size: "md",
   },
+};
+
+function StepperExample() {
+  const [width, setWidth] = useState("120");
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+        width: 200,
+      }}
+    >
+      <Input
+        label="Column width"
+        type="number"
+        min={0}
+        step="any"
+        stepper
+        endAdornment="px"
+        value={width}
+        onChange={(e) => setWidth(e.target.value)}
+      />
+      <Input
+        label="Disabled"
+        type="number"
+        min={0}
+        stepper
+        endAdornment="px"
+        value="64"
+        disabled
+      />
+    </div>
+  );
+}
+
+export const Stepper: Story = {
+  args: defaultArgs,
+  render: () => <StepperExample />,
 };

--- a/webapp/IronCalc/src/components/Input/Input.stories.tsx
+++ b/webapp/IronCalc/src/components/Input/Input.stories.tsx
@@ -178,7 +178,6 @@ function NumberInputExample() {
         type="number"
         min={0}
         step="any"
-        numberInput
         endAdornment="px"
         value={width}
         onChange={(e) => setWidth(e.target.value)}
@@ -187,7 +186,6 @@ function NumberInputExample() {
         label="Disabled"
         type="number"
         min={0}
-        numberInput
         endAdornment="px"
         value="64"
         disabled

--- a/webapp/IronCalc/src/components/Input/Input.stories.tsx
+++ b/webapp/IronCalc/src/components/Input/Input.stories.tsx
@@ -162,7 +162,7 @@ export const WithBothAdornments: Story = {
   },
 };
 
-function StepperExample() {
+function NumberInputExample() {
   const [width, setWidth] = useState("120");
   return (
     <div
@@ -178,7 +178,7 @@ function StepperExample() {
         type="number"
         min={0}
         step="any"
-        stepper
+        numberInput
         endAdornment="px"
         value={width}
         onChange={(e) => setWidth(e.target.value)}
@@ -187,7 +187,7 @@ function StepperExample() {
         label="Disabled"
         type="number"
         min={0}
-        stepper
+        numberInput
         endAdornment="px"
         value="64"
         disabled
@@ -196,7 +196,7 @@ function StepperExample() {
   );
 }
 
-export const Stepper: Story = {
+export const NumberInput: Story = {
   args: defaultArgs,
-  render: () => <StepperExample />,
+  render: () => <NumberInputExample />,
 };

--- a/webapp/IronCalc/src/components/Input/Input.tsx
+++ b/webapp/IronCalc/src/components/Input/Input.tsx
@@ -20,7 +20,7 @@ export type InputSize = "sm" | "md";
 
 /** Extends native `<input>` props.
  * Defaults: `size` "md".
- * Optional: `label`, `helperText`, `error`, `startAdornment`, `endAdornment`, `stepper`.
+ * Optional: `label`, `helperText`, `error`, `startAdornment`, `endAdornment`, `numberInput`.
  */
 
 export interface InputProperties
@@ -31,7 +31,7 @@ export interface InputProperties
   error?: boolean;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
-  stepper?: boolean;
+  numberInput?: boolean;
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProperties>(
@@ -44,7 +44,7 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
       disabled = false,
       startAdornment,
       endAdornment,
-      stepper = false,
+      numberInput = false,
       required,
       id: idProp,
       className,
@@ -82,16 +82,16 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
       `${size}`,
       error && "is-error",
       disabled && "is-disabled",
-      !stepper && startAdornment && "has-start",
-      !stepper && endAdornment && "has-end",
-      stepper && "is-stepper",
+      !numberInput && startAdornment && "has-start",
+      !numberInput && endAdornment && "has-end",
+      numberInput && "is-number-input",
     ]
       .filter(Boolean)
       .join(" ");
 
     const inputControl = (
       <div className={controlClassName}>
-        {stepper ? (
+        {numberInput ? (
           <>
             <IconButton
               icon={<Minus />}
@@ -99,7 +99,7 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
               variant="ghost"
               size="xs"
               disabled={disabled}
-              className="ic-input-stepper-btn"
+              className="ic-input-number-btn"
               onClick={(e) => handleStep("down", e)}
             />
             {editMode ? (
@@ -130,13 +130,13 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
             ) : (
               <button
                 type="button"
-                className="ic-input-stepper-display"
+                className="ic-input-number-display"
                 disabled={disabled}
                 onClick={() => setEditMode(true)}
               >
                 <span>{rest.value}</span>
                 {endAdornment && (
-                  <span className="ic-input-stepper-unit">{endAdornment}</span>
+                  <span className="ic-input-number-unit">{endAdornment}</span>
                 )}
               </button>
             )}
@@ -146,7 +146,7 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
               variant="ghost"
               size="xs"
               disabled={disabled}
-              className="ic-input-stepper-btn"
+              className="ic-input-number-btn"
               onClick={(e) => handleStep("up", e)}
             />
           </>

--- a/webapp/IronCalc/src/components/Input/Input.tsx
+++ b/webapp/IronCalc/src/components/Input/Input.tsx
@@ -1,9 +1,12 @@
+import { Minus, Plus } from "lucide-react";
 import {
   forwardRef,
   type InputHTMLAttributes,
   type ReactNode,
   useId,
+  useState,
 } from "react";
+import { IconButton } from "../Button/IconButton";
 
 import "./input.css";
 
@@ -17,7 +20,7 @@ export type InputSize = "sm" | "md";
 
 /** Extends native `<input>` props.
  * Defaults: `size` "md".
- * Optional: `label`, `helperText`, `error`, `startAdornment`, `endAdornment`.
+ * Optional: `label`, `helperText`, `error`, `startAdornment`, `endAdornment`, `stepper`.
  */
 
 export interface InputProperties
@@ -28,6 +31,7 @@ export interface InputProperties
   error?: boolean;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
+  stepper?: boolean;
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProperties>(
@@ -40,6 +44,7 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
       disabled = false,
       startAdornment,
       endAdornment,
+      stepper = false,
       required,
       id: idProp,
       className,
@@ -51,17 +56,126 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
     const autoId = useId();
     const id = idProp ?? autoId;
     const helperId = `${id}-helper`;
+    const [editMode, setEditMode] = useState(false);
+
+    const handleStep = (
+      direction: "up" | "down",
+      event: React.MouseEvent,
+    ): void => {
+      const current = Number(rest.value) || 0;
+      const baseStep =
+        rest.step === undefined || rest.step === "any"
+          ? 1
+          : Number(rest.step) || 1;
+      const stepSize = event.shiftKey ? baseStep * 10 : baseStep;
+      const minVal = rest.min !== undefined ? Number(rest.min) : -Infinity;
+      const maxVal = rest.max !== undefined ? Number(rest.max) : Infinity;
+      const next = direction === "up" ? current + stepSize : current - stepSize;
+      const clamped = Math.max(minVal, Math.min(maxVal, next));
+      rest.onChange?.({
+        target: { value: String(clamped) },
+      } as React.ChangeEvent<HTMLInputElement>);
+    };
 
     const controlClassName = [
       "ic-input-control",
       `${size}`,
       error && "is-error",
       disabled && "is-disabled",
-      startAdornment && "has-start",
-      endAdornment && "has-end",
+      !stepper && startAdornment && "has-start",
+      !stepper && endAdornment && "has-end",
+      stepper && "is-stepper",
     ]
       .filter(Boolean)
       .join(" ");
+
+    const inputControl = (
+      <div className={controlClassName}>
+        {stepper ? (
+          <>
+            <IconButton
+              icon={<Minus />}
+              aria-label="Decrease"
+              variant="ghost"
+              size="xs"
+              disabled={disabled}
+              className="ic-input-stepper-btn"
+              onClick={(e) => handleStep("down", e)}
+            />
+            {editMode ? (
+              <input
+                ref={ref}
+                id={id}
+                // biome-ignore lint/a11y/noAutofocus: user explicitly clicked to enter edit mode
+                autoFocus
+                disabled={disabled}
+                required={required}
+                aria-invalid={error || undefined}
+                aria-describedby={helperText ? helperId : undefined}
+                onBlur={() => setEditMode(false)}
+                onKeyDown={(e) => {
+                  e.stopPropagation();
+                  if (e.key === "Enter" || e.key === "Escape") {
+                    setEditMode(false);
+                  }
+                }}
+                onClick={(e) => e.stopPropagation()}
+                onPaste={(e) => e.stopPropagation()}
+                onCopy={(e) => e.stopPropagation()}
+                onCut={(e) => e.stopPropagation()}
+                onFocus={(e) => e.target.select()}
+                spellCheck={false}
+                {...rest}
+              />
+            ) : (
+              <button
+                type="button"
+                className="ic-input-stepper-display"
+                disabled={disabled}
+                onClick={() => setEditMode(true)}
+              >
+                <span>{rest.value}</span>
+                {endAdornment && (
+                  <span className="ic-input-stepper-unit">{endAdornment}</span>
+                )}
+              </button>
+            )}
+            <IconButton
+              icon={<Plus />}
+              aria-label="Increase"
+              variant="ghost"
+              size="xs"
+              disabled={disabled}
+              className="ic-input-stepper-btn"
+              onClick={(e) => handleStep("up", e)}
+            />
+          </>
+        ) : (
+          <>
+            {startAdornment && <span>{startAdornment}</span>}
+            <input
+              ref={ref}
+              id={id}
+              disabled={disabled}
+              required={required}
+              aria-invalid={error || undefined}
+              aria-describedby={helperText ? helperId : undefined}
+              // FIXME: the stopPropagation everywhere is because of my (Nicolás Hatcher)
+              // bad implementation of keyboard handling in the spreadsheet
+              onKeyDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+              onPaste={(e) => e.stopPropagation()}
+              onCopy={(e) => e.stopPropagation()}
+              onCut={(e) => e.stopPropagation()}
+              onFocus={(e) => e.target.select()}
+              spellCheck={false}
+              {...rest}
+            />
+            {endAdornment && <span>{endAdornment}</span>}
+          </>
+        )}
+      </div>
+    );
 
     return (
       <div
@@ -74,30 +188,7 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
           </label>
         )}
 
-        <div className={controlClassName}>
-          {startAdornment && <span>{startAdornment}</span>}
-
-          <input
-            ref={ref}
-            id={id}
-            disabled={disabled}
-            required={required}
-            aria-invalid={error || undefined}
-            aria-describedby={helperText ? helperId : undefined}
-            // FIXME: the stopPropagation everywhere is because of my (Nicolás Hatcher)
-            // bad implementation of keyboard handling in the spreadsheet
-            onKeyDown={(e) => e.stopPropagation()}
-            onClick={(e) => e.stopPropagation()}
-            onPaste={(e) => e.stopPropagation()}
-            onCopy={(e) => e.stopPropagation()}
-            onCut={(e) => e.stopPropagation()}
-            onFocus={(e) => e.target.select()}
-            spellCheck={false}
-            {...rest}
-          />
-
-          {endAdornment && <span>{endAdornment}</span>}
-        </div>
+        {inputControl}
 
         {helperText && <p id={helperId}>{helperText}</p>}
       </div>

--- a/webapp/IronCalc/src/components/Input/Input.tsx
+++ b/webapp/IronCalc/src/components/Input/Input.tsx
@@ -20,7 +20,8 @@ export type InputSize = "sm" | "md";
 
 /** Extends native `<input>` props.
  * Defaults: `size` "md".
- * Optional: `label`, `helperText`, `error`, `startAdornment`, `endAdornment`, `numberInput`.
+ * Optional: `label`, `helperText`, `error`, `startAdornment`, `endAdornment`.
+ * When `type="number"`, renders a NumberInput with [−] display [+] controls.
  */
 
 export interface InputProperties
@@ -31,7 +32,6 @@ export interface InputProperties
   error?: boolean;
   startAdornment?: ReactNode;
   endAdornment?: ReactNode;
-  numberInput?: boolean;
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProperties>(
@@ -44,7 +44,6 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
       disabled = false,
       startAdornment,
       endAdornment,
-      numberInput = false,
       required,
       id: idProp,
       className,
@@ -73,7 +72,7 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
       const next = direction === "up" ? current + stepSize : current - stepSize;
       const clamped = Math.max(minVal, Math.min(maxVal, next));
       rest.onChange?.({
-        target: { value: String(clamped) },
+        target: { value: `${clamped}` },
       } as React.ChangeEvent<HTMLInputElement>);
     };
 
@@ -82,41 +81,50 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
       `${size}`,
       error && "is-error",
       disabled && "is-disabled",
-      !numberInput && startAdornment && "has-start",
-      !numberInput && endAdornment && "has-end",
-      numberInput && "is-number-input",
+      rest.type !== "number" && startAdornment && "has-start",
+      rest.type !== "number" && endAdornment && "has-end",
+      rest.type === "number" && "is-number-input",
     ]
       .filter(Boolean)
       .join(" ");
 
     const inputControl = (
       <div className={controlClassName}>
-        {numberInput ? (
+        {rest.type === "number" ? (
           <>
             <IconButton
               icon={<Minus />}
               aria-label="Decrease"
+              type="button"
               variant="ghost"
               size="xs"
               disabled={disabled}
               className="ic-input-number-btn"
-              onClick={(e) => handleStep("down", e)}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleStep("down", e);
+              }}
             />
             {editMode ? (
               <input
                 ref={ref}
                 id={id}
-                // biome-ignore lint/a11y/noAutofocus: user explicitly clicked to enter edit mode
-                autoFocus
                 disabled={disabled}
                 required={required}
                 aria-invalid={error || undefined}
                 aria-describedby={helperText ? helperId : undefined}
+                spellCheck={false}
+                {...rest}
+                // biome-ignore lint/a11y/noAutofocus: user explicitly clicked to enter edit mode
+                autoFocus
                 onBlur={() => setEditMode(false)}
                 onKeyDown={(e) => {
                   e.stopPropagation();
-                  if (e.key === "Enter" || e.key === "Escape") {
+                  if (e.key === "Escape") {
                     setEditMode(false);
+                  } else if (e.key === "Enter") {
+                    setEditMode(false);
+                    rest.onKeyDown?.(e);
                   }
                 }}
                 onClick={(e) => e.stopPropagation()}
@@ -124,15 +132,19 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
                 onCopy={(e) => e.stopPropagation()}
                 onCut={(e) => e.stopPropagation()}
                 onFocus={(e) => e.target.select()}
-                spellCheck={false}
-                {...rest}
               />
             ) : (
               <button
                 type="button"
+                id={id}
                 className="ic-input-number-display"
                 disabled={disabled}
-                onClick={() => setEditMode(true)}
+                aria-invalid={error || undefined}
+                aria-describedby={helperText ? helperId : undefined}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setEditMode(true);
+                }}
               >
                 <span>{rest.value}</span>
                 {endAdornment && (
@@ -143,11 +155,15 @@ export const Input = forwardRef<HTMLInputElement, InputProperties>(
             <IconButton
               icon={<Plus />}
               aria-label="Increase"
+              type="button"
               variant="ghost"
               size="xs"
               disabled={disabled}
               className="ic-input-number-btn"
-              onClick={(e) => handleStep("up", e)}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleStep("up", e);
+              }}
             />
           </>
         ) : (

--- a/webapp/IronCalc/src/components/Input/input.css
+++ b/webapp/IronCalc/src/components/Input/input.css
@@ -139,19 +139,35 @@
   border-radius: 4px;
 }
 
+.ic-input-number-btn:focus-visible {
+  outline: none;
+  background-color: var(--palette-grey-100);
+}
+
 .ic-input-number-display {
   flex: 1;
+  align-self: stretch;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  border-radius: 4px;
   background: none;
   border: none;
+  margin: 3px;
+  gap: 4px;
   padding: 0;
   cursor: text;
   font-size: var(--typography-font-size);
   font-family: var(--typography-font-family);
   color: var(--palette-common-black);
+}
+
+.ic-input-number-display:focus {
+  outline: none;
+}
+
+.ic-input-number-display:focus-visible {
+  background-color: var(--palette-grey-100);
 }
 
 .ic-input-number-display:disabled {

--- a/webapp/IronCalc/src/components/Input/input.css
+++ b/webapp/IronCalc/src/components/Input/input.css
@@ -130,16 +130,16 @@
   margin-left: 6px;
 }
 
-/* Stepper variant */
-.ic-input-control.md.is-stepper {
+/* NumberInput variant */
+.ic-input-control.md.is-number-input {
   padding-inline: 3px;
 }
 
-.ic-input-stepper-btn {
+.ic-input-number-btn {
   border-radius: 4px;
 }
 
-.ic-input-stepper-display {
+.ic-input-number-display {
   flex: 1;
   display: flex;
   align-items: center;
@@ -154,23 +154,23 @@
   color: var(--palette-common-black);
 }
 
-.ic-input-stepper-display:disabled {
+.ic-input-number-display:disabled {
   cursor: not-allowed;
   color: var(--palette-grey-400);
 }
 
-.ic-input-stepper-unit {
+.ic-input-number-unit {
   color: var(--palette-grey-500);
 }
 
-.ic-input-control.is-stepper > input {
+.ic-input-control.is-number-input > input {
   flex: 1;
   text-align: center;
   appearance: textfield;
 }
 
-.ic-input-control.is-stepper > input::-webkit-outer-spin-button,
-.ic-input-control.is-stepper > input::-webkit-inner-spin-button {
+.ic-input-control.is-number-input > input::-webkit-outer-spin-button,
+.ic-input-control.is-number-input > input::-webkit-inner-spin-button {
   -webkit-appearance: none;
 }
 

--- a/webapp/IronCalc/src/components/Input/input.css
+++ b/webapp/IronCalc/src/components/Input/input.css
@@ -130,6 +130,50 @@
   margin-left: 6px;
 }
 
+/* Stepper variant */
+.ic-input-control.md.is-stepper {
+  padding-inline: 3px;
+}
+
+.ic-input-stepper-btn {
+  border-radius: 4px;
+}
+
+.ic-input-stepper-display {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: text;
+  font-size: var(--typography-font-size);
+  font-family: var(--typography-font-family);
+  color: var(--palette-common-black);
+}
+
+.ic-input-stepper-display:disabled {
+  cursor: not-allowed;
+  color: var(--palette-grey-400);
+}
+
+.ic-input-stepper-unit {
+  color: var(--palette-grey-500);
+}
+
+.ic-input-control.is-stepper > input {
+  flex: 1;
+  text-align: center;
+  appearance: textfield;
+}
+
+.ic-input-control.is-stepper > input::-webkit-outer-spin-button,
+.ic-input-control.is-stepper > input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
 /* Helper text */
 .ic-input > p {
   margin: 0;

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -830,7 +830,6 @@ const Worksheet = forwardRef(
             min: 0,
             step: "any",
             endAdornment: "px",
-            numberInput: true,
           }}
           onSubmit={(value): void => {
             const width = Number.parseFloat(value);
@@ -856,7 +855,6 @@ const Worksheet = forwardRef(
             min: 0,
             step: "any",
             endAdornment: "px",
-            numberInput: true,
           }}
           onSubmit={(value): void => {
             const height = Number.parseFloat(value);

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -830,7 +830,7 @@ const Worksheet = forwardRef(
             min: 0,
             step: "any",
             endAdornment: "px",
-            stepper: true,
+            numberInput: true,
           }}
           onSubmit={(value): void => {
             const width = Number.parseFloat(value);
@@ -856,7 +856,7 @@ const Worksheet = forwardRef(
             min: 0,
             step: "any",
             endAdornment: "px",
-            stepper: true,
+            numberInput: true,
           }}
           onSubmit={(value): void => {
             const height = Number.parseFloat(value);

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -822,8 +822,16 @@ const Worksheet = forwardRef(
           open={columnWidthDialogOpen}
           onClose={() => setColumnWidthDialogOpen(false)}
           title={t("context_menu.column_header.set_column_width")}
+          confirmLabel={t("common.apply")}
+          cancelLabel={t("common.cancel")}
           defaultValue={columnWidthDefault}
-          inputProps={{ type: "number", min: 0, step: "any" }}
+          inputProps={{
+            type: "number",
+            min: 0,
+            step: "any",
+            endAdornment: "px",
+            stepper: true,
+          }}
           onSubmit={(value): void => {
             const width = Number.parseFloat(value);
             if (!Number.isFinite(width) || width < 0) {
@@ -840,8 +848,16 @@ const Worksheet = forwardRef(
           open={rowHeightDialogOpen}
           onClose={() => setRowHeightDialogOpen(false)}
           title={t("context_menu.row_header.set_row_height")}
+          confirmLabel={t("common.apply")}
+          cancelLabel={t("common.cancel")}
           defaultValue={rowHeightDefault}
-          inputProps={{ type: "number", min: 0, step: "any" }}
+          inputProps={{
+            type: "number",
+            min: 0,
+            step: "any",
+            endAdornment: "px",
+            stepper: true,
+          }}
           onSubmit={(value): void => {
             const height = Number.parseFloat(value);
             if (!Number.isFinite(height) || height < 0) {

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -133,7 +133,7 @@
       "insert_columns_before": "{{count}} Spalte(n) links einfügen",
       "move_columns_left": "Spalten nach links verschieben",
       "move_columns_right": "Spalten nach rechts verschieben",
-      "set_column_width": "Spaltenbreite...",
+      "set_column_width": "Spaltenbreite festlegen",
       "show_hidden_columns": "Ausgeblendete Spalten einblenden",
       "unfreeze_columns": "Fixierung der Spalten aufheben"
     },
@@ -147,7 +147,7 @@
       "insert_rows_below": "{{count}} Zeile(n) unterhalb einfügen",
       "move_rows_down": "Zeilen nach unten verschieben",
       "move_rows_up": "Zeilen nach oben verschieben",
-      "set_row_height": "Zeilenhöhe...",
+      "set_row_height": "Zeilenhöhe festlegen",
       "show_hidden_rows": "Ausgeblendete Zeilen einblenden",
       "unfreeze_rows": "Fixierung der Zeilen aufheben"
     }

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -10,6 +10,10 @@
     "themed_colors": "Designfarben",
     "title": "Farbwähler"
   },
+  "common": {
+    "apply": "Anwenden",
+    "cancel": "Abbrechen"
+  },
   "conditional_formatting": {
     "add_new_rule": "Neue Regel hinzufügen",
     "apply": "Änderungen übernehmen",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -133,7 +133,7 @@
       "insert_columns_before": "Insert {{count}} column(s) left",
       "move_columns_left": "Move columns left",
       "move_columns_right": "Move columns right",
-      "set_column_width": "Column width...",
+      "set_column_width": "Set column width",
       "show_hidden_columns": "Show hidden columns",
       "unfreeze_columns": "Unfreeze columns"
     },
@@ -147,7 +147,7 @@
       "insert_rows_below": "Insert {{count}} row(s) below",
       "move_rows_down": "Move rows down",
       "move_rows_up": "Move rows up",
-      "set_row_height": "Row height...",
+      "set_row_height": "Set row height",
       "show_hidden_rows": "Show hidden rows",
       "unfreeze_rows": "Unfreeze rows"
     }

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -10,6 +10,10 @@
     "themed_colors": "Theme colors",
     "title": "Color Picker"
   },
+  "common": {
+    "apply": "Apply",
+    "cancel": "Cancel"
+  },
   "conditional_formatting": {
     "add_new_rule": "Add a new rule",
     "apply": "Apply changes",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -10,6 +10,10 @@
     "themed_colors": "Colores del tema",
     "title": "Selector de color"
   },
+  "common": {
+    "apply": "Aplicar",
+    "cancel": "Cancelar"
+  },
   "conditional_formatting": {
     "add_new_rule": "Añadir una nueva regla",
     "apply": "Aplicar cambios",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -133,7 +133,7 @@
       "insert_columns_before": "Insertar {{count}} columna(s) a la izquierda",
       "move_columns_left": "Mover columnas a la izquierda",
       "move_columns_right": "Mover columnas a la derecha",
-      "set_column_width": "Ancho de columna...",
+      "set_column_width": "Definir ancho de columna",
       "show_hidden_columns": "Mostrar columnas ocultas",
       "unfreeze_columns": "Quitar fijación de columnas"
     },
@@ -147,7 +147,7 @@
       "insert_rows_below": "Insertar {{count}} fila(s) debajo",
       "move_rows_down": "Mover filas hacia abajo",
       "move_rows_up": "Mover filas hacia arriba",
-      "set_row_height": "Alto de fila...",
+      "set_row_height": "Definir alto de fila",
       "show_hidden_rows": "Mostrar filas ocultas",
       "unfreeze_rows": "Quitar fijación de filas"
     }

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -10,6 +10,10 @@
     "themed_colors": "Couleurs du thème",
     "title": "Sélecteur de couleur"
   },
+  "common": {
+    "apply": "Appliquer",
+    "cancel": "Annuler"
+  },
   "conditional_formatting": {
     "add_new_rule": "Ajouter une nouvelle règle",
     "apply": "Appliquer les modifications",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -133,7 +133,7 @@
       "insert_columns_before": "Insérer {{count}} colonne(s) à gauche",
       "move_columns_left": "Déplacer les colonnes vers la gauche",
       "move_columns_right": "Déplacer les colonnes vers la droite",
-      "set_column_width": "Largeur de colonne...",
+      "set_column_width": "Définir la largeur de colonne",
       "show_hidden_columns": "Afficher les colonnes masquées",
       "unfreeze_columns": "Annuler le figeage des colonnes"
     },
@@ -147,7 +147,7 @@
       "insert_rows_below": "Insérer {{count}} ligne(s) en dessous",
       "move_rows_down": "Déplacer les lignes vers le bas",
       "move_rows_up": "Déplacer les lignes vers le haut",
-      "set_row_height": "Hauteur de ligne...",
+      "set_row_height": "Définir la hauteur de ligne",
       "show_hidden_rows": "Afficher les lignes masquées",
       "unfreeze_rows": "Annuler le figeage des lignes"
     }

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -10,6 +10,10 @@
     "themed_colors": "Colori del tema",
     "title": "Selettore di colore"
   },
+  "common": {
+    "apply": "Applica",
+    "cancel": "Annulla"
+  },
   "conditional_formatting": {
     "add_new_rule": "Aggiungi una nuova regola",
     "apply": "Applica modifiche",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -133,7 +133,7 @@
       "insert_columns_before": "Inserisci {{count}} colonna(e) a sinistra",
       "move_columns_left": "Sposta le colonne a sinistra",
       "move_columns_right": "Sposta le colonne a destra",
-      "set_column_width": "Larghezza colonna...",
+      "set_column_width": "Imposta larghezza colonna",
       "show_hidden_columns": "Mostra colonne nascoste",
       "unfreeze_columns": "Rimuovi blocco delle colonne"
     },
@@ -147,7 +147,7 @@
       "insert_rows_below": "Inserisci {{count}} riga(e) sotto",
       "move_rows_down": "Sposta le righe verso il basso",
       "move_rows_up": "Sposta le righe verso l’alto",
-      "set_row_height": "Altezza riga...",
+      "set_row_height": "Imposta altezza riga",
       "show_hidden_rows": "Mostra righe nascoste",
       "unfreeze_rows": "Rimuovi blocco delle righe"
     }


### PR DESCRIPTION
This PR adds a new variant to the `Input` component so it can be used in the recently added 'Set column width/row height', where we use a number field. It also updates the wording and adds a `px` indicator.

<img width="350" height="189" alt="image" src="https://github.com/user-attachments/assets/020d3213-f8bd-4942-b616-b3fbccc8a54d" />

## Changes

- Added a `numberInput` prop to the `Input` component: displays `[−] value px [+]` with ghost icon buttons inside the input border. Clicking the value area enters edit mode; blur, Enter, or Escape exits it. Shift+click increments by 10× 😁.
- Uses the new variant in the Set Column Width and Set Row Height dialogs.
- Renames dialog menu labels and CTAs across all 5 locales:
  - 'OK' → 'Apply'
  - 'Column width...' → 'Set column width'
  - 'Row height' → 'Set row height'
- Adds a `NumberInput` story to Storybook.