### PR TITLE
fix[app]: pin/unpin/duplicate not refreshing the workbook list instantly

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/useWorkbookMenu.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/useWorkbookMenu.ts
@@ -18,6 +18,7 @@ export function useWorkbookMenu({ setModel, onDelete }: Options) {
   const [intendedSelection, setIntendedSelection] = useState<string | null>(
     null,
   );
+  const [, forceRefresh] = useState(0);
 
   const selectedUuid = getSelectedUuid();
 
@@ -65,11 +66,13 @@ export function useWorkbookMenu({ setModel, onDelete }: Options) {
   const handlePinToggle = (uuid: string) => {
     togglePinWorkbook(uuid);
     setIntendedSelection(null);
+    forceRefresh((n) => n + 1);
   };
 
   const handleDuplicate = (uuid: string) => {
     duplicateModel(uuid);
     setIntendedSelection(null);
+    forceRefresh((n) => n + 1);
   };
 
   return {


### PR DESCRIPTION
Pinning, unpinning and duplicating a workbook wasn't showing immediately, only after some unrelated UI interaction.