### PR TITLE
feat: the ability to redraw the canvas without throwing away UI state

### DIFF
--- a/webapp/IronCalc/src/IronCalc.tsx
+++ b/webapp/IronCalc/src/IronCalc.tsx
@@ -11,6 +11,11 @@ import { type PartialIronCalcThemeVariables, setThemeVariables } from "./theme";
 interface IronCalcProperties {
   model: Model;
   themeVariables?: PartialIronCalcThemeVariables;
+  // If we apply a mutation to the model from outside React 
+  // (e.g. applying a remote diff), we want to update the
+  // canvas without throwing away the editing state. This can
+  // be done by incrementing the externalRevision prop.
+  externalRevision?: number;
 }
 
 export interface IronCalcHandle {
@@ -18,8 +23,18 @@ export interface IronCalcHandle {
 }
 
 const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
-  ({ themeVariables, model }, ref) => {
+  ({ themeVariables, model, externalRevision = 0 }, ref) => {
     const rootRef = useRef<HTMLDivElement>(null);
+
+    // We keep the WorkbookState as a ref so that it survives re-renders
+    // of this component.
+    // But we do reset it when model identity is explicitly changed.
+    const workbookState = useRef<WorkbookState | null>(null);
+    const lastModel = useRef<Model | null>(null);
+    if (workbookState.current === null || lastModel.current !== model) {
+      workbookState.current = new WorkbookState();
+      lastModel.current = model;
+    }
 
     useEffect(() => {
       if (rootRef.current && themeVariables) {
@@ -40,7 +55,11 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
     return (
       <div ref={rootRef} className="ic-root">
         <I18nextProvider i18n={i18n}>
-          <Workbook model={model} workbookState={new WorkbookState()} />
+          <Workbook
+            model={model}
+            workbookState={workbookState.current}
+            externalRevision={externalRevision}
+          />
         </I18nextProvider>
       </div>
     );

--- a/webapp/IronCalc/src/IronCalc.tsx
+++ b/webapp/IronCalc/src/IronCalc.tsx
@@ -26,15 +26,14 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
   ({ themeVariables, model, externalRevision = 0 }, ref) => {
     const rootRef = useRef<HTMLDivElement>(null);
 
-    // We keep the WorkbookState as a ref so that it survives re-renders
-    // of this component.
-    // But we do reset it when model identity is explicitly changed.
-    const workbookState = useRef<WorkbookState | null>(null);
-    const lastModel = useRef<Model | null>(null);
-    if (workbookState.current === null || lastModel.current !== model) {
-      workbookState.current = new WorkbookState();
-      lastModel.current = model;
+    // We keep WorkbookState and the model as a ref, so that
+    // it survives re-rendering this component.
+    // We build a new WorkbookState whenever the model identity changes.
+    const workbook = useRef<{ state: WorkbookState; model: Model } | null>(null);
+    if (workbook.current === null || workbook.current.model !== model) {
+      workbook.current = { state: new WorkbookState(), model };
     }
+    const workbookState = workbook.current.state;
 
     useEffect(() => {
       if (rootRef.current && themeVariables) {
@@ -57,7 +56,7 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
         <I18nextProvider i18n={i18n}>
           <Workbook
             model={model}
-            workbookState={workbookState.current}
+            workbookState={workbookState}
             externalRevision={externalRevision}
           />
         </I18nextProvider>

--- a/webapp/IronCalc/src/IronCalc.tsx
+++ b/webapp/IronCalc/src/IronCalc.tsx
@@ -11,7 +11,7 @@ import { type PartialIronCalcThemeVariables, setThemeVariables } from "./theme";
 interface IronCalcProperties {
   model: Model;
   themeVariables?: PartialIronCalcThemeVariables;
-  // If we apply a mutation to the model from outside React 
+  // If we apply a mutation to the model from outside React
   // (e.g. applying a remote diff), we want to update the
   // canvas without throwing away the editing state. This can
   // be done by incrementing the externalRevision prop.
@@ -29,7 +29,9 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
     // We keep WorkbookState and the model as a ref, so that
     // it survives re-rendering this component.
     // We build a new WorkbookState whenever the model identity changes.
-    const workbook = useRef<{ state: WorkbookState; model: Model } | null>(null);
+    const workbook = useRef<{ state: WorkbookState; model: Model } | null>(
+      null,
+    );
     if (workbook.current === null || workbook.current.model !== model) {
       workbook.current = { state: new WorkbookState(), model };
     }

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -49,8 +49,12 @@ function colorToParam(color: Color): string {
   return `[${color[0]}, ${color[1]}]`;
 }
 
-const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
-  const { model, workbookState } = props;
+const Workbook = (props: {
+  model: Model;
+  workbookState: WorkbookState;
+  externalRevision?: number;
+}) => {
+  const { model, workbookState, externalRevision = 0 } = props;
   const { t } = useTranslation();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const worksheetRef = useRef<{
@@ -61,6 +65,13 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
   // Calling `setRedrawId((id) => id + 1);` forces a redraw
   // This is needed because `model` or `workbookState` can change without React being aware of it
   const setRedrawId = useState(0)[1];
+
+  // We also redraw if we modify the model from the outside, indicated by
+  // `externalRevision`. This way we can redraw the canvas without throwing away
+  // the editing state (which would cause edits and focus to be lost)
+  useEffect(() => {
+    setRedrawId((id) => id + 1);
+  }, [externalRevision, setRedrawId]);
 
   const [alertDialogMessage, setAlertDialogMessage] = useState<string | null>(
     null,

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -68,9 +68,15 @@ const Workbook = (props: {
 
   // We also redraw if we modify the model from the outside, indicated by
   // `externalRevision`. This way we can redraw the canvas without throwing away
-  // the editing state (which would cause edits and focus to be lost)
+  // the editing state (which would cause edits and focus to be lost).
+  // We track the previous revision so we only redraw on an actual change,
+  // not on the initial mount (where the canvas already draws on its own).
+  const previousRevision = useRef(externalRevision);
   useEffect(() => {
-    setRedrawId((id) => id + 1);
+    if (previousRevision.current !== externalRevision) {
+      previousRevision.current = externalRevision;
+      setRedrawId((id) => id + 1);
+    }
   }, [externalRevision, setRedrawId]);
 
   const [alertDialogMessage, setAlertDialogMessage] = useState<string | null>(

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -77,7 +77,7 @@ const Workbook = (props: {
       previousRevision.current = externalRevision;
       setRedrawId((id) => id + 1);
     }
-  }, [externalRevision, setRedrawId]);
+  }, [externalRevision]);
 
   const [alertDialogMessage, setAlertDialogMessage] = useState<string | null>(
     null,


### PR DESCRIPTION
We have IronCalc wrapped as a WebXDC app. WebXDC apps work peer to peer. Peers inform others about changes to the model by sending out the diffs, and peers apply these diffs to themselves.

Applying the diffs doesn't induce UI re-render in IronCalc,  so in our WebXDC app, we deliberately set a new model to trigger a  complete re-render. 

But setting a new model destroyes the focus & editor state each time a diff comes in, cause the WorkbookState gets recreated.

Here we add an `externalRevision` prop to the IronCalc component, and maintain WorkbookState as a ref. This way, by updating the `externalRevision` prop, we can make the canvas rerender without losing any UI state. The last one to commit a cell wins.

We think does not break app.ironcalc.com's multi worksheet behavior, which share the same editing state. As soon as you click to switch worksheets, the current editing state gets committed, so no bogus editing state remains. But to make sure, we ensure we reset the WorkbookState if we notice we are initialized with a different model.

We realize that this doesn't "solve" collaboration in general - you can still trigger misbehavior by structural changes like adding a row. That's a much bigger project. But it does enable many operations to happen a lot more  smoothly, and it's a small change, so that's why we propose it.