### PR TITLE
update[app]: use an unified warning message

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/LocalStorageAlert.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/LocalStorageAlert.tsx
@@ -1,5 +1,5 @@
 import { IconButton } from "@ironcalc/workbook";
-import { CircleAlert, X } from "lucide-react";
+import { X } from "lucide-react";
 import { useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 
@@ -22,19 +22,22 @@ function LocalStorageAlert() {
 
   return (
     <div className="app-ic-drawer-alert">
-      <div className="app-ic-drawer-alert-icon">
-        <CircleAlert />
-      </div>
-      <div>
-        <h2>{t("left_drawer.alert.title")}</h2>
-        <p>{t("left_drawer.alert.subtitle")}</p>
-        <p>
-          <Trans
-            i18nKey="left_drawer.alert.subtitle2"
-            components={{ bold: <strong /> }}
-          />
-        </p>
-      </div>
+      <p>
+        <Trans
+          i18nKey="welcome_dialog.storage_warning"
+          components={{
+            warn: <strong className="app-ic-wd-storage-warning-title" />,
+            docsLink: (
+              // biome-ignore lint/a11y/useAnchorContent: content is provided by the translation
+              <a
+                href="https://docs.ironcalc.com/web-application/about.html"
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+            ),
+          }}
+        />
+      </p>
       <IconButton
         icon={<X />}
         aria-label={t("left_drawer.alert.close")}

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
@@ -190,8 +190,7 @@
 .app-ic-drawer-alert {
   position: relative;
   display: flex;
-  gap: 6px;
-  padding: 10px;
+  padding: 10px 28px 10px 10px;
   border-radius: 8px;
   border: 1px solid var(--palette-grey-300);
   background-color: color-mix(
@@ -206,31 +205,28 @@
   color: var(--palette-grey-900);
 }
 
-.app-ic-drawer-alert-icon {
-  display: flex;
-  flex-shrink: 0;
-  margin-top: 1px;
-  color: var(--palette-primary-main);
-}
-
-.app-ic-drawer-alert-icon svg,
 .app-ic-drawer-alert .ic-button svg {
   width: 12px;
   height: 12px;
-}
-
-.app-ic-drawer-alert h2 {
-  margin: 0 0 4px;
-  font-size: inherit;
-  font-weight: 600;
 }
 
 .app-ic-drawer-alert p {
   margin: 0;
 }
 
-.app-ic-drawer-alert p + p {
-  margin-top: 6px;
+.app-ic-drawer-alert a {
+  color: var(--palette-primary-main);
+  text-decoration: none;
+}
+
+.app-ic-drawer-alert a:hover {
+  text-decoration: underline;
+}
+
+.app-ic-drawer-alert a:focus-visible {
+  outline: 2px solid var(--palette-primary-main);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .app-ic-drawer-alert .ic-button {

--- a/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/StorageWarning.tsx
@@ -1,11 +1,10 @@
 import { CloudOff } from "lucide-react";
 import { type RefObject, useId, useState } from "react";
 import { createPortal } from "react-dom";
-import { useTranslation } from "react-i18next";
+import { Trans } from "react-i18next";
 import { usePopoverPosition } from "./usePopoverPosition";
 
 export function StorageWarning() {
-  const { t } = useTranslation();
   const popoverId = useId();
   const [visible, setVisible] = useState(false);
   const { triggerRef, popoverRef, position } = usePopoverPosition(visible);
@@ -39,8 +38,14 @@ export function StorageWarning() {
           data-visible={visible}
           style={position}
         >
-          {t("file_bar.title_input.warning_text1")}
-          <strong>{t("file_bar.title_input.warning_text2")}</strong>
+          <p>
+            <Trans
+              i18nKey="file_bar.cloud_warning"
+              components={{
+                warn: <strong className="app-ic-wd-storage-warning-title" />,
+              }}
+            />
+          </p>
         </div>,
         document.body,
       )}

--- a/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
@@ -42,10 +42,7 @@
 
 .app-ic-file-bar-cloud-popover-content {
   position: fixed;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  width: 240px;
+  width: 320px;
   background-color: var(--palette-common-white);
   border: 1px solid var(--palette-grey-300);
   border-radius: 8px;
@@ -60,6 +57,10 @@
   transition:
     opacity 150ms ease-out,
     visibility 0s linear 150ms;
+}
+
+.app-ic-file-bar-cloud-popover-content p {
+  margin: 0;
 }
 
 .app-ic-file-bar-cloud-popover-content[data-visible="true"] {

--- a/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/file-bar.css
@@ -43,6 +43,7 @@
 .app-ic-file-bar-cloud-popover-content {
   position: fixed;
   width: 320px;
+  max-width: calc(100vw - 16px);
   background-color: var(--palette-common-white);
   border: 1px solid var(--palette-grey-300);
   border-radius: 8px;

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -70,9 +70,6 @@
       "delete": "Arbeitsmappe löschen"
     },
     "alert": {
-      "title": "Achtung!",
-      "subtitle": "IronCalc speichert Ihre Daten nur im lokalen Speicher Ihres Browsers.",
-      "subtitle2": "<bold>Laden Sie Ihre XLSX regelmäßig herunter</bold> – zukünftige Versionen können aktuelle Arbeitsmappen möglicherweise nicht öffnen, auch wenn sie geteilt wurden.",
       "close": "Schließen"
     },
     "documentation": "Dokumentation",
@@ -86,6 +83,7 @@
   "file_bar": {
     "open_sidebar": "Seitenleiste öffnen",
     "close_sidebar": "Seitenleiste schließen",
+    "cloud_warning": "<warn>Achtung!</warn> Diese App ist ein Proof of Concept und kein fertiges Produkt. Experimentieren, teilen sowie hoch- und herunterladen Sie Modelle gerne, aber teilen oder laden Sie keine Modelle mit sensiblen oder privaten Daten hoch. Daten werden regelmäßig gelöscht.",
     "file_menu": {
       "button": "Datei",
       "new_blank_workbook": "Neue leere Arbeitsmappe",
@@ -116,10 +114,6 @@
       "about": "Über IronCalc",
       "documentation": "Dokumentation",
       "keyboard_shortcuts": "Tastaturkürzel"
-    },
-    "title_input": {
-      "warning_text1": "Diese Arbeitsmappe wird nur in Ihrem Browser gespeichert. Um sie sicher aufzubewahren, laden Sie sie als .xlsx herunter.",
-      "warning_text2": " Zukünftige Versionen könnten inkompatibel sein."
     },
     "share_popover": {
       "button": "Teilen",

--- a/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
@@ -70,9 +70,6 @@
       "delete": "Delete workbook"
     },
     "alert": {
-      "title": "Heads up!",
-      "subtitle": "IronCalc stores your data only in your browser's local storage.",
-      "subtitle2": "<bold>Download your XLSX often</bold> – future versions may not open current workbooks, even if shared.",
       "close": "Close"
     },
     "documentation": "Documentation",
@@ -86,6 +83,7 @@
   "file_bar": {
     "open_sidebar": "Open sidebar",
     "close_sidebar": "Close sidebar",
+    "cloud_warning": "<warn>Warning!</warn> This app is a proof of concept, not a finished product. Feel free to explore, share, and upload/download models, but don't share or upload models with sensitive or private data. Data will be deleted periodically.",
     "file_menu": {
       "button": "File",
       "new_blank_workbook": "New blank workbook",
@@ -116,10 +114,6 @@
       "about": "About Ironcalc",
       "documentation": "Documentation",
       "keyboard_shortcuts": "Keyboard Shortcuts"
-    },
-    "title_input": {
-      "warning_text1": "This workbook is stored only in your browser. To keep it safe, download it as .xlsx.",
-      "warning_text2": " Future versions may be incompatible."
     },
     "share_popover": {
       "button": "Share",

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -70,9 +70,6 @@
       "delete": "Eliminar libro"
     },
     "alert": {
-      "title": "Atención",
-      "subtitle": "IronCalc almacena tus datos solo en el almacenamiento local de tu navegador.",
-      "subtitle2": "<bold>Descarga tu XLSX con frecuencia</bold> – las versiones futuras podrían no abrir los libros actuales, incluso si se comparten.",
       "close": "Cerrar"
     },
     "documentation": "Documentación",
@@ -86,6 +83,7 @@
   "file_bar": {
     "open_sidebar": "Abrir barra lateral",
     "close_sidebar": "Cerrar barra lateral",
+    "cloud_warning": "<warn>¡Atención!</warn> Esta aplicación es una prueba de concepto y no un producto terminado. Siéntete libre de explorar, compartir y subir/descargar modelos, pero no compartas ni subas modelos con datos sensibles o privados. Los datos se eliminarán periódicamente.",
     "file_menu": {
       "button": "Archivo",
       "new_blank_workbook": "Nuevo libro en blanco",
@@ -116,10 +114,6 @@
       "about": "Acerca de IronCalc",
       "documentation": "Documentación",
       "keyboard_shortcuts": "Atajos de teclado"
-    },
-    "title_input": {
-      "warning_text1": "Este libro se almacena solo en tu navegador. Para mantenerlo seguro, descárgalo como .xlsx.",
-      "warning_text2": " Las versiones futuras podrían ser incompatibles."
     },
     "share_popover": {
       "button": "Compartir",

--- a/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
@@ -70,9 +70,6 @@
       "delete": "Supprimer le classeur"
     },
     "alert": {
-      "title": "Attention !",
-      "subtitle": "IronCalc stocke vos données uniquement dans le stockage local de votre navigateur.",
-      "subtitle2": "<bold>Téléchargez souvent votre XLSX</bold> – les versions futures pourraient ne pas ouvrir les classeurs actuels, même s'ils sont partagés.",
       "close": "Fermer"
     },
     "documentation": "Documentation",
@@ -86,6 +83,7 @@
   "file_bar": {
     "open_sidebar": "Ouvrir la barre latérale",
     "close_sidebar": "Fermer la barre latérale",
+    "cloud_warning": "<warn>Attention !</warn> Cette application est une preuve de concept et non un produit fini. N'hésitez pas à explorer, partager et importer/télécharger des modèles, mais ne partagez pas et n'importez pas de modèles contenant des données sensibles ou privées. Les données seront supprimées périodiquement.",
     "file_menu": {
       "button": "Fichier",
       "new_blank_workbook": "Nouveau classeur vierge",
@@ -116,10 +114,6 @@
       "about": "À propos d'IronCalc",
       "documentation": "Documentation",
       "keyboard_shortcuts": "Raccourcis clavier"
-    },
-    "title_input": {
-      "warning_text1": "Ce classeur est stocké uniquement dans votre navigateur. Pour le conserver en sécurité, téléchargez-le au format .xlsx.",
-      "warning_text2": " Les versions futures pourraient être incompatibles."
     },
     "share_popover": {
       "button": "Partager",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -70,9 +70,6 @@
       "delete": "Elimina cartella di lavoro"
     },
     "alert": {
-      "title": "Attenzione!",
-      "subtitle": "IronCalc memorizza i tuoi dati solo nella memoria locale del browser.",
-      "subtitle2": "<bold>Scarica spesso il tuo XLSX</bold> – le versioni future potrebbero non aprire le cartelle di lavoro attuali, anche se condivise.",
       "close": "Chiudi"
     },
     "documentation": "Documentazione",
@@ -86,6 +83,7 @@
   "file_bar": {
     "open_sidebar": "Apri barra laterale",
     "close_sidebar": "Chiudi barra laterale",
+    "cloud_warning": "<warn>Attenzione!</warn> Questa applicazione è una prova di concetto e non un prodotto finito. Sentiti libero di esplorare, condividere e caricare/scaricare modelli, ma non condividere o caricare modelli con dati sensibili o privati. I dati verranno eliminati periodicamente.",
     "file_menu": {
       "button": "File",
       "new_blank_workbook": "Nuova cartella di lavoro vuota",
@@ -116,10 +114,6 @@
       "about": "Informazioni su IronCalc",
       "documentation": "Documentazione",
       "keyboard_shortcuts": "Scorciatoie da tastiera"
-    },
-    "title_input": {
-      "warning_text1": "Questa cartella di lavoro è memorizzata solo nel tuo browser. Per tenerla al sicuro, scaricala come .xlsx.",
-      "warning_text2": " Le versioni future potrebbero essere incompatibili."
     },
     "share_popover": {
       "button": "Condividi",


### PR DESCRIPTION
We now use the same warning message in both Welcome Dialog, Top bar popover and Left drawer. The previous one was misleading.

<img width="381" height="140" alt="image" src="https://github.com/user-attachments/assets/73dc624d-a19c-49e1-8182-574d2fd5af11" />

<img width="449" height="336" alt="image" src="https://github.com/user-attachments/assets/732e5bc6-664c-4e2c-86bb-ec04f8d5a2cf" />

Closes #1174 

