### PR TITLE
update: add a textarea component to design system

### DIFF
--- a/webapp/IronCalc/src/components/Input/input.css
+++ b/webapp/IronCalc/src/components/Input/input.css
@@ -189,6 +189,7 @@
 
 .ic-input-control.is-number-input > input {
   flex: 1;
+  padding: 0;
   text-align: center;
   appearance: textfield;
 }

--- a/webapp/IronCalc/src/components/Input/input.css
+++ b/webapp/IronCalc/src/components/Input/input.css
@@ -37,21 +37,10 @@
 /* Sizes */
 .ic-input-control.sm {
   height: 28px;
-  padding: 0 8px;
 }
 
 .ic-input-control.md {
   height: 32px;
-  padding: 0 10px;
-}
-
-/* Adjust padding when icons are present */
-.ic-input-control.has-start {
-  padding-left: 8px;
-}
-
-.ic-input-control.has-end {
-  padding-right: 8px;
 }
 
 /* States */
@@ -87,6 +76,7 @@
 /* Input */
 .ic-input-control > input {
   flex: 1;
+  align-self: stretch;
   min-width: 0;
   border: none;
   outline: none;
@@ -95,7 +85,6 @@
   font-family: var(--typography-font-family);
   font-size: var(--typography-font-size);
   font-weight: 400;
-  padding: 0;
 }
 
 .ic-input-control > input::placeholder {
@@ -105,6 +94,23 @@
 .ic-input-control > input:disabled {
   cursor: not-allowed;
   color: var(--palette-grey-400);
+}
+
+.ic-input-control.sm > input {
+  padding: 0 8px;
+}
+
+.ic-input-control.md > input {
+  padding: 0 10px;
+}
+
+/* Adjust padding when icons are present */
+.ic-input-control.has-start > input {
+  padding-left: 6px;
+}
+
+.ic-input-control.has-end > input {
+  padding-right: 6px;
 }
 
 /* Adornments */
@@ -123,11 +129,13 @@
 }
 
 .ic-input-control.has-start > span:first-child {
+  margin-left: 8px;
   margin-right: 6px;
 }
 
 .ic-input-control.has-end > span:last-child {
   margin-left: 6px;
+  margin-right: 8px;
 }
 
 /* NumberInput variant */

--- a/webapp/IronCalc/src/components/Textarea/Textarea.stories.tsx
+++ b/webapp/IronCalc/src/components/Textarea/Textarea.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { TextareaProperties } from "./Textarea";
+import { Textarea } from "./Textarea";
+
+const defaultArgs: TextareaProperties = {};
+
+const meta = {
+  title: "Components/Textarea",
+  component: Textarea,
+  parameters: {
+    layout: "centered",
+  },
+  args: defaultArgs,
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md"],
+      description: "Textarea size",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Disable the textarea",
+    },
+    error: {
+      control: "boolean",
+      description: "Error state",
+    },
+    required: {
+      control: "boolean",
+      description: "Mark field as required (appends * to label)",
+    },
+    label: {
+      control: "text",
+      description: "Label rendered above the textarea",
+    },
+    helperText: {
+      control: "text",
+      description: "Helper or error text rendered below the textarea",
+    },
+    placeholder: {
+      control: "text",
+      description: "Placeholder text",
+    },
+    rows: {
+      control: "number",
+      description: "Number of visible text lines",
+    },
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    ...defaultArgs,
+    label: "Label",
+    placeholder: "Placeholder",
+    size: "md",
+  },
+};
+
+export const AllStates: Story = {
+  args: defaultArgs,
+  render: () => (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: 16, width: 280 }}
+    >
+      <Textarea placeholder="Default" />
+      <Textarea
+        label="Complete"
+        defaultValue="Some value"
+        helperText="Helpful hint goes here."
+        required
+      />
+      <Textarea
+        label="Error"
+        defaultValue="$$bad"
+        error
+        helperText="This value is invalid."
+      />
+      <Textarea
+        label="Disabled"
+        placeholder="Cannot edit"
+        disabled
+        helperText="This field is locked."
+      />
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  args: defaultArgs,
+  render: () => (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: 12, width: 280 }}
+    >
+      <Textarea size="sm" placeholder="Small" />
+      <Textarea size="md" placeholder="Medium" />
+    </div>
+  ),
+};
+
+export const WithRows: Story = {
+  args: {
+    ...defaultArgs,
+    label: "Description",
+    placeholder: "Write something…",
+    rows: 6,
+    size: "md",
+  },
+};

