### PR TITLE
fix: reduce font size to 12px in worksheet, editor, and color picker

### DIFF
--- a/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/advanced-color-picker.css
+++ b/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/advanced-color-picker.css
@@ -83,7 +83,7 @@
 
 .ic-advanced-color-picker-hash-label {
   margin: auto 0 auto 10px;
-  font-size: 13px;
+  font-size: 12px;
   color: var(--palette-grey-900);
   font-family: var(--typography-font-family);
 }

--- a/webapp/IronCalc/src/components/Editor/Editor.tsx
+++ b/webapp/IronCalc/src/components/Editor/Editor.tsx
@@ -207,7 +207,7 @@ const Editor = (options: EditorOptions) => {
           display: showEditor,
           background: "#FFF",
           fontFamily: "var(--palette-sheet-default-cell-font-family)",
-          fontSize: "13px",
+          fontSize: "12px",
         }}
       >
         <div

--- a/webapp/IronCalc/src/components/Worksheet/worksheet.css
+++ b/webapp/IronCalc/src/components/Worksheet/worksheet.css
@@ -130,7 +130,7 @@
   border: 2px solid var(--palette-sheet-outline-color);
   border-radius: 3px;
   word-break: break-word;
-  font-size: 13px;
+  font-size: 12px;
   display: flex;
   box-shadow: inset 0 0 0 1px var(--palette-common-white);
 }


### PR DESCRIPTION
This PR standardizes font size from 13px to 12px across three components, for visual consistency:

- AdvancedColorPicker hash label
- Cell Editor input
- Worksheet cell rendering