### PR TITLE
fix: wrap text in CF rules reference

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
@@ -169,6 +169,9 @@
   font-size: 12px;
   color: var(--palette-grey-600);
   font-family: var(--typography-font-family);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ic-cf-list-item-icons {


### PR DESCRIPTION
Fixes #1142

Text doest't overflow anymore, we only allow 1 line.

<img width="396" height="110" alt="image" src="https://github.com/user-attachments/assets/6e8b7182-b1a6-4617-9cbb-b1efca9a758a" />