--- a/webapp/IronCalc/src/components/Textarea/Textarea.tsx
+++ b/webapp/IronCalc/src/components/Textarea/Textarea.tsx
@@ -1,0 +1,97 @@
+import {
+  forwardRef,
+  type ReactNode,
+  type TextareaHTMLAttributes,
+  useId,
+} from "react";
+
+import "./textarea.css";
+
+/**
+ * Reusable multiline Textarea with optional label and helper text.
+ * Sizes: sm, md
+ * States: default, hover, focused, error, disabled.
+ */
+
+export type TextareaSize = "sm" | "md";
+
+/** Extends native `<textarea>` props.
+ * Defaults: `size` "md".
+ * Optional: `label`, `helperText`, `error`.
+ */
+
+export interface TextareaProperties
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "size"> {
+  size?: TextareaSize;
+  label?: ReactNode;
+  helperText?: ReactNode;
+  error?: boolean;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProperties>(
+  function Textarea(
+    {
+      size = "md",
+      label,
+      helperText,
+      error = false,
+      disabled = false,
+      required,
+      id: idProp,
+      className,
+      style,
+      ...rest
+    },
+    ref,
+  ) {
+    const autoId = useId();
+    const id = idProp ?? autoId;
+    const helperId = `${id}-helper`;
+
+    const controlClassName = [
+      "ic-textarea-control",
+      `${size}`,
+      error && "is-error",
+      disabled && "is-disabled",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <div
+        className={["ic-textarea", className].filter(Boolean).join(" ")}
+        style={style}
+      >
+        {label && (
+          <label htmlFor={id} data-required={required || undefined}>
+            {label}
+          </label>
+        )}
+
+        <div className={controlClassName}>
+          <textarea
+            ref={ref}
+            id={id}
+            disabled={disabled}
+            required={required}
+            aria-invalid={error || undefined}
+            aria-describedby={helperText ? helperId : undefined}
+            // FIXME: the stopPropagation everywhere is because of my (Nicolás Hatcher)
+            // bad implementation of keyboard handling in the spreadsheet
+            onKeyDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            onPaste={(e) => e.stopPropagation()}
+            onCopy={(e) => e.stopPropagation()}
+            onCut={(e) => e.stopPropagation()}
+            spellCheck={false}
+            {...rest}
+          />
+        </div>
+
+        {helperText && <p id={helperId}>{helperText}</p>}
+      </div>
+    );
+  },
+);
+
+Textarea.displayName = "Textarea";

--- a/webapp/IronCalc/src/components/Textarea/textarea.css
+++ b/webapp/IronCalc/src/components/Textarea/textarea.css
@@ -1,0 +1,117 @@
+.ic-textarea {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ic-textarea > label {
+  display: block;
+  font-size: var(--typography-font-size);
+  font-family: var(--typography-font-family);
+  font-weight: 500;
+  color: var(--palette-common-black);
+}
+
+.ic-textarea > label[data-required="true"]::after {
+  content: " *";
+  color: var(--palette-error-main);
+}
+
+.ic-textarea:has(.is-disabled) > label {
+  color: var(--palette-grey-400);
+}
+
+.ic-textarea-control {
+  position: relative;
+  display: flex;
+  box-sizing: border-box;
+  border: 1px solid var(--palette-grey-300);
+  border-radius: 6px;
+  background-color: var(--palette-common-white);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+/* States */
+.ic-textarea-control:hover:not(.is-disabled):not(.is-error) {
+  border-color: var(--palette-grey-600);
+}
+
+.ic-textarea-control:focus-within:not(.is-disabled):not(.is-error) {
+  border-color: var(--palette-primary-main);
+  border-width: 1px;
+  outline: none;
+}
+
+.ic-textarea-control:focus-within:hover:not(.is-disabled):not(.is-error) {
+  border-color: var(--palette-primary-dark);
+}
+
+.ic-textarea-control.is-error {
+  border-color: var(--palette-error-main);
+  border-width: 1px;
+}
+
+.ic-textarea-control.is-error:hover:not(.is-disabled) {
+  border-color: var(--palette-error-dark);
+}
+
+.ic-textarea-control.is-disabled {
+  background-color: var(--palette-grey-200);
+  border-color: var(--palette-grey-300);
+  cursor: not-allowed;
+}
+
+/* Textarea */
+.ic-textarea-control > textarea {
+  flex: 1;
+  min-width: 0;
+  min-height: 64px;
+  resize: vertical;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--palette-common-black);
+  font-family: var(--typography-font-family);
+  font-size: var(--typography-font-size);
+  font-weight: 400;
+  line-height: 1.4;
+}
+
+.ic-textarea-control > textarea::placeholder {
+  color: var(--palette-grey-400);
+}
+
+.ic-textarea-control > textarea:disabled {
+  cursor: not-allowed;
+  color: var(--palette-grey-400);
+}
+
+/* Padding lives on the textarea itself (not the wrapper) so the full box,
+   not just the text glyphs, is part of the textarea's clickable/focusable area. */
+.ic-textarea-control.sm > textarea {
+  padding: 6px 8px;
+}
+
+.ic-textarea-control.md > textarea {
+  padding: 8px 10px;
+}
+
+/* Helper text */
+.ic-textarea > p {
+  margin: 0;
+  padding: 0;
+  font-size: var(--typography-font-size);
+  font-family: var(--typography-font-family);
+  line-height: 1.4;
+  color: var(--palette-grey-500);
+}
+
+.ic-textarea:has(.is-error) > p {
+  color: var(--palette-error-main);
+}
+
+.ic-textarea:has(.is-disabled) > p {
+  color: var(--palette-grey-400);
+}


### PR DESCRIPTION
This PR adds a textarea component to our design system. This component is needed right now in the Named Ranges drawer but will be used in other places in the future.

<img width="1075" height="592" alt="image" src="https://github.com/user-attachments/assets/c1f0d54a-9841-4691-ba97-992353e0074c" />

### Changes

- `Textarea.tsx`: new component, sizes `sm`/`md`, label/helperText/error/disabled support
- `textarea.css`: styles match `Input`'s design
- `Textarea.stories.tsx`: Storybook story, consistent with `Input`'s

Besides, I've fixed a tiny issue in the input component, for consistency:

- `input.css`: focusing on inputs was tricky because clicking on the padding around the input text wouldn't activate focus state. I've moved horizontal padding from `.ic-input-control` onto the `<input>` itself. 

All inputs in use have been tested so there are no regressions.