### PR TITLE
rootContainer prop

### DIFF
--- a/webapp/IronCalc/src/IronCalc.tsx
+++ b/webapp/IronCalc/src/IronCalc.tsx
@@ -1,16 +1,21 @@
 import type { Model } from "@ironcalc/wasm";
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import { forwardRef, useEffect, useImperativeHandle } from "react";
 import { I18nextProvider } from "react-i18next";
 import Workbook from "./components/Workbook/Workbook.tsx";
 import { WorkbookState } from "./components/workbookState.ts";
 import i18n from "./i18n";
 import "./theme/theme.css";
 import "./index.css";
-import { type PartialIronCalcThemeVariables, setThemeVariables } from "./theme";
+import {
+  type PartialIronCalcThemeVariables,
+  setThemeVariables,
+  unsetThemeVariables,
+} from "./theme";
 
 interface IronCalcProperties {
   model: Model;
   themeVariables?: PartialIronCalcThemeVariables;
+  rootContainer?: HTMLElement | null;
 }
 
 export interface IronCalcHandle {
@@ -18,14 +23,22 @@ export interface IronCalcHandle {
 }
 
 const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
-  ({ themeVariables, model }, ref) => {
-    const rootRef = useRef<HTMLDivElement>(null);
+  ({ themeVariables, model, rootContainer }, ref) => {
+    const root = rootContainer ?? document.body;
+    useEffect(() => {
+      if (root.classList.contains("ic-root")) {
+        console.warn("rootContainer already in use:", root);
+      }
+      root.classList.add("ic-root");
+      return () => root.classList.remove("ic-root");
+    }, [root]);
 
     useEffect(() => {
-      if (rootRef.current && themeVariables) {
-        setThemeVariables(themeVariables, rootRef.current);
+      if (themeVariables) {
+        setThemeVariables(themeVariables, root);
+        return () => unsetThemeVariables(root);
       }
-    }, [themeVariables]);
+    }, [root, themeVariables]);
 
     useImperativeHandle(ref, () => ({
       setLanguage(language: string) {
@@ -38,7 +51,7 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
     }));
 
     return (
-      <div ref={rootRef} className="ic-root">
+      <div className="ic-widget">
         <I18nextProvider i18n={i18n}>
           <Workbook model={model} workbookState={new WorkbookState()} />
         </I18nextProvider>

--- a/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/AdvancedColorPicker.tsx
+++ b/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/AdvancedColorPicker.tsx
@@ -2,9 +2,9 @@ import { Check } from "lucide-react";
 import type { RefObject } from "react";
 import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import { HexColorInput, HexColorPicker } from "react-colorful";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "../Button/Button";
+import { createAnchoredPortal } from "../createAnchoredPortal";
 import "./advanced-color-picker.css";
 import { getFocusableElements } from "../util";
 import { useKeyDown } from "./useKeyDown";
@@ -136,7 +136,7 @@ const AdvancedColorPicker = ({
     return null;
   }
 
-  return createPortal(
+  return createAnchoredPortal(
     <div className="ic-menu-layer">
       <div className="ic-menu-backdrop" onClick={onCancel} aria-hidden="true" />
 
@@ -231,7 +231,7 @@ const AdvancedColorPicker = ({
         </div>
       </div>
     </div>,
-    document.body,
+    anchorEl.current,
   );
 };
 

--- a/webapp/IronCalc/src/components/Button/button.css
+++ b/webapp/IronCalc/src/components/Button/button.css
@@ -1,4 +1,4 @@
-:root {
+.ic-root {
   --black-04: color-mix(in srgb, var(--palette-common-black) 4%, transparent);
   --black-12: color-mix(in srgb, var(--palette-common-black) 12%, transparent);
 }

--- a/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
+++ b/webapp/IronCalc/src/components/ColorPicker/ColorPicker.tsx
@@ -3,10 +3,10 @@ import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import AdvancedColorPicker from "../AdvancedColorPicker.tsx/AdvancedColorPicker";
+import { createAnchoredPortal } from "../createAnchoredPortal";
 import { getFocusableElements } from "../util";
 import "./color-picker.css";
 import type { Color, IronCalcTheme } from "@ironcalc/wasm";
-import { createPortal } from "react-dom";
 import useAnchorPosition, { type Placement } from "./useAnchorPosition";
 import useKeyDown from "./useKeyDown";
 import {
@@ -190,7 +190,7 @@ const ColorPicker = ({
     );
   }
 
-  return createPortal(
+  return createAnchoredPortal(
     <div
       ref={panelRef}
       className="ic-color-picker"
@@ -303,7 +303,7 @@ const ColorPicker = ({
         </div>
       </div>
     </div>,
-    document.body,
+    anchorEl.current,
   );
 };
 

--- a/webapp/IronCalc/src/components/IconPicker/IconPicker.tsx
+++ b/webapp/IronCalc/src/components/IconPicker/IconPicker.tsx
@@ -21,7 +21,7 @@ import {
   X,
 } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { createAnchoredPortal } from "../createAnchoredPortal";
 import "./icon-picker.css";
 
 // Ordered list of all available icons for cycling.
@@ -130,7 +130,7 @@ const IconPicker = ({ value, color, onChange }: IconPickerProps) => {
         />
       </button>
       {open &&
-        createPortal(
+        createAnchoredPortal(
           <div
             ref={panelRef}
             className="ic-icon-picker-panel"
@@ -151,7 +151,7 @@ const IconPicker = ({ value, color, onChange }: IconPickerProps) => {
               </button>
             ))}
           </div>,
-          document.body,
+          buttonRef.current,
         )}
     </>
   );

--- a/webapp/IronCalc/src/components/Menu/Menu.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.tsx
@@ -9,8 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { createPortal } from "react-dom";
-
+import { createAnchoredPortal } from "../createAnchoredPortal";
 import "./menu.css";
 import { useAnchorPosition } from "./useAnchorPosition";
 import { useMenuKeyDown } from "./useMenuKeyDown";
@@ -44,6 +43,9 @@ export type MenuProperties = MenuTriggerProperties | MenuControlledProperties;
 
 export function Menu(props: MenuProperties) {
   const isTriggerMode = props.trigger !== undefined;
+  const [portalAnchor, setPortalAnchor] = useState<HTMLSpanElement | null>(
+    null,
+  );
 
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const open = isTriggerMode ? uncontrolledOpen : props.open;
@@ -122,7 +124,7 @@ export function Menu(props: MenuProperties) {
   }, [open, menuRef]);
 
   const menu = open
-    ? createPortal(
+    ? createAnchoredPortal(
         <div
           ref={menuRef}
           role="presentation"
@@ -133,13 +135,14 @@ export function Menu(props: MenuProperties) {
             {props.children}
           </div>
         </div>,
-        document.body,
+        portalAnchor,
       )
     : null;
 
   if (!isTriggerMode) {
     return (
       <MenuContext.Provider value={{ close, activeSetOpenRef }}>
+        <span ref={setPortalAnchor} hidden />
         {menu}
       </MenuContext.Provider>
     );
@@ -163,6 +166,7 @@ export function Menu(props: MenuProperties) {
   return (
     <MenuContext.Provider value={{ close, activeSetOpenRef }}>
       {clonedTrigger}
+      <span ref={setPortalAnchor} hidden />
       {menu}
     </MenuContext.Provider>
   );

--- a/webapp/IronCalc/src/components/Menu/MenuItem.tsx
+++ b/webapp/IronCalc/src/components/Menu/MenuItem.tsx
@@ -1,6 +1,6 @@
 import { Check, ChevronRight } from "lucide-react";
 import { type ReactNode, useContext, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { createAnchoredPortal } from "../createAnchoredPortal";
 import { MenuContext } from "./Menu";
 import { useAnchorPosition } from "./useAnchorPosition";
 import { useMenuKeyDown } from "./useMenuKeyDown";
@@ -203,7 +203,7 @@ export function MenuItemWithSubmenu({
       </button>
 
       {open
-        ? createPortal(
+        ? createAnchoredPortal(
             <MenuContext.Provider
               value={{
                 close: closeAll,
@@ -230,7 +230,7 @@ export function MenuItemWithSubmenu({
                 </div>
               </div>
             </MenuContext.Provider>,
-            document.body,
+            itemRef.current,
           )
         : null}
     </>

--- a/webapp/IronCalc/src/components/Modal/ModalDialog.tsx
+++ b/webapp/IronCalc/src/components/Modal/ModalDialog.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEventHandler, ReactNode, RefObject } from "react";
-import { createPortal } from "react-dom";
+import { useState } from "react";
+import { createAnchoredPortal } from "../createAnchoredPortal";
 
 interface ModalDialogProperties {
   modalRef: RefObject<HTMLDivElement | null>;
@@ -18,27 +19,36 @@ export function ModalDialog({
   className,
   children,
 }: ModalDialogProperties) {
-  return createPortal(
-    <div
-      className="ic-modal-dialog-backdrop"
-      onClick={onClose}
-      // HACK: prevents the workbook from stealing focus while the modal is open
-      onPointerDown={(event) => event.stopPropagation()}
-      role="none"
-    >
-      <div
-        ref={modalRef}
-        className={["ic-modal-dialog", className].filter(Boolean).join(" ")}
-        onClick={(event) => event.stopPropagation()}
-        onKeyDown={onKeyDown}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        tabIndex={-1}
-      >
-        {children}
-      </div>
-    </div>,
-    document.body,
+  const [portalAnchor, setPortalAnchor] = useState<HTMLSpanElement | null>(
+    null,
+  );
+
+  return (
+    <>
+      <span ref={setPortalAnchor} hidden />
+      {createAnchoredPortal(
+        <div
+          className="ic-modal-dialog-backdrop"
+          onClick={onClose}
+          // HACK: prevents the workbook from stealing focus while the modal is open
+          onPointerDown={(event) => event.stopPropagation()}
+          role="none"
+        >
+          <div
+            ref={modalRef}
+            className={["ic-modal-dialog", className].filter(Boolean).join(" ")}
+            onClick={(event) => event.stopPropagation()}
+            onKeyDown={onKeyDown}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            tabIndex={-1}
+          >
+            {children}
+          </div>
+        </div>,
+        portalAnchor,
+      )}
+    </>
   );
 }

--- a/webapp/IronCalc/src/components/Select/Select.tsx
+++ b/webapp/IronCalc/src/components/Select/Select.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { createPortal } from "react-dom";
+import { createAnchoredPortal } from "../createAnchoredPortal";
 
 import "./select.css";
 import "./dropdown-menu.css";
@@ -338,7 +338,7 @@ export function Select({
         </button>
 
         {open
-          ? createPortal(
+          ? createAnchoredPortal(
               <div
                 ref={menuRef}
                 className="ic-dropdown-menu-wrapper"
@@ -391,7 +391,7 @@ export function Select({
                   })}
                 </div>
               </div>,
-              document.body,
+              rootRef.current,
             )
           : null}
       </div>

--- a/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
+++ b/webapp/IronCalc/src/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useId, useState } from "react";
-import { createPortal } from "react-dom";
 
+import { createAnchoredPortal } from "../createAnchoredPortal";
 import "./tooltip.css";
 import { useTooltipPosition } from "./useTooltipPosition";
 
@@ -47,7 +47,7 @@ export function Tooltip({ title, children }: TooltipProperties) {
         {children}
       </span>
 
-      {createPortal(
+      {createAnchoredPortal(
         <div
           ref={tooltipRef}
           id={tooltipId}
@@ -58,7 +58,7 @@ export function Tooltip({ title, children }: TooltipProperties) {
         >
           {title}
         </div>,
-        document.body,
+        triggerRef.current,
       )}
     </>
   );

--- a/webapp/IronCalc/src/components/Workbook/Workbook.stories.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.stories.tsx
@@ -45,6 +45,7 @@ function WorkbookWithInit() {
   }
   return (
     <div
+      className="ic-widget"
       style={{
         position: "absolute",
         top: 0,

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -122,7 +122,8 @@ const Worksheet = forwardRef(
         !extendTo ||
         !scrollElement.current ||
         !editor ||
-        !arrayStructure
+        !arrayStructure ||
+        !canvasRef.closest(".ic-root")
       ) {
         return;
       }

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -125,7 +125,10 @@ export default class WorksheetCanvas {
     this.editor = options.elements.editor;
     this.refresh = options.refresh;
 
-    const rootRef = this.canvas.closest(".ic-root") ?? document.documentElement;
+    const rootRef = this.canvas.closest(".ic-root");
+    if (!rootRef) {
+      throw new Error("WorksheetCanvas must be rendered within an .ic-root");
+    }
     this.theme = readThemeFromCSS(rootRef);
 
     this.cellOutline = options.elements.cellOutline;

--- a/webapp/IronCalc/src/components/createAnchoredPortal.ts
+++ b/webapp/IronCalc/src/components/createAnchoredPortal.ts
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Portals into the nearest `.ic-root` ancestor of `anchor` or renders nothing if there is none.
+ */
+export function createAnchoredPortal(
+  children: ReactNode,
+  anchor: Element | null | undefined,
+) {
+  const container = anchor?.closest<HTMLElement>(".ic-root");
+  return container ? createPortal(children, container) : null;
+}

--- a/webapp/IronCalc/src/index.css
+++ b/webapp/IronCalc/src/index.css
@@ -1,4 +1,4 @@
-.ic-root {
+.ic-widget {
   --formula-bar-height: 40px;
   --navigation-height: 40px;
   --toolbar-height: 40px;

--- a/webapp/IronCalc/src/theme/index.ts
+++ b/webapp/IronCalc/src/theme/index.ts
@@ -1,5 +1,6 @@
 export {
   defaultThemeVariables,
   setThemeVariables,
+  unsetThemeVariables,
 } from "./theme";
 export type { PartialIronCalcThemeVariables } from "./themeVariables";

--- a/webapp/IronCalc/src/theme/theme.css
+++ b/webapp/IronCalc/src/theme/theme.css
@@ -1,4 +1,4 @@
-:root {
+.ic-root {
   /* typography */
   --typography-font-family: "Inter";
   --typography-font-size: 12px;

--- a/webapp/IronCalc/src/theme/theme.ts
+++ b/webapp/IronCalc/src/theme/theme.ts
@@ -87,3 +87,11 @@ export function setThemeVariables(
     }
   }
 }
+
+export function unsetThemeVariables(
+  target: HTMLElement = document.documentElement,
+): void {
+  for (const name of Object.keys(defaultThemeVariables)) {
+    target.style.removeProperty(name);
+  }
+}


### PR DESCRIPTION
Replacement for #871. It solves basically the same issues but in a different way: there is now a `rootContainer` concept, tied to the repurposed `.ic-root` class, which is an element within which both the widget and the modals are to be mounted. It defaults to `document.body` and can be specified as a property on the widget. This provides more flexibility for embedding IronCalc, eg. in a shadow DOM.

Notes:
- `.ic-root` no longer points to the widget; a new `.ic-widget` class is introduced for that purpose instead.
- The default CSS theme variables no longer select on`:root` but on `.ic-root` instead.
- `createAnchoredPortal` is a new helper function that finds the closest `.ic-root` parent node from an anchor element. 
- Portals and the worksheet canvas don't render while the root element is not found, which may be the case during the initial render.