### PR TITLE
update: improve list reordering in Conditional Formatting

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/ConditionalFormatting.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/ConditionalFormatting.tsx
@@ -1,6 +1,8 @@
 import type { Dxf, IronCalcTheme, Model } from "@ironcalc/wasm";
 import {
-  ArrowLeft,
+  ChevronDown,
+  ChevronLeft,
+  ChevronUp,
   PackageOpen,
   PencilLine,
   Plus,
@@ -10,6 +12,7 @@ import {
   X,
 } from "lucide-react";
 import { useState } from "react";
+import { flushSync } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../Button/Button";
 import { IconButton } from "../../Button/IconButton";
@@ -92,8 +95,7 @@ const ConditionalFormatting = ({
   const loadRules = (): Rule[] => {
     const list = model.getConditionalFormattingList(sheet);
     return list.flatMap((cf) => {
-      // The list is sorted by priority, so the rule's storage index is carried
-      // explicitly in `cf.index` rather than inferred from its position.
+      // List is priority-sorted; cf.index is the stable storage index.
       const modelIndex = cf.index;
       const partial = cfRuleToRuleData(cf);
       if (!partial) {
@@ -176,16 +178,22 @@ const ConditionalFormatting = ({
     onUpdate();
   };
 
-  // Temporary UX: double click raises a rule's priority, ctrl/cmd + double click
-  // lowers it. A proper reordering UX will replace this later.
   const handleReorder = (rule: Rule, lower: boolean) => {
     const index = parseInt(rule.id, 10);
-    if (lower) {
-      model.lowerConditionalFormattingPriority(sheet, index);
+    const applyReorder = () => {
+      if (lower) {
+        model.lowerConditionalFormattingPriority(sheet, index);
+      } else {
+        model.raiseConditionalFormattingPriority(sheet, index);
+      }
+      onUpdate();
+    };
+    // flushSync ensures the DOM is updated before the transition snapshots it.
+    if (typeof document.startViewTransition === "function") {
+      document.startViewTransition(() => flushSync(applyReorder));
     } else {
-      model.raiseConditionalFormattingPriority(sheet, index);
+      applyReorder();
     }
-    onUpdate();
   };
 
   if (isEditView) {
@@ -198,7 +206,7 @@ const ConditionalFormatting = ({
         <div className="ic-cf-edit-header">
           <Tooltip title={t("conditional_formatting.back_to_list")}>
             <IconButton
-              icon={<ArrowLeft />}
+              icon={<ChevronLeft />}
               onClick={handleCancel}
               aria-label={t("conditional_formatting.back_to_list")}
             />
@@ -407,13 +415,10 @@ const ConditionalFormatting = ({
                     <div
                       key={rule.id}
                       className={`ic-cf-list-item${isActive ? " ic-cf-list-item--selected" : ""}`}
+                      style={{ viewTransitionName: `ic-cf-rule-${rule.id}` }}
                       // biome-ignore lint/a11y/noNoninteractiveTabindex: FIXME
                       tabIndex={0}
                       onClick={() => selectRuleRange(rule)}
-                      onDoubleClick={(e) => {
-                        e.stopPropagation();
-                        handleReorder(rule, e.ctrlKey || e.metaKey);
-                      }}
                       onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") {
                           e.preventDefault();
@@ -421,7 +426,29 @@ const ConditionalFormatting = ({
                         }
                       }}
                     >
-                      <div className="ic-cf-list-item-order">{index + 1}</div>
+                      <div className="ic-cf-list-item-order-stack">
+                        <IconButton
+                          className="ic-cf-list-item-order-chevron"
+                          icon={<ChevronUp size={14} />}
+                          disabled={index === 0}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleReorder(rule, false);
+                          }}
+                          aria-label={t("conditional_formatting.move_up")}
+                        />
+                        <div className="ic-cf-list-item-order">{index + 1}</div>
+                        <IconButton
+                          className="ic-cf-list-item-order-chevron"
+                          icon={<ChevronDown size={14} />}
+                          disabled={index === filteredRules.length - 1}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleReorder(rule, true);
+                          }}
+                          aria-label={t("conditional_formatting.move_down")}
+                        />
+                      </div>
                       <div
                         className="ic-cf-list-item-preview"
                         style={

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/ConditionalFormatting.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/ConditionalFormatting.tsx
@@ -319,7 +319,7 @@ const ConditionalFormatting = ({
                   {t("conditional_formatting.no_search_results")}
                 </div>
               ) : (
-                filteredRules.map((rule) => {
+                filteredRules.map((rule, index) => {
                   const isActive = isRangeInRanges(
                     getSanitizedSelectedArea(),
                     rule.applyTo,
@@ -421,6 +421,7 @@ const ConditionalFormatting = ({
                         }
                       }}
                     >
+                      <div className="ic-cf-list-item-order">{index + 1}</div>
                       <div
                         className="ic-cf-list-item-preview"
                         style={

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/ConditionalFormatting.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/ConditionalFormatting.tsx
@@ -327,7 +327,7 @@ const ConditionalFormatting = ({
                   {t("conditional_formatting.no_search_results")}
                 </div>
               ) : (
-                filteredRules.map((rule, index) => {
+                filteredRules.map((rule) => {
                   const isActive = isRangeInRanges(
                     getSanitizedSelectedArea(),
                     rule.applyTo,
@@ -429,19 +429,21 @@ const ConditionalFormatting = ({
                       <div className="ic-cf-list-item-order-stack">
                         <IconButton
                           className="ic-cf-list-item-order-chevron"
-                          icon={<ChevronUp size={14} />}
-                          disabled={index === 0}
+                          icon={<ChevronUp />}
+                          disabled={rules[0]?.id === rule.id}
                           onClick={(e) => {
                             e.stopPropagation();
                             handleReorder(rule, false);
                           }}
                           aria-label={t("conditional_formatting.move_up")}
                         />
-                        <div className="ic-cf-list-item-order">{index + 1}</div>
+                        <div className="ic-cf-list-item-order">
+                          {rules.findIndex((r) => r.id === rule.id) + 1}
+                        </div>
                         <IconButton
                           className="ic-cf-list-item-order-chevron"
-                          icon={<ChevronDown size={14} />}
-                          disabled={index === filteredRules.length - 1}
+                          icon={<ChevronDown />}
+                          disabled={rules[rules.length - 1]?.id === rule.id}
                           onClick={(e) => {
                             e.stopPropagation();
                             handleReorder(rule, true);

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
@@ -129,26 +129,46 @@
 
 .ic-cf-list-item:hover {
   background-color: var(--palette-grey-50);
-  padding-left: 16px;
+}
+
+.ic-cf-list-item-order-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
 }
 
 .ic-cf-list-item-order {
   width: 16px;
   height: 16px;
-  border-radius: 50%;
-  background-color: var(--palette-grey-100);
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
+  font-size: var(--typography-font-size);
   font-family: var(--typography-font-family);
   color: var(--palette-grey-600);
-  transition: background-color 0.2s ease-in-out;
 }
 
-.ic-cf-list-item:hover .ic-cf-list-item-order {
+.ic-cf-list-item-order-chevron {
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  opacity: 0;
+}
+
+.ic-cf-list-item:hover .ic-cf-list-item-order-chevron {
+  opacity: 1;
+}
+
+.ic-cf-list-item-order-chevron:not(:disabled):hover {
   background-color: var(--palette-grey-300);
+}
+
+.ic-cf-list-item-order-chevron:disabled {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .ic-cf-list-item-preview {

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
@@ -156,19 +156,18 @@
   height: 16px;
   min-width: 16px;
   opacity: 0;
+  pointer-events: none;
 }
 
-.ic-cf-list-item:hover .ic-cf-list-item-order-chevron {
+.ic-cf-list-item:hover .ic-cf-list-item-order-chevron,
+.ic-cf-list-item:focus-within .ic-cf-list-item-order-chevron,
+.ic-cf-list-item--selected .ic-cf-list-item-order-chevron {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .ic-cf-list-item-order-chevron:not(:disabled):hover {
   background-color: var(--palette-grey-300);
-}
-
-.ic-cf-list-item-order-chevron:disabled {
-  opacity: 0;
-  pointer-events: none;
 }
 
 .ic-cf-list-item-preview {
@@ -219,11 +218,14 @@
   gap: 2px;
   flex-shrink: 0;
   opacity: 0;
+  pointer-events: none;
 }
 
 .ic-cf-list-item:hover .ic-cf-list-item-icons,
+.ic-cf-list-item:focus-within .ic-cf-list-item-icons,
 .ic-cf-list-item--selected .ic-cf-list-item-icons {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .ic-cf-edit-header {

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
@@ -113,7 +113,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 8px 12px;
+  padding: 8px 12px 8px 8px;
   cursor: pointer;
   height: 68px;
   box-sizing: border-box;
@@ -123,13 +123,32 @@
 }
 
 .ic-cf-list-item--selected {
-  padding-left: 20px;
+  padding-left: 16px;
   border-left: 3px solid var(--palette-primary-main);
 }
 
 .ic-cf-list-item:hover {
   background-color: var(--palette-grey-50);
-  padding-left: 20px;
+  padding-left: 16px;
+}
+
+.ic-cf-list-item-order {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: var(--palette-grey-100);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-family: var(--typography-font-family);
+  color: var(--palette-grey-600);
+  transition: background-color 0.2s ease-in-out;
+}
+
+.ic-cf-list-item:hover .ic-cf-list-item-order {
+  background-color: var(--palette-grey-300);
 }
 
 .ic-cf-list-item-preview {
@@ -179,6 +198,12 @@
   align-items: center;
   gap: 2px;
   flex-shrink: 0;
+  opacity: 0;
+}
+
+.ic-cf-list-item:hover .ic-cf-list-item-icons,
+.ic-cf-list-item--selected .ic-cf-list-item-icons {
+  opacity: 1;
 }
 
 .ic-cf-edit-header {

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -65,6 +65,8 @@
     "icon_sets_settings": "Einstellungen",
     "icon_sets_show_value": "Zellenwert anzeigen",
     "icon_sets_when_value_is": "Wenn der Wert",
+    "move_down": "Priorität verringern",
+    "move_up": "Priorität erhöhen",
     "new": "Neu hinzufügen",
     "no_search_results": "Keine Regeln entsprechen Ihrer Suche.",
     "op_begins_with": "Beginnt mit",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -65,6 +65,8 @@
     "icon_sets_settings": "Settings",
     "icon_sets_show_value": "Show cell value",
     "icon_sets_when_value_is": "When value is",
+    "move_down": "Lower priority",
+    "move_up": "Raise priority",
     "new": "Add new",
     "no_search_results": "No rules match your search.",
     "op_begins_with": "Begins With",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -65,6 +65,8 @@
     "icon_sets_settings": "Configuración",
     "icon_sets_show_value": "Mostrar valor de celda",
     "icon_sets_when_value_is": "Cuando el valor es",
+    "move_down": "Bajar prioridad",
+    "move_up": "Subir prioridad",
     "new": "Añadir nuevo",
     "no_search_results": "Ninguna regla coincide con tu búsqueda.",
     "op_begins_with": "Comienza con",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -65,6 +65,8 @@
     "icon_sets_settings": "Paramètres",
     "icon_sets_show_value": "Afficher la valeur de la cellule",
     "icon_sets_when_value_is": "Quand la valeur est",
+    "move_down": "Baisser la priorité",
+    "move_up": "Augmenter la priorité",
     "new": "Ajouter",
     "no_search_results": "Aucune règle ne correspond à votre recherche.",
     "op_begins_with": "Commence par",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -65,6 +65,8 @@
     "icon_sets_settings": "Impostazioni",
     "icon_sets_show_value": "Mostra valore cella",
     "icon_sets_when_value_is": "Quando il valore è",
+    "move_down": "Abbassa priorità",
+    "move_up": "Alza priorità",
     "new": "Aggiungi nuovo",
     "no_search_results": "Nessuna regola corrisponde alla tua ricerca.",
     "op_begins_with": "Inizia con",


### PR DESCRIPTION
This PR adds a more ux-friendly way to reorder the items in the Conditional Formatting list.

https://github.com/user-attachments/assets/ed8d948e-fe72-4403-b44c-d3dc0f920c73

### Changes

1. Added a number indicator to each item
2. Added arrow buttons to each list item. Clicking them will move them up/down
3. Hided rule actions. Now we can only see them on hover or selected
4. Removed the temporary hack (we had to double click to move up/down items)
5. Added some locale keys (used in aria labels)