### PR TITLE
update: add a separator between canvas and row/col headers

### DIFF
--- a/webapp/IronCalc/src/components/WorksheetCanvas/cfRenderer.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/cfRenderer.ts
@@ -10,7 +10,7 @@ const ICON_LEFT_MARGIN = 3;
 // Border drawing helpers (extracted from WorksheetCanvas to keep it smaller)
 // ---------------------------------------------------------------------------
 
-function drawBorderLine(
+export function drawBorderLine(
   context: CanvasRenderingContext2D,
   x1: number,
   y1: number,

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -5,6 +5,7 @@ import type { Cell } from "../types";
 import type { WorkbookState } from "../workbookState";
 import {
   drawBorder,
+  drawBorderLine,
   ICON_AREA_WIDTH,
   renderDataBar,
   renderIcon,
@@ -2044,6 +2045,24 @@ export default class WorksheetCanvas {
     context.lineTo(x + headerColumnWidth, 0.5);
     context.stroke();
 
+    // Separators between the headers and the cells
+    context.strokeStyle = this.theme.headerBorderColor;
+    drawBorderLine(
+      context,
+      0,
+      headerRowHeight + 0.5,
+      this.width,
+      headerRowHeight + 0.5,
+    );
+    drawBorderLine(
+      context,
+      headerColumnWidth + 0.5,
+      0,
+      headerColumnWidth + 0.5,
+      this.height,
+    );
+
+    // Overlays drawn on top of everything else
     this.drawCellOutline();
     this.drawCellEditor();
     this.drawExtendToArea();


### PR DESCRIPTION
Fixes #1134, it'd look like this now:

<img width="799" height="350" alt="image" src="https://github.com/user-attachments/assets/b8e2db2a-c336-4a79-8ece-f241643a2dd2" />

@nhatcher please let me know if you like this approach.

