### PR TITLE
fix: a few mobile-specific styling issues

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
@@ -121,6 +121,7 @@
   font-size: var(--typography-font-size);
   padding: 0 6px;
   background-color: var(--palette-common-white, #fff);
+  color: var(--palette-common-black);
   font-family: inherit;
 }
 

--- a/webapp/IronCalc/src/components/RightDrawer/rightdrawer.css
+++ b/webapp/IronCalc/src/components/RightDrawer/rightdrawer.css
@@ -63,4 +63,8 @@
   .ic-drawer-resize-handle {
     display: none;
   }
+
+  .ic-drawer-divider {
+    display: none;
+  }
 }

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
@@ -1,5 +1,5 @@
 import type { Color, Model } from "@ironcalc/wasm";
-import { Menu as MenuIcon, Plus } from "lucide-react";
+import { Menu as MenuIcon, Plus, Settings } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../Button/Button";
 import { IconButton } from "../Button/IconButton";
@@ -102,6 +102,7 @@ function SheetTabBar(props: SheetTabBarProps) {
       <div className="ic-sheet-tab-bar-right-container">
         <Tooltip title={t("regional_settings.open_regional_settings")}>
           <Button
+            className="ic-sheet-tab-bar-regional-settings-button"
             style={{ color: "var(--palette-grey-600)" }}
             variant="ghost"
             size="sm"
@@ -115,6 +116,14 @@ function SheetTabBar(props: SheetTabBarProps) {
               `regional_settings.language.display_language.${props.model.getLanguage()}`,
             )}
           </Button>
+        </Tooltip>
+        <Tooltip title={t("regional_settings.open_regional_settings")}>
+          <IconButton
+            className="ic-sheet-tab-bar-regional-settings-icon-button"
+            aria-label={t("regional_settings.open_regional_settings")}
+            icon={<Settings />}
+            onClick={props.onOpenRegionalSettings}
+          />
         </Tooltip>
       </div>
     </div>

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
@@ -103,7 +103,6 @@ function SheetTabBar(props: SheetTabBarProps) {
         <Tooltip title={t("regional_settings.open_regional_settings")}>
           <Button
             className="ic-sheet-tab-bar-regional-settings-button"
-            style={{ color: "var(--palette-grey-600)" }}
             variant="ghost"
             size="sm"
             onClick={() => {

--- a/webapp/IronCalc/src/components/SheetTabBar/sheet-tab-bar.css
+++ b/webapp/IronCalc/src/components/SheetTabBar/sheet-tab-bar.css
@@ -61,6 +61,10 @@
   background-color: var(--palette-grey-300);
 }
 
+.ic-sheet-tab-bar-regional-settings-icon-button {
+  display: none;
+}
+
 @media (max-width: 769px) {
   .ic-sheet-tab-bar-left-buttons-container {
     padding: 0 8px;
@@ -70,7 +74,16 @@
     border-right: 1px solid var(--palette-grey-200);
   }
 
-  .ic-sheet-tab-bar-right-container {
+  .ic-sheet-tab-bar-regional-settings-button {
     display: none;
+  }
+
+  .ic-sheet-tab-bar-regional-settings-icon-button {
+    display: inline-flex;
+  }
+
+  .ic-sheet-tab-bar-right-container {
+    border-left: 1px solid var(--palette-grey-200);
+    gap: 0;
   }
 }

--- a/webapp/IronCalc/src/components/SheetTabBar/sheet-tab-bar.css
+++ b/webapp/IronCalc/src/components/SheetTabBar/sheet-tab-bar.css
@@ -61,6 +61,11 @@
   background-color: var(--palette-grey-300);
 }
 
+.ic-sheet-tab-bar-regional-settings-button,
+.ic-sheet-tab-bar-regional-settings-icon-button {
+  color: var(--palette-grey-600);
+}
+
 .ic-sheet-tab-bar-regional-settings-icon-button {
   display: none;
 }

--- a/webapp/IronCalc/src/components/SheetTabBar/sheet-tab-bar.css
+++ b/webapp/IronCalc/src/components/SheetTabBar/sheet-tab-bar.css
@@ -70,6 +70,10 @@
     padding: 0 8px;
   }
 
+  .ic-sheet-tab-bar-sheets {
+    padding-left: 4px;
+  }
+
   .ic-sheet-tab-bar-vertical-divider {
     border-right: 1px solid var(--palette-grey-200);
   }

--- a/webapp/IronCalc/src/components/SheetTabBar/sheet-tab.css
+++ b/webapp/IronCalc/src/components/SheetTabBar/sheet-tab.css
@@ -99,3 +99,9 @@
   outline: none;
   border-color: var(--palette-primary-main);
 }
+
+@media (max-width: 769px) {
+  .ic-sheet-tab {
+    margin-right: 4px;
+  }
+}


### PR DESCRIPTION
This PR fixes the following issues in the mobile view:

1. **Missing Settings bar:** we're adding a Settings icon button on the bottom-right corner

<img width="504" height="50" alt="image" src="https://github.com/user-attachments/assets/e8845b2d-417c-4cd9-896a-e5cd30a5fdaf" />

2. **Reduced spacing in footer:** we gain some pixels by reducing margins and gap between tab buttons

3. **Removed double border in right drawers:** we had a visual bug that kept a double top border  in drawers on mobile

4. Fixed color in cell styles: some links were defaulting to blue [1] so we force a proper color now

---

[1]
<img width="300" height="auto" alt="IMG_7273" src="https://github.com/user-attachments/assets/d01baf64-e00d-4c89-877b-06f6c3895dc7" />
