### PR TITLE
update: use textarea component in Named Ranges drawer

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/EditNamedRange.tsx
@@ -6,6 +6,7 @@ import { Button } from "../../Button/Button";
 import { IconButton } from "../../Button/IconButton";
 import { Input } from "../../Input/Input";
 import { Select } from "../../Select/Select";
+import { Textarea } from "../../Textarea/Textarea";
 import { Tooltip } from "../../Tooltip/Tooltip";
 import { getFullRangeToString } from "../../util";
 import "./edit-name-range.css";
@@ -211,7 +212,7 @@ const EditNamedRange = ({
               })),
             ]}
           />
-          <Input
+          <Textarea
             label={t("name_manager_dialog.refers_to")}
             placeholder={t("name_manager_dialog.enter_formula")}
             value={formula}

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/edit-name-range.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/edit-name-range.css
@@ -88,7 +88,6 @@
 
 .ic-edit-range-range-button.ic-button {
   --button-height: 24px;
-  margin-right: -2px;
   border-radius: 3px;
 }
 

--- a/webapp/IronCalc/src/components/Textarea/Textarea.tsx
+++ b/webapp/IronCalc/src/components/Textarea/Textarea.tsx
@@ -26,6 +26,7 @@ export interface TextareaProperties
   label?: ReactNode;
   helperText?: ReactNode;
   error?: boolean;
+  endAdornment?: ReactNode;
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProperties>(
@@ -37,6 +38,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProperties>(
       error = false,
       disabled = false,
       required,
+      endAdornment,
       id: idProp,
       className,
       style,
@@ -53,6 +55,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProperties>(
       `${size}`,
       error && "is-error",
       disabled && "is-disabled",
+      endAdornment && "has-end",
     ]
       .filter(Boolean)
       .join(" ");
@@ -86,6 +89,9 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProperties>(
             spellCheck={false}
             {...rest}
           />
+          {endAdornment && (
+            <span className="ic-textarea-end-adornment">{endAdornment}</span>
+          )}
         </div>
 
         {helperText && <p id={helperId}>{helperText}</p>}

--- a/webapp/IronCalc/src/components/Textarea/textarea.css
+++ b/webapp/IronCalc/src/components/Textarea/textarea.css
@@ -98,6 +98,17 @@
   padding: 8px 10px;
 }
 
+.ic-textarea-control.has-end > textarea {
+  padding-right: 32px;
+}
+
+/* Adornment */
+.ic-textarea-end-adornment {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+}
+
 /* Helper text */
 .ic-textarea > p {
   margin: 0;


### PR DESCRIPTION
This should make easier working with long formulas in Named Ranges:

<img width="566" height="508" alt="image" src="https://github.com/user-attachments/assets/dde09bf6-919c-49dc-8f17-ba7c4bec2bed" />