### PR TITLE
FIX: Formulas en CF and Named ranges are kept in English

### DIFF
--- a/base/src/conditional_formatting.rs
+++ b/base/src/conditional_formatting.rs
@@ -772,7 +772,8 @@ impl<'a> Model<'a> {
             row: anchor_row,
             column: anchor_col,
         };
-        let node = self.parser.parse(body, &context_rc);
+        // CF formulas are stored internally in English.
+        let node = self.parse_internal_formula(body, &context_rc);
 
         for &(r1, c1, r2, c2) in ranges {
             for row in r1..=r2 {
@@ -1343,16 +1344,143 @@ impl<'a> Model<'a> {
         }
     }
 
+    /// The anchor used to parse/stringify a conditional-formatting formula on
+    /// `sheet`. References round trip identically regardless of the anchor, so a
+    /// fixed A1 anchor is enough.
+    fn cf_formula_context(&self, sheet: u32) -> CellReferenceRC {
+        let sheet_name = self
+            .workbook
+            .worksheets
+            .get(sheet as usize)
+            .map(|w| w.get_name())
+            .unwrap_or_default();
+        CellReferenceRC {
+            sheet: sheet_name,
+            row: 1,
+            column: 1,
+        }
+    }
+
+    /// Translates every formula in a CF rule from the active language/locale
+    /// into the internal English representation that is stored.
+    fn cf_rule_to_internal(&mut self, rule: &mut CfRule, sheet: u32) {
+        let ctx = self.cf_formula_context(sheet);
+        match rule {
+            CfRule::CellIs {
+                formula, formula2, ..
+            } => {
+                let f = formula.clone();
+                *formula = self.user_formula_to_internal(&f, &ctx).unwrap_or(f);
+                if let Some(f2) = formula2 {
+                    let f2c = f2.clone();
+                    *f2 = self.user_formula_to_internal(&f2c, &ctx).unwrap_or(f2c);
+                }
+            }
+            CfRule::Formula { formula, .. } => {
+                let f = formula.clone();
+                *formula = self.user_formula_to_internal(&f, &ctx).unwrap_or(f);
+            }
+            CfRule::ColorScale { thresholds } => {
+                for t in thresholds {
+                    self.cfvo_to_internal(&mut t.cfvo, &ctx);
+                }
+            }
+            CfRule::DataBar { min, max, .. } => {
+                if let Some(min) = min {
+                    self.cfvo_to_internal(min, &ctx);
+                }
+                if let Some(max) = max {
+                    self.cfvo_to_internal(max, &ctx);
+                }
+            }
+            CfRule::IconSet { thresholds, .. } => {
+                for t in thresholds {
+                    self.cfvo_to_internal(&mut t.cfvo, &ctx);
+                }
+            }
+            CfRule::IconRating { thresholds, .. } => {
+                for (cfvo, _) in thresholds {
+                    self.cfvo_to_internal(cfvo, &ctx);
+                }
+            }
+            // Remaining rule kinds carry no formula strings.
+            _ => {}
+        }
+    }
+
+    fn cfvo_to_internal(&mut self, cfvo: &mut Cfvo, ctx: &CellReferenceRC) {
+        if let Cfvo::Formula(f) = cfvo {
+            let fc = f.clone();
+            *f = self.user_formula_to_internal(&fc, ctx).unwrap_or(fc);
+        }
+    }
+
+    /// Translates every formula in a CF rule from the internal English
+    /// representation into the active language/locale for display.
+    fn cf_rule_to_display(&self, rule: &mut CfRule, sheet: u32) {
+        let ctx = self.cf_formula_context(sheet);
+        match rule {
+            CfRule::CellIs {
+                formula, formula2, ..
+            } => {
+                *formula = self.internal_formula_to_display(formula, &ctx);
+                if let Some(f2) = formula2 {
+                    *f2 = self.internal_formula_to_display(f2, &ctx);
+                }
+            }
+            CfRule::Formula { formula, .. } => {
+                *formula = self.internal_formula_to_display(formula, &ctx);
+            }
+            CfRule::ColorScale { thresholds } => {
+                for t in thresholds {
+                    self.cfvo_to_display(&mut t.cfvo, &ctx);
+                }
+            }
+            CfRule::DataBar { min, max, .. } => {
+                if let Some(min) = min {
+                    self.cfvo_to_display(min, &ctx);
+                }
+                if let Some(max) = max {
+                    self.cfvo_to_display(max, &ctx);
+                }
+            }
+            CfRule::IconSet { thresholds, .. } => {
+                for t in thresholds {
+                    self.cfvo_to_display(&mut t.cfvo, &ctx);
+                }
+            }
+            CfRule::IconRating { thresholds, .. } => {
+                for (cfvo, _) in thresholds {
+                    self.cfvo_to_display(cfvo, &ctx);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn cfvo_to_display(&self, cfvo: &mut Cfvo, ctx: &CellReferenceRC) {
+        if let Cfvo::Formula(f) = cfvo {
+            *f = self.internal_formula_to_display(f, ctx);
+        }
+    }
+
     /// Returns all CF rules for the given sheet in list order.
+    ///
+    /// Formulas are stored internally in English; they are translated into the
+    /// active language/locale for display.
     pub fn get_conditional_formatting_list(
         &self,
         sheet: u32,
     ) -> Result<Vec<ConditionalFormatting>, String> {
-        Ok(self
+        let mut list = self
             .workbook
             .worksheet(sheet)?
             .conditional_formatting
-            .clone())
+            .clone();
+        for cf in &mut list {
+            self.cf_rule_to_display(&mut cf.cf_rule, sheet);
+        }
+        Ok(list)
     }
 
     /// Returns the differential format (Dxf) for the CF rule at `index` on `sheet`,
@@ -1398,7 +1526,10 @@ impl<'a> Model<'a> {
         if parse_sqref(range).is_empty() {
             return Err(format!("Invalid conditional formatting range: '{range}'"));
         }
-        let final_rule = self.cf_rule_from_input(rule);
+        let mut final_rule = self.cf_rule_from_input(rule);
+        // Formulas are stored internally in English regardless of the user's
+        // active language.
+        self.cf_rule_to_internal(&mut final_rule, sheet);
         let ws = self.workbook.worksheet_mut(sheet)?;
         let priority = ws
             .conditional_formatting
@@ -1444,7 +1575,10 @@ impl<'a> Model<'a> {
                 "Invalid conditional formatting range: '{new_range}'"
             ));
         }
-        let final_rule = self.cf_rule_from_input(new_rule);
+        let mut final_rule = self.cf_rule_from_input(new_rule);
+        // Formulas are stored internally in English regardless of the user's
+        // active language.
+        self.cf_rule_to_internal(&mut final_rule, sheet);
         let ws = self.workbook.worksheet_mut(sheet)?;
         if index >= ws.conditional_formatting.len() {
             return Err(format!(

--- a/base/src/conditional_formatting.rs
+++ b/base/src/conditional_formatting.rs
@@ -1361,58 +1361,65 @@ impl<'a> Model<'a> {
         }
     }
 
-    /// Translates every formula in a CF rule from the active language/locale
-    /// into the internal English representation that is stored.
-    fn cf_rule_to_internal(&mut self, rule: &mut CfRule, sheet: u32) {
+    /// Translates every formula in a CF rule input from the active
+    /// language/locale into the internal English representation that is stored.
+    ///
+    /// This runs before the rule is materialized (and before any dxf entry is
+    /// created), so an invalid formula fails the whole operation without leaving
+    /// behind an orphan dxf or storing a non-canonical formula that would later
+    /// fail to parse as English.
+    fn cf_rule_input_to_internal(
+        &mut self,
+        rule: &mut CfRuleInput,
+        sheet: u32,
+    ) -> Result<(), String> {
         let ctx = self.cf_formula_context(sheet);
         match rule {
-            CfRule::CellIs {
+            CfRuleInput::CellIs {
                 formula, formula2, ..
             } => {
-                let f = formula.clone();
-                *formula = self.user_formula_to_internal(&f, &ctx).unwrap_or(f);
+                *formula = self.user_formula_to_internal(formula, &ctx)?;
                 if let Some(f2) = formula2 {
-                    let f2c = f2.clone();
-                    *f2 = self.user_formula_to_internal(&f2c, &ctx).unwrap_or(f2c);
+                    *f2 = self.user_formula_to_internal(f2, &ctx)?;
                 }
             }
-            CfRule::Formula { formula, .. } => {
-                let f = formula.clone();
-                *formula = self.user_formula_to_internal(&f, &ctx).unwrap_or(f);
+            CfRuleInput::Formula { formula, .. } => {
+                *formula = self.user_formula_to_internal(formula, &ctx)?;
             }
-            CfRule::ColorScale { thresholds } => {
+            CfRuleInput::ColorScale { thresholds } => {
                 for t in thresholds {
-                    self.cfvo_to_internal(&mut t.cfvo, &ctx);
+                    self.cfvo_to_internal(&mut t.cfvo, &ctx)?;
                 }
             }
-            CfRule::DataBar { min, max, .. } => {
+            CfRuleInput::DataBar { min, max, .. } => {
                 if let Some(min) = min {
-                    self.cfvo_to_internal(min, &ctx);
+                    self.cfvo_to_internal(min, &ctx)?;
                 }
                 if let Some(max) = max {
-                    self.cfvo_to_internal(max, &ctx);
+                    self.cfvo_to_internal(max, &ctx)?;
                 }
             }
-            CfRule::IconSet { thresholds, .. } => {
+            CfRuleInput::IconSet { thresholds, .. } => {
                 for t in thresholds {
-                    self.cfvo_to_internal(&mut t.cfvo, &ctx);
+                    self.cfvo_to_internal(&mut t.cfvo, &ctx)?;
                 }
             }
-            CfRule::IconRating { thresholds, .. } => {
+            CfRuleInput::IconRating { thresholds, .. } => {
                 for (cfvo, _) in thresholds {
-                    self.cfvo_to_internal(cfvo, &ctx);
+                    self.cfvo_to_internal(cfvo, &ctx)?;
                 }
             }
             // Remaining rule kinds carry no formula strings.
             _ => {}
         }
+        Ok(())
     }
 
-    fn cfvo_to_internal(&mut self, cfvo: &mut Cfvo, ctx: &CellReferenceRC) {
+    fn cfvo_to_internal(&mut self, cfvo: &mut Cfvo, ctx: &CellReferenceRC) -> Result<(), String> {
         if let Cfvo::Formula(f) = cfvo {
-            let fc = f.clone();
-            *f = self.user_formula_to_internal(&fc, ctx).unwrap_or(fc);
+            *f = self.user_formula_to_internal(f, ctx)?;
         }
+        Ok(())
     }
 
     /// Translates every formula in a CF rule from the internal English
@@ -1526,10 +1533,12 @@ impl<'a> Model<'a> {
         if parse_sqref(range).is_empty() {
             return Err(format!("Invalid conditional formatting range: '{range}'"));
         }
-        let mut final_rule = self.cf_rule_from_input(rule);
         // Formulas are stored internally in English regardless of the user's
-        // active language.
-        self.cf_rule_to_internal(&mut final_rule, sheet);
+        // active language. Translate before materializing the rule so an invalid
+        // formula fails without creating an orphan dxf.
+        let mut rule = rule;
+        self.cf_rule_input_to_internal(&mut rule, sheet)?;
+        let final_rule = self.cf_rule_from_input(rule);
         let ws = self.workbook.worksheet_mut(sheet)?;
         let priority = ws
             .conditional_formatting
@@ -1575,10 +1584,12 @@ impl<'a> Model<'a> {
                 "Invalid conditional formatting range: '{new_range}'"
             ));
         }
-        let mut final_rule = self.cf_rule_from_input(new_rule);
         // Formulas are stored internally in English regardless of the user's
-        // active language.
-        self.cf_rule_to_internal(&mut final_rule, sheet);
+        // active language. Translate before materializing the rule so an invalid
+        // formula fails without creating an orphan dxf.
+        let mut new_rule = new_rule;
+        self.cf_rule_input_to_internal(&mut new_rule, sheet)?;
+        let final_rule = self.cf_rule_from_input(new_rule);
         let ws = self.workbook.worksheet_mut(sheet)?;
         if index >= ws.conditional_formatting.len() {
             return Err(format!(

--- a/base/src/cut_paste.rs
+++ b/base/src/cut_paste.rs
@@ -5,6 +5,8 @@ use crate::{
         types::{Area, CellReferenceRC},
         utils,
     },
+    language::get_default_language,
+    locale::get_default_locale,
     model::Model,
     utils as common,
 };
@@ -399,7 +401,8 @@ impl<'a> Model<'a> {
                 row: anchor_row,
                 column: anchor_col,
             };
-            let node = self.parser.parse(body, &cell_ref);
+            // CF formulas are stored internally in English.
+            let node = self.parse_internal_formula(body, &cell_ref);
             let new_body = move_formula(
                 &node,
                 &MoveContext {
@@ -411,8 +414,8 @@ impl<'a> Model<'a> {
                     row_delta,
                     column_delta: col_delta,
                 },
-                self.locale,
-                self.language,
+                get_default_locale(),
+                get_default_language(),
             );
             if has_eq {
                 format!("={new_body}")

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -12,8 +12,11 @@ use crate::{
         lexer::LexerMode,
         parser::{
             move_formula::{move_formula, MoveContext},
+            new_parser_english,
             static_analysis::StaticResult,
-            stringify::{rename_defined_name_in_node, to_localized_string, to_rc_format},
+            stringify::{
+                rename_defined_name_in_node, to_english_string, to_localized_string, to_rc_format,
+            },
             ArrayNode, NamedVariable, Node, Parser,
         },
         token::{get_error_by_name, Error, OpProduct, OpSum, OpUnary},
@@ -26,7 +29,7 @@ use crate::{
     },
     implicit_intersection::implicit_intersection,
     language::{get_default_language, get_language, Language},
-    locale::{get_locale, Locale},
+    locale::{get_default_locale, get_locale, Locale},
     types::*,
     utils as common,
 };
@@ -400,6 +403,94 @@ impl<'a> Model<'a> {
         }
     }
 
+    /// Parses a formula that is stored internally (always in English) and
+    /// returns the resulting node.
+    ///
+    /// Formula strings kept outside of cells (defined names and conditional
+    /// formatting rules) are always stored in English — see
+    /// [Model::user_formula_to_internal]. They must therefore be parsed with
+    /// the English language and locale regardless of the user's active
+    /// language. This temporarily switches the parser, parses, and restores it.
+    pub(crate) fn parse_internal_formula(&mut self, body: &str, context: &CellReferenceRC) -> Node {
+        let locale = self.locale;
+        let language = self.language;
+        self.parser.set_locale(get_default_locale());
+        self.parser.set_language(get_default_language());
+        let node = self.parser.parse(body, context);
+        self.parser.set_locale(locale);
+        self.parser.set_language(language);
+        node
+    }
+
+    /// Translates a formula the user typed (in the active language and locale)
+    /// into the canonical English representation that is stored internally.
+    ///
+    /// The formula is first parsed in the active language/locale. If that fails
+    /// it is parsed as English — this lets internally generated formulas (which
+    /// are already English, e.g. produced by undo/redo or cut & paste) round
+    /// trip unchanged regardless of the active language. Returns an error if the
+    /// formula parses in neither. Any leading `=` is preserved.
+    pub(crate) fn user_formula_to_internal(
+        &mut self,
+        formula: &str,
+        context: &CellReferenceRC,
+    ) -> Result<String, String> {
+        let trimmed = formula.trim();
+        let had_equals = trimmed.starts_with('=');
+        let body = trimmed.strip_prefix('=').unwrap_or(trimmed);
+        let mut node = self.parser.parse(body, context);
+        if let Node::ParseErrorKind { .. } = node {
+            // The user's language could not parse it: it might already be in the
+            // internal English form.
+            node = self.parse_internal_formula(body, context);
+        }
+        if let Node::ParseErrorKind { .. } = node {
+            return Err(format!("Invalid formula: '{formula}'"));
+        }
+        let english = to_english_string(&node, context);
+        Ok(if had_equals {
+            format!("={english}")
+        } else {
+            english
+        })
+    }
+
+    /// Translates an internally-stored (English) formula into the active
+    /// language and locale for display to the user. Any leading `=` is
+    /// preserved. If the formula fails to parse it is returned unchanged.
+    pub(crate) fn internal_formula_to_display(
+        &self,
+        formula: &str,
+        context: &CellReferenceRC,
+    ) -> String {
+        let trimmed = formula.trim();
+        let had_equals = trimmed.starts_with('=');
+        let body = trimmed.strip_prefix('=').unwrap_or(trimmed);
+        if body.is_empty() {
+            return formula.to_string();
+        }
+        // Stored formulas are in English, so parse with an English parser.
+        let worksheet_names = self
+            .workbook
+            .worksheets
+            .iter()
+            .map(|s| s.get_name())
+            .collect();
+        let defined_names = self.workbook.get_defined_names_with_scope();
+        let mut parser =
+            new_parser_english(worksheet_names, defined_names, self.workbook.tables.clone());
+        let node = parser.parse(body, context);
+        if let Node::ParseErrorKind { .. } = node {
+            return formula.to_string();
+        }
+        let local = to_localized_string(&node, context, self.locale, self.language);
+        if had_equals {
+            format!("={local}")
+        } else {
+            local
+        }
+    }
+
     /// Evaluates a formula string on a sheet, returning the numeric result.
     /// Assumes the workbook has already been evaluated (cell values are up-to-date).
     /// Returns `None` if the formula is invalid or does not produce a number.
@@ -414,7 +505,7 @@ impl<'a> Model<'a> {
             row: 1,
             column: 1,
         };
-        let node = self.parser.parse(body, &context_rc);
+        let node = self.parse_internal_formula(body, &context_rc);
         let context_index = CellReferenceIndex {
             sheet,
             row: 1,
@@ -2619,6 +2710,22 @@ impl<'a> Model<'a> {
         Err("Defined name not found".to_string())
     }
 
+    /// Returns the list of defined names as `(name, scope, formula)`.
+    ///
+    /// Formulas are stored internally in English; they are translated into the
+    /// active language/locale for display.
+    pub fn get_defined_name_list(&self) -> Vec<(String, Option<u32>, String)> {
+        let context = self.defined_name_context();
+        self.workbook
+            .get_defined_names_with_scope()
+            .into_iter()
+            .map(|(name, scope, formula)| {
+                let formula = self.internal_formula_to_display(&formula, &context);
+                (name, scope, formula)
+            })
+            .collect()
+    }
+
     /// Gets the Excel Value (Bool, Number, String) of a cell
     ///
     /// See also:
@@ -3388,14 +3495,33 @@ impl<'a> Model<'a> {
         formula: &str,
     ) -> Result<(), String> {
         let sheet_id = self.is_valid_defined_name(name, scope, formula)?;
+        // Defined-name formulas are stored internally in English so they keep
+        // working when the user switches language/locale.
+        let context = self.defined_name_context();
+        let internal_formula = self.user_formula_to_internal(formula, &context)?;
         self.workbook.defined_names.push(DefinedName {
             name: name.to_string(),
-            formula: formula.to_string(),
+            formula: internal_formula,
             sheet_id,
         });
         self.reset_parsed_structures();
 
         Ok(())
+    }
+
+    /// The context used to parse/stringify defined-name formulas. Defined names
+    /// have no natural anchor cell, so we use the first worksheet's A1.
+    fn defined_name_context(&self) -> CellReferenceRC {
+        CellReferenceRC {
+            sheet: self
+                .workbook
+                .worksheets
+                .first()
+                .map(|ws| ws.get_name())
+                .unwrap_or_else(|| "Sheet1".to_string()),
+            row: 1,
+            column: 1,
+        }
     }
 
     /// Validates if a defined name can be created
@@ -3446,7 +3572,13 @@ impl<'a> Model<'a> {
                 row: 1,
                 column: 1,
             };
-            let node = self.parser.parse(formula_body, &dummy_ref);
+            // Accept the formula whether it is written in the active language
+            // or already in the internal English form (e.g. generated by
+            // undo/redo or cut & paste).
+            let mut node = self.parser.parse(formula_body, &dummy_ref);
+            if let Node::ParseErrorKind { .. } = node {
+                node = self.parse_internal_formula(formula_body, &dummy_ref);
+            }
             if !matches!(node, Node::LambdaDefKind { .. }) {
                 return Err("Formula: Invalid defined name formula".to_string());
             }
@@ -3527,6 +3659,9 @@ impl<'a> Model<'a> {
                 index = Some(i);
             }
         }
+        // Defined-name formulas are stored internally in English.
+        let context = self.defined_name_context();
+        let internal_formula = self.user_formula_to_internal(new_formula, &context)?;
         if let Some(i) = index {
             if let Some(df) = self.workbook.defined_names.get_mut(i) {
                 if new_name != df.name {
@@ -3555,7 +3690,7 @@ impl<'a> Model<'a> {
                 }
                 df.name = new_name.to_string();
                 df.sheet_id = new_sheet_id;
-                df.formula = new_formula.to_string();
+                df.formula = internal_formula;
                 self.reset_parsed_structures();
             }
             Ok(())

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -151,7 +151,10 @@ impl<'a> Model<'a> {
                     row: 1,
                     column: 1,
                 };
-                match self.parser.parse(formula_body, &dummy_ref) {
+                // Defined-name formulas are stored internally in English, so
+                // they must be parsed with the English parser regardless of the
+                // user's active language.
+                match self.parse_internal_formula(formula_body, &dummy_ref) {
                     Node::LambdaDefKind { parameters, body } => {
                         ParsedDefinedName::LambdaDefinition(parameters, *body)
                     }

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -116,6 +116,7 @@ mod test_implicit_intersection;
 mod test_issue_155;
 mod test_issue_483;
 mod test_language;
+mod test_language_switch;
 mod test_ln;
 mod test_locale;
 mod test_log;

--- a/base/src/test/test_language_switch.rs
+++ b/base/src/test/test_language_switch.rs
@@ -1,0 +1,215 @@
+#![allow(clippy::unwrap_used, clippy::panic)]
+
+//! Formula strings stored outside of cells (conditional-formatting rules and
+//! defined names) are always stored internally in English. They are translated
+//! into the active language/locale for display and parsed from the active
+//! language/locale on input. This keeps them working when the user switches
+//! language: the stored (English) formula is unaffected, the display follows
+//! the language, and evaluation always parses the English form.
+
+use crate::{
+    cf_types::{CfRule, CfRuleInput},
+    test::util::new_empty_model,
+    types::{Color, Dxf, Fill},
+    Model,
+};
+
+fn red_fill() -> Dxf {
+    Dxf {
+        fill: Some(Fill {
+            color: Color::Rgb("#FF0000".to_string()),
+        }),
+        font: None,
+        border: None,
+        num_fmt: None,
+        alignment: None,
+    }
+}
+
+fn is_red(model: &Model<'static>, row: i32, col: i32) -> bool {
+    model
+        .get_extended_style_for_cell(0, row, col)
+        .unwrap()
+        .style
+        .fill
+        .color
+        == Color::Rgb("#FF0000".to_string())
+}
+
+/// The formula stored internally for the (single) CF rule on sheet 0.
+fn stored_cf_formula(model: &Model<'static>) -> String {
+    match &model.workbook.worksheets[0].conditional_formatting[0].cf_rule {
+        CfRule::Formula { formula, .. } => formula.clone(),
+        other => panic!("expected a Formula rule, got {other:?}"),
+    }
+}
+
+/// The formula shown to the user for the (single) CF rule on sheet 0.
+fn displayed_cf_formula(model: &Model<'static>) -> String {
+    let list = model.get_conditional_formatting_list(0).unwrap();
+    match &list[0].cf_rule {
+        CfRule::Formula { formula, .. } => formula.clone(),
+        other => panic!("expected a Formula rule, got {other:?}"),
+    }
+}
+
+fn model_with_column_a() -> Model<'static> {
+    let mut model = new_empty_model();
+    for row in 1..=10 {
+        model.set_user_input(0, row, 1, row.to_string()).unwrap();
+    }
+    model
+}
+
+// ---------------------------------------------------------------------------
+// Conditional formatting
+// ---------------------------------------------------------------------------
+
+/// A CF formula rule entered in English is stored in English, and after
+/// switching to Spanish it is displayed in Spanish but still evaluates.
+#[test]
+fn cf_formula_entered_in_english_survives_switch_to_spanish() {
+    let mut model = model_with_column_a();
+    model
+        .add_conditional_formatting(
+            0,
+            "A1:A10",
+            CfRuleInput::Formula {
+                formula: "=IF($A1>5,TRUE,FALSE)".to_string(),
+                format: red_fill(),
+                stop_if_true: false,
+            },
+        )
+        .unwrap();
+    model.evaluate();
+
+    // Stored internally in English.
+    assert_eq!(stored_cf_formula(&model), "=IF($A1>5,TRUE,FALSE)");
+    // Displayed in English (the active language).
+    assert_eq!(displayed_cf_formula(&model), "=IF($A1>5,TRUE,FALSE)");
+    for row in 6..=10 {
+        assert!(is_red(&model, row, 1), "row {row} should be red in English");
+    }
+
+    // Switch to Spanish.
+    model.set_language("es").unwrap();
+
+    // Still stored in English, but displayed in Spanish.
+    assert_eq!(stored_cf_formula(&model), "=IF($A1>5,TRUE,FALSE)");
+    assert_eq!(displayed_cf_formula(&model), "=SI($A1>5,VERDADERO,FALSO)");
+
+    // And the rule keeps highlighting the same rows.
+    model.evaluate();
+    for row in 6..=10 {
+        assert!(is_red(&model, row, 1), "row {row} should be red in Spanish");
+    }
+    for row in 1..=5 {
+        assert!(!is_red(&model, row, 1), "row {row} should not be red");
+    }
+}
+
+/// A CF formula rule entered in Spanish is stored in English (canonical) and
+/// works straight away.
+#[test]
+fn cf_formula_entered_in_spanish_is_stored_in_english() {
+    let mut model = model_with_column_a();
+    model.set_language("es").unwrap();
+
+    model
+        .add_conditional_formatting(
+            0,
+            "A1:A10",
+            CfRuleInput::Formula {
+                formula: "=SI($A1>5,VERDADERO,FALSO)".to_string(),
+                format: red_fill(),
+                stop_if_true: false,
+            },
+        )
+        .unwrap();
+    model.evaluate();
+
+    // Stored in English even though it was entered in Spanish.
+    assert_eq!(stored_cf_formula(&model), "=IF($A1>5,TRUE,FALSE)");
+    // Displayed back in Spanish.
+    assert_eq!(displayed_cf_formula(&model), "=SI($A1>5,VERDADERO,FALSO)");
+    for row in 6..=10 {
+        assert!(is_red(&model, row, 1), "row {row} should be red");
+    }
+
+    // Switching back to English shows the English form.
+    model.set_language("en").unwrap();
+    assert_eq!(displayed_cf_formula(&model), "=IF($A1>5,TRUE,FALSE)");
+    model.evaluate();
+    for row in 6..=10 {
+        assert!(is_red(&model, row, 1), "row {row} should still be red");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Defined names
+// ---------------------------------------------------------------------------
+
+/// A LAMBDA defined name entered in English is stored in English, and after
+/// switching to Spanish it is displayed in Spanish and keeps evaluating —
+/// even after an edit that forces the defined names to be reparsed.
+#[test]
+fn defined_name_lambda_entered_in_english_survives_switch_to_spanish() {
+    let mut model = new_empty_model();
+    model
+        .new_defined_name("MyIf", None, "=LAMBDA(x, IF(x>0, 1, 2))")
+        .unwrap();
+    model._set("A1", "=MyIf(5)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), *"1");
+
+    // Stored internally in English.
+    assert_eq!(
+        model.workbook.defined_names[0].formula,
+        "=LAMBDA(x,IF(x>0,1,2))"
+    );
+
+    model.set_language("es").unwrap();
+
+    // Still stored in English, displayed in Spanish.
+    assert_eq!(
+        model.workbook.defined_names[0].formula,
+        "=LAMBDA(x,IF(x>0,1,2))"
+    );
+    let names = model.get_defined_name_list();
+    assert_eq!(names[0].2, "=LAMBDA(x,SI(x>0,1,2))");
+
+    // An edit reparses the defined names; the English form must still parse.
+    model
+        .new_defined_name("Other", None, "Sheet1!$Z$1")
+        .unwrap();
+    model.evaluate();
+    assert_eq!(
+        model._get_text("A1"),
+        *"1",
+        "MyIf should still evaluate after the language switch and reparse"
+    );
+}
+
+/// A LAMBDA defined name entered in Spanish is stored in English (canonical).
+#[test]
+fn defined_name_lambda_entered_in_spanish_is_stored_in_english() {
+    let mut model = new_empty_model();
+    model.set_language("es").unwrap();
+    model
+        .new_defined_name("MiSi", None, "=LAMBDA(x, SI(x>0, 1, 2))")
+        .unwrap();
+    model._set("A1", "=MiSi(5)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), *"1");
+
+    // Stored in English even though it was entered in Spanish.
+    assert_eq!(
+        model.workbook.defined_names[0].formula,
+        "=LAMBDA(x,IF(x>0,1,2))"
+    );
+
+    // Displayed in Spanish, and in English after switching.
+    assert_eq!(model.get_defined_name_list()[0].2, "=LAMBDA(x,SI(x>0,1,2))");
+    model.set_language("en").unwrap();
+    assert_eq!(model.get_defined_name_list()[0].2, "=LAMBDA(x,IF(x>0,1,2))");
+}

--- a/base/src/test/test_language_switch.rs
+++ b/base/src/test/test_language_switch.rs
@@ -145,6 +145,25 @@ fn cf_formula_entered_in_spanish_is_stored_in_english() {
     }
 }
 
+/// An invalid CF formula is rejected rather than silently stored in a
+/// non-canonical form (which would later fail to parse as English).
+#[test]
+fn cf_invalid_formula_is_rejected() {
+    let mut model = model_with_column_a();
+    let result = model.add_conditional_formatting(
+        0,
+        "A1:A10",
+        CfRuleInput::Formula {
+            formula: "=IF(".to_string(),
+            format: red_fill(),
+            stop_if_true: false,
+        },
+    );
+    assert!(result.is_err(), "an invalid CF formula should be rejected");
+    // Nothing was stored.
+    assert!(model.get_conditional_formatting_list(0).unwrap().is_empty());
+}
+
 // ---------------------------------------------------------------------------
 // Defined names
 // ---------------------------------------------------------------------------

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -18,6 +18,7 @@ mod test_general;
 mod test_grid_lines;
 mod test_hidden_columns;
 mod test_keyboard_navigation;
+mod test_language_switch;
 mod test_last_empty_cell;
 mod test_multi_row_column;
 mod test_named_styles;

--- a/base/src/test/user_model/test_language_switch.rs
+++ b/base/src/test/user_model/test_language_switch.rs
@@ -1,0 +1,121 @@
+#![allow(clippy::unwrap_used, clippy::panic)]
+//! Regression tests for #1126 at the
+//! `UserModel` level. They make sure the undo/redo diff machinery keeps working
+//! when conditional-formatting rules and defined names are created in a
+//! non-English language: the diffs hold the internal (English) formula, so they
+//! replay correctly regardless of the active language.
+
+use crate::{
+    cf_types::{CfRule, CfRuleInput},
+    test::user_model::util::new_empty_user_model,
+    types::{Color, Dxf, Fill},
+    UserModel,
+};
+
+fn red_fill() -> Dxf {
+    Dxf {
+        fill: Some(Fill {
+            color: Color::Rgb("#FF0000".to_string()),
+        }),
+        font: None,
+        border: None,
+        num_fmt: None,
+        alignment: None,
+    }
+}
+
+fn stored_cf_formula(model: &UserModel<'static>) -> String {
+    match &model.model.workbook.worksheets[0].conditional_formatting[0].cf_rule {
+        CfRule::Formula { formula, .. } => formula.clone(),
+        other => panic!("expected a Formula rule, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Defined names
+// ---------------------------------------------------------------------------
+#[test]
+fn defined_name_created_in_spanish_undo_redo() {
+    let mut model = new_empty_user_model();
+    model.set_language("es").unwrap();
+    model
+        .new_defined_name("MiSi", None, "=LAMBDA(x, SI(x>0, 1, 2))")
+        .unwrap();
+    model.set_user_input(0, 1, 1, "=MiSi(5)").unwrap();
+    assert_eq!(model.model._get_text("A1"), *"1");
+
+    // Stored in English, displayed in Spanish.
+    assert_eq!(
+        model.model.workbook.defined_names[0].formula,
+        "=LAMBDA(x,IF(x>0,1,2))"
+    );
+    assert_eq!(model.get_defined_name_list()[0].2, "=LAMBDA(x,SI(x>0,1,2))");
+
+    // Switching language must not break undo/redo: the diff carries English.
+    model.set_language("en").unwrap();
+
+    model.undo().unwrap(); // undo the A1 = "=MiSi(5)" input
+    model.undo().unwrap(); // undo the defined-name creation
+    assert!(model.get_defined_name_list().is_empty());
+
+    model.redo().unwrap(); // redo the defined-name creation
+    assert_eq!(
+        model.model.workbook.defined_names[0].formula,
+        "=LAMBDA(x,IF(x>0,1,2))"
+    );
+    model.redo().unwrap(); // redo the A1 input
+    assert_eq!(model.model._get_text("A1"), *"1");
+}
+
+// ---------------------------------------------------------------------------
+// Conditional formatting
+// ---------------------------------------------------------------------------
+#[test]
+fn cf_formula_created_in_spanish_undo_redo() {
+    let mut model = new_empty_user_model();
+    for row in 1..=10 {
+        model.set_user_input(0, row, 1, &row.to_string()).unwrap();
+    }
+    model.set_language("es").unwrap();
+    model
+        .add_conditional_formatting(
+            0,
+            "A1:A10",
+            CfRuleInput::Formula {
+                formula: "=SI($A1>5,VERDADERO,FALSO)".to_string(),
+                format: red_fill(),
+                stop_if_true: false,
+            },
+        )
+        .unwrap();
+
+    // Stored in English, displayed in Spanish.
+    assert_eq!(stored_cf_formula(&model), "=IF($A1>5,TRUE,FALSE)");
+    let list = model.get_conditional_formatting_list(0).unwrap();
+    let CfRule::Formula { formula, .. } = &list[0].cf_rule else {
+        panic!("expected a Formula rule");
+    };
+    assert_eq!(formula, "=SI($A1>5,VERDADERO,FALSO)");
+
+    let is_red = |m: &UserModel<'static>, row: i32| {
+        m.model
+            .get_extended_style_for_cell(0, row, 1)
+            .unwrap()
+            .style
+            .fill
+            .color
+            == Color::Rgb("#FF0000".to_string())
+    };
+    assert!(is_red(&model, 10));
+
+    // Switch to English then undo/redo.
+    model.set_language("en").unwrap();
+
+    model.undo().unwrap();
+    assert!(model.get_conditional_formatting_list(0).unwrap().is_empty());
+
+    model.redo().unwrap();
+    assert_eq!(stored_cf_formula(&model), "=IF($A1>5,TRUE,FALSE)");
+    assert!(is_red(&model, 10));
+    assert!(!is_red(&model, 1));
+}

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -1952,7 +1952,7 @@ impl<'a> UserModel<'a> {
 
     /// Returns the list of defined names
     pub fn get_defined_name_list(&self) -> Vec<(String, Option<u32>, String)> {
-        self.model.workbook.get_defined_names_with_scope()
+        self.model.get_defined_name_list()
     }
 
     /// Delete an existing defined name
@@ -1977,10 +1977,16 @@ impl<'a> UserModel<'a> {
         formula: &str,
     ) -> Result<(), String> {
         self.model.new_defined_name(name, scope, formula)?;
+        // Diffs store the internal (English) formula so undo/redo replays
+        // correctly regardless of the active language at replay time.
+        let value = self
+            .model
+            .get_defined_name_formula(name, scope)
+            .unwrap_or_else(|_| formula.to_string());
         let diff_list = vec![Diff::CreateDefinedName {
             name: name.to_string(),
             scope,
-            value: formula.to_string(),
+            value,
         }];
         self.push_diff_list(diff_list);
         self.evaluate_if_not_paused();
@@ -1996,21 +2002,27 @@ impl<'a> UserModel<'a> {
         new_scope: Option<u32>,
         new_formula: &str,
     ) -> Result<(), String> {
+        // Both formulas in the diff are stored internally (in English) so
+        // undo/redo replays correctly regardless of the active language.
         let old_formula = self
             .model
             .get_defined_name_formula(name, scope)
             .map_err(|_| "General: Failed to get old name")?;
+        self.model
+            .update_defined_name(name, scope, new_name, new_scope, new_formula)?;
+        let new_formula_internal = self
+            .model
+            .get_defined_name_formula(new_name, new_scope)
+            .unwrap_or_else(|_| new_formula.to_string());
         let diff_list = vec![Diff::UpdateDefinedName {
             name: name.to_string(),
             scope,
-            old_formula: old_formula.to_string(),
+            old_formula,
             new_name: new_name.to_string(),
             new_scope,
-            new_formula: new_formula.to_string(),
+            new_formula: new_formula_internal,
         }];
         self.push_diff_list(diff_list);
-        self.model
-            .update_defined_name(name, scope, new_name, new_scope, new_formula)?;
         self.evaluate_if_not_paused();
         Ok(())
     }

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -1978,11 +1978,10 @@ impl<'a> UserModel<'a> {
     ) -> Result<(), String> {
         self.model.new_defined_name(name, scope, formula)?;
         // Diffs store the internal (English) formula so undo/redo replays
-        // correctly regardless of the active language at replay time.
-        let value = self
-            .model
-            .get_defined_name_formula(name, scope)
-            .unwrap_or_else(|_| formula.to_string());
+        // correctly regardless of the active language at replay time. A
+        // just-created name is guaranteed to be retrievable, so propagate any
+        // (unexpected) error rather than masking it with a localized formula.
+        let value = self.model.get_defined_name_formula(name, scope)?;
         let diff_list = vec![Diff::CreateDefinedName {
             name: name.to_string(),
             scope,
@@ -2010,10 +2009,9 @@ impl<'a> UserModel<'a> {
             .map_err(|_| "General: Failed to get old name")?;
         self.model
             .update_defined_name(name, scope, new_name, new_scope, new_formula)?;
-        let new_formula_internal = self
-            .model
-            .get_defined_name_formula(new_name, new_scope)
-            .unwrap_or_else(|_| new_formula.to_string());
+        // Read back the canonical (English) formula that was just stored so the
+        // diff stays canonical; a successful update guarantees it is retrievable.
+        let new_formula_internal = self.model.get_defined_name_formula(new_name, new_scope)?;
         let diff_list = vec![Diff::UpdateDefinedName {
             name: name.to_string(),
             scope,

--- a/bindings/nodejs/src/model.rs
+++ b/bindings/nodejs/src/model.rs
@@ -313,8 +313,7 @@ impl Model {
   pub fn get_defined_name_list(&'_ self, env: Env) -> Result<Unknown<'_>> {
     let data: Vec<DefinedName> = self
       .model
-      .workbook
-      .get_defined_names_with_scope()
+      .get_defined_name_list()
       .iter()
       .map(|s| DefinedName {
         name: s.0.to_owned(),


### PR DESCRIPTION
This fixes a bug where formulas in CF and name ranges are broken when switching languages. In this fix we keep the formulas always in English internally and display in the local language and locale

Fixes #1126