### PR TITLE
fix: remove webkit 

### DIFF
--- a/webapp/IronCalc/src/components/Input/input.css
+++ b/webapp/IronCalc/src/components/Input/input.css
@@ -185,6 +185,7 @@
   appearance: textfield;
 }
 
+/* Textfield alone doesn't hide spin buttons in Chrome/Safari so we need these */
 .ic-input-control.is-number-input > input::-webkit-outer-spin-button,
 .ic-input-control.is-number-input > input::-webkit-inner-spin-button {
   -webkit-appearance: none;

--- a/webapp/IronCalc/src/components/Toolbar/toolbar.css
+++ b/webapp/IronCalc/src/components/Toolbar/toolbar.css
@@ -17,11 +17,7 @@
   overflow-x: auto;
   padding: 4px 8px;
   gap: 4px;
-  scrollbar-width: none; /* Firefox */
-}
-
-.ic-toolbar-container::-webkit-scrollbar {
-  display: none; /* Chrome/Safari */
+  scrollbar-width: none;
 }
 
 /* Color line */


### PR DESCRIPTION
Partially fixes #1133 

For the number input, currently there's no way to hide the spinners without using webkit, but I've added an explanatory comment.