### PR TITLE
fix: sticky search bar in right drawers

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
@@ -24,7 +24,8 @@
   flex-direction: column;
   color: var(--palette-grey-700);
   line-height: 1.5;
-  overflow: auto;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .ic-cf-empty-state {
@@ -63,10 +64,12 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .ic-cf-search-container {
   height: 40px;
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   padding: 0 8px;
@@ -107,6 +110,8 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .ic-cf-list-item {

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/named-ranges.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/named-ranges.css
@@ -10,19 +10,23 @@
   flex-direction: column;
   color: var(--palette-grey-700);
   line-height: 1.5;
-  overflow: auto;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .ic-named-ranges-list-container {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .ic-named-ranges-list-body {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .ic-named-ranges-scope-filter {
@@ -56,6 +60,7 @@
 
 .ic-named-ranges-search-container {
   height: 40px;
+  flex-shrink: 0;
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
This PR fixes a regression that made the Search+Filter container in right drawers (Conditional Formatting and Named Ranges) scrollable.

`before`
<img width="402" height="152" alt="image" src="https://github.com/user-attachments/assets/459e9f24-d9e6-4999-b5b0-a9ae4eed8f7a" />

`after`
<img width="396" height="149" alt="image" src="https://github.com/user-attachments/assets/269d2369-6fa0-4ef9-8137-bfe78822bfdc" />
