### PR TITLE
update: formula helper improvements

### DIFF
--- a/webapp/IronCalc/src/components/Editor/Editor.tsx
+++ b/webapp/IronCalc/src/components/Editor/Editor.tsx
@@ -270,7 +270,9 @@ const Editor = (options: EditorOptions) => {
   }, [showHelper, text, cursor]);
 
   // Replace the partial function name with `NAME(` and place the caret inside.
-  const acceptHelperFunction = () => {
+  // Takes an explicit index (rather than always reading `helperSelected`) so a
+  // click can accept the row it lands on without waiting on a state update.
+  const acceptHelperFunction = (index: number = helperSelected) => {
     const textarea = textareaRef.current;
     if (!textarea || completion?.kind !== "list") {
       return;
@@ -279,7 +281,7 @@ const Editor = (options: EditorOptions) => {
       textarea.value,
       textarea.selectionStart,
       completion,
-      helperSelected,
+      index,
     );
     textarea.value = result.text;
     textarea.setSelectionRange(result.cursor, result.cursor);
@@ -440,6 +442,7 @@ const Editor = (options: EditorOptions) => {
                 completion={completion}
                 selected={helperSelected}
                 onSelect={setHelperSelected}
+                onAccept={acceptHelperFunction}
               />
             </div>,
             textareaRef.current,

--- a/webapp/IronCalc/src/components/Editor/Editor.tsx
+++ b/webapp/IronCalc/src/components/Editor/Editor.tsx
@@ -270,8 +270,7 @@ const Editor = (options: EditorOptions) => {
   }, [showHelper, text, cursor]);
 
   // Replace the partial function name with `NAME(` and place the caret inside.
-  // Takes an explicit index (rather than always reading `helperSelected`) so a
-  // click can accept the row it lands on without waiting on a state update.
+  // Takes an explicit index so a row click can accept the row it lands on directly.
   const acceptHelperFunction = (index: number = helperSelected) => {
     const textarea = textareaRef.current;
     if (!textarea || completion?.kind !== "list") {

--- a/webapp/IronCalc/src/components/FormulaHelper/FormulaHelper.stories.tsx
+++ b/webapp/IronCalc/src/components/FormulaHelper/FormulaHelper.stories.tsx
@@ -52,10 +52,16 @@ function FormulaHelperPlayground() {
   };
 
   return (
-    <div style={{ padding: 40, width: 520 }}>
-      <p style={{ color: "#6a6a6a", fontSize: 13 }}>
-        Type a formula, e.g. <code>=SU</code> or <code>=SUMIF(</code>. Use ↑/↓
-        and Enter in the list.
+    <div style={{ width: 320 }}>
+      <p
+        style={{
+          color: "var(--palette-grey-700)",
+          fontSize: "var(--typography-font-size)",
+          fontFamily: "var(--typography-font-family)",
+        }}
+      >
+        Type a formula, e.g. <code>=SU</code> or <code>=SUMIF(</code>.<br />
+        Use ↑/↓ and Enter in the list.
       </p>
       <div style={{ position: "relative" }}>
         <input
@@ -87,14 +93,14 @@ function FormulaHelperPlayground() {
             }
           }}
           style={{
-            width: "100%",
+            width: 140,
             boxSizing: "border-box",
-            padding: "8px 10px",
-            fontSize: 15,
-            fontFamily: "ui-monospace, Menlo, Consolas, monospace",
-            border: "2px solid #f5a623",
-            borderRadius: 4,
-            outline: "none",
+            padding: "8px",
+            fontSize: "var(--typography-font-size)",
+            fontFamily: "var(--typography-font-family)",
+            border: "2px solid var(--palette-primary-main)",
+            outline:
+              "3px solid color-mix(in srgb, var(--palette-primary-main) 20%, transparent)",
           }}
         />
         {completion ? (
@@ -118,7 +124,7 @@ const meta = {
   title: "Components/FormulaHelper",
   component: FormulaHelperPlayground,
   parameters: {
-    layout: "fullscreen",
+    layout: "centered",
   },
 } satisfies Meta<typeof FormulaHelperPlayground>;
 

--- a/webapp/IronCalc/src/components/FormulaHelper/FormulaHelper.stories.tsx
+++ b/webapp/IronCalc/src/components/FormulaHelper/FormulaHelper.stories.tsx
@@ -37,12 +37,12 @@ function FormulaHelperPlayground() {
     : null;
 
   // Accept the highlighted function: replace the partial name with `NAME(`.
-  const accept = () => {
+  const accept = (index: number = selected) => {
     const input = inputRef.current;
     if (!input || completion?.kind !== "list") {
       return;
     }
-    const result = applyListCompletion(text, cursor, completion, selected);
+    const result = applyListCompletion(text, cursor, completion, index);
     setText(result.text);
     setSelected(0);
     requestAnimationFrame(() => {
@@ -105,6 +105,7 @@ function FormulaHelperPlayground() {
               completion={completion}
               selected={selected}
               onSelect={setSelected}
+              onAccept={accept}
             />
           </div>
         ) : null}

--- a/webapp/IronCalc/src/components/FormulaHelper/FormulaHelper.tsx
+++ b/webapp/IronCalc/src/components/FormulaHelper/FormulaHelper.tsx
@@ -10,13 +10,15 @@
 // either the mouse (hover) or the keyboard (arrow keys). See the editor
 // integration in Editor.tsx and the standalone demo in FormulaHelper.stories.
 
-import { BookOpen, ChevronUp } from "lucide-react";
+import { ChevronUp } from "lucide-react";
 import {
   Fragment,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
+  useCallback,
   useState,
 } from "react";
+import { IconButton } from "../Button/IconButton";
 import {
   type Completion,
   displayArgName,
@@ -93,6 +95,12 @@ function FunctionList({
   onAccept: (index: number) => void;
 }) {
   const clamped = Math.min(Math.max(selected, 0), matches.length - 1);
+
+  // Fires whenever the selected button changes, scrolling it into view.
+  const scrollSelectedIntoView = useCallback((el: HTMLButtonElement | null) => {
+    el?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, []);
+
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: only swallows events so editing isn't interrupted
     // biome-ignore lint/a11y/useKeyWithClickEvents: not user-interactive; stops propagation only
@@ -108,6 +116,7 @@ function FunctionList({
           <button
             type="button"
             key={name}
+            ref={isSelected ? scrollSelectedIntoView : undefined}
             className={`ic-fh-list-item${isSelected ? " ic-fh-selected" : ""}`}
             onMouseEnter={() => onSelect(index)}
             onClick={() => onAccept(index)}
@@ -173,19 +182,35 @@ function FunctionDetail({
             ))}
             {" )"}
           </div>
-          <div className="ic-fh-desc">{info.description}</div>
+          {collapsed ? null : (
+            <div className="ic-fh-desc">
+              {info.description}
+              {url ? (
+                <a
+                  className="ic-fh-link"
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Read more
+                </a>
+              ) : null}
+            </div>
+          )}
         </div>
-        <button
-          type="button"
-          className="ic-fh-icon-btn"
+        <IconButton
+          icon={
+            <ChevronUp
+              size={16}
+              style={{ transform: collapsed ? "rotate(180deg)" : undefined }}
+            />
+          }
+          aria-label={collapsed ? "Expand" : "Collapse"}
           title={collapsed ? "Expand" : "Collapse"}
+          size="xs"
+          className="ic-fh-collapse-btn"
           onClick={() => setCollapsed((value) => !value)}
-        >
-          <ChevronUp
-            size={16}
-            style={{ transform: collapsed ? "rotate(180deg)" : undefined }}
-          />
-        </button>
+        />
       </div>
 
       {collapsed || info.examples.length === 0 ? null : (
@@ -196,15 +221,6 @@ function FunctionDetail({
               {example}
             </div>
           ))}
-        </div>
-      )}
-
-      {collapsed || !url ? null : (
-        <div className="ic-fh-footer">
-          <a className="ic-fh-link" href={url} target="_blank" rel="noreferrer">
-            <BookOpen size={15} />
-            Learn more about {name}
-          </a>
         </div>
       )}
     </div>

--- a/webapp/IronCalc/src/components/FormulaHelper/FormulaHelper.tsx
+++ b/webapp/IronCalc/src/components/FormulaHelper/FormulaHelper.tsx
@@ -47,12 +47,15 @@ interface FormulaHelperProps {
   selected: number;
   // Called when a row is hovered, so the parent can update `selected`.
   onSelect: (index: number) => void;
+  // Called when a row is clicked, to accept that row's completion.
+  onAccept: (index: number) => void;
 }
 
 export function FormulaHelper({
   completion,
   selected,
   onSelect,
+  onAccept,
 }: FormulaHelperProps) {
   if (!completion) {
     return null;
@@ -64,6 +67,7 @@ export function FormulaHelper({
         prefix={completion.prefix}
         selected={selected}
         onSelect={onSelect}
+        onAccept={onAccept}
       />
     );
   }
@@ -80,11 +84,13 @@ function FunctionList({
   prefix,
   selected,
   onSelect,
+  onAccept,
 }: {
   matches: string[];
   prefix: string;
   selected: number;
   onSelect: (index: number) => void;
+  onAccept: (index: number) => void;
 }) {
   const clamped = Math.min(Math.max(selected, 0), matches.length - 1);
   return (
@@ -104,6 +110,7 @@ function FunctionList({
             key={name}
             className={`ic-fh-list-item${isSelected ? " ic-fh-selected" : ""}`}
             onMouseEnter={() => onSelect(index)}
+            onClick={() => onAccept(index)}
           >
             <span className="ic-fh-name">
               <span className="ic-fh-name-match">{prefix}</span>

--- a/webapp/IronCalc/src/components/FormulaHelper/formulaHelper.css
+++ b/webapp/IronCalc/src/components/FormulaHelper/formulaHelper.css
@@ -2,12 +2,6 @@
    design mockup (orange accent, function list + signature/docs card). */
 
 .ic-fh {
-  --ic-fh-orange: var(--palette-primary-main);
-  --ic-fh-orange-bg: color-mix(
-    in srgb,
-    var(--palette-primary-main) 20%,
-    transparent
-  );
   font-family: var(--typography-font-family);
   width: 320px;
   max-width: 90vw;
@@ -105,7 +99,7 @@
 }
 
 .ic-fh-arg-active {
-  background: var(--ic-fh-orange-bg);
+  background: color-mix(in srgb, var(--palette-primary-main) 20%, transparent);
   color: var(--palette-common-black);
   border-radius: 3px;
   padding: 1px 3px;

--- a/webapp/IronCalc/src/components/FormulaHelper/formulaHelper.css
+++ b/webapp/IronCalc/src/components/FormulaHelper/formulaHelper.css
@@ -2,19 +2,21 @@
    design mockup (orange accent, function list + signature/docs card). */
 
 .ic-fh {
-  --ic-fh-orange: #f5a623;
-  --ic-fh-orange-bg: #fbe4cd;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
-    sans-serif;
+  --ic-fh-orange: var(--palette-primary-main);
+  --ic-fh-orange-bg: color-mix(
+    in srgb,
+    var(--palette-primary-main) 20%,
+    transparent
+  );
+  font-family: var(--typography-font-family);
   width: 320px;
   max-width: 90vw;
-  background: #ffffff;
-  border: 1px solid #e6e6e6;
+  background: var(--palette-common-white);
+  border: 1px solid var(--palette-grey-300);
   border-radius: 6px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
-  font-size: 13px;
-  color: #21243d;
+  box-shadow: var(--shadow-md);
+  font-size: var(--typography-font-size);
+  color: var(--palette-common-black);
   overflow: hidden;
 }
 
@@ -23,41 +25,46 @@
 .ic-fh-list {
   max-height: 320px;
   overflow-y: auto;
-  padding: 4px 0;
+  padding: 4px;
+  scroll-padding-block: 4px;
 }
 
 .ic-fh-list-item {
   display: block;
   width: 100%;
   text-align: left;
-  padding: 5px 16px;
+  padding: 8px;
+  border-radius: 4px;
   cursor: pointer;
   border: none;
   background: transparent;
   font: inherit;
-  color: inherit;
+  color: var(--palette-common-black);
+  outline: none;
 }
 
 .ic-fh-list-item.ic-fh-selected {
-  background: #f3f3f3;
+  background: var(--palette-grey-50);
 }
 
 .ic-fh-name {
   font-weight: 400;
-  color: #21243d;
+  color: var(--palette-common-black);
 }
 
 /* The portion of the name that matches what the user has typed so far. */
 .ic-fh-name-match {
   text-decoration: underline;
+  text-underline-offset: 3px;
+  line-height: 1.4;
 }
 
 .ic-fh-list-desc {
   display: block;
-  color: #8a8a8a;
-  font-size: 12px;
-  line-height: 1.35;
-  margin-top: 2px;
+  color: var(--palette-grey-600);
+  font-size: var(--typography-font-size);
+  line-height: 1.4;
+  margin-top: 4px;
 }
 
 /* ---------- Function detail (e.g. "=SUM(") ---------- */
@@ -66,7 +73,11 @@
   display: flex;
   align-items: flex-start;
   gap: 8px;
-  padding: 12px 14px 10px;
+  padding: 12px;
+}
+
+.ic-fh-collapse-btn {
+  margin: -4px -4px -4px 0;
 }
 
 .ic-fh-header-main {
@@ -75,84 +86,64 @@
 }
 
 .ic-fh-signature {
-  font-size: 14px;
-  line-height: 1.5;
-  color: #8a8a8a;
+  font-size: var(--typography-font-size);
+  line-height: 1.4;
+  color: var(--palette-grey-600);
 }
 
 .ic-fh-fn-name {
   font-weight: 700;
-  color: #21243d;
+  color: var(--palette-common-black);
 }
 
 .ic-fh-comma {
-  color: #8a8a8a;
+  color: var(--palette-grey-600);
 }
 
 .ic-fh-arg {
-  color: #8a8a8a;
+  color: var(--palette-grey-600);
 }
 
 .ic-fh-arg-active {
   background: var(--ic-fh-orange-bg);
-  color: #21243d;
+  color: var(--palette-common-black);
   border-radius: 3px;
   padding: 1px 3px;
 }
 
 .ic-fh-desc {
-  margin-top: 6px;
-  color: #6a6a6a;
+  margin-top: 4px;
+  font-size: var(--typography-font-size);
+  color: var(--palette-grey-700);
   line-height: 1.4;
 }
 
-.ic-fh-icon-btn {
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  color: #8a8a8a;
-  padding: 2px;
-  display: inline-flex;
-  border-radius: 4px;
-  flex: 0 0 auto;
-}
-
-.ic-fh-icon-btn:hover {
-  background: #f0f0f0;
-}
-
 .ic-fh-body {
-  padding: 0 14px 10px;
+  padding: 12px;
+  border-top: 1px solid var(--palette-grey-200);
 }
 
 .ic-fh-examples-label {
-  color: #8a8a8a;
-  font-size: 12px;
+  color: var(--palette-grey-600);
+  font-size: calc(var(--typography-font-size) - 1px);
   margin-bottom: 4px;
 }
 
 .ic-fh-example {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  color: #21243d;
-  line-height: 1.5;
-}
-
-.ic-fh-footer {
-  display: flex;
-  padding: 9px 14px;
-  border-top: 1px solid #efefef;
+  font-family: var(--typography-font-family);
+  color: var(--palette-common-black);
+  line-height: 1.4;
 }
 
 .ic-fh-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: #21243d;
-  font-size: 12px;
+  margin-left: 4px;
+  color: var(--palette-primary-main);
+  font-size: inherit;
   cursor: pointer;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .ic-fh-link:hover {
-  color: var(--ic-fh-orange);
+  text-decoration: underline;
 }


### PR DESCRIPTION
This PR polishes a bunch of cosmetic bugs in the new formula helper, and adds a couple of UX improvements.

### Changes

1. List rows in the formula helper can now be selected with a mouse click (not just arrow keys + Enter/Tab).
2. The selected row now scrolls into view during keyboard navigation.
3. The function detail card's collapse/expand toggle now uses the `IconButton` component.
4. The description text is now hidden when the card is collapsed.
5. Moved the "Read more" link to right after the description text.
6. `formulaHelper.css` no longer has any hardcoded colors.
7. Some minor cosmetic changes in the Storybook story.

---

Missing from this PR, will be done soon:
- There are a still bunch of visual bugs in the formula editor, we can tackle them after as they need more testing
- We need to fix some layout issues when the helper is too close from the edges
- We should fire the formula helper when we start typing with `+`. At the moment we only do it with `=`