### PR TITLE
FIX: Cursor hint was shown too often

### DIFF
--- a/base/src/expressions/parser/mod.rs
+++ b/base/src/expressions/parser/mod.rs
@@ -908,15 +908,21 @@ impl<'a> Parser<'a> {
                     if let Err(err) = self.lexer.expect(TokenType::RightParenthesis) {
                         // `SUM(A1` parses a complete argument and then fails to
                         // find the `)`. If we ran out of input we are still
-                        // inside the call, so keep the argument completion hint.
+                        // inside the call, sitting right after a complete
+                        // argument: report the (correct) argument index so the
+                        // signature tooltip works, but NOT `Range` — a fresh
+                        // reference cannot begin after a complete operand. (A
+                        // separator or `)` is what is expected here.)
                         let at_eof = err.position >= self.lexer.get_formula().chars().count();
+                        let expecting = if at_eof {
+                            let index = (args.len() as u32).max(1);
+                            vec![ExpectedTokens::Argument(display_name.clone(), index)]
+                        } else {
+                            vec![ExpectedTokens::Other]
+                        };
                         return Node::ParseErrorKind {
                             formula: self.lexer.get_formula(),
-                            expecting: if at_eof {
-                                self.expecting_here.clone()
-                            } else {
-                                vec![ExpectedTokens::Other]
-                            },
+                            expecting,
                             position: err.position,
                             message: err.message,
                         };
@@ -1354,8 +1360,11 @@ impl<'a> Parser<'a> {
         Ok(args)
     }
 
-    /// Records that the position currently being parsed is argument `index`
-    /// (1-based) of `fn_name`, so an EOF there reports useful completions.
+    /// Records that the position currently being parsed *starts* argument
+    /// `index` (1-based) of `fn_name`: a fresh operand goes here, so a `Range`
+    /// is a valid completion. Reported if an EOF lands on this empty slot (e.g.
+    /// `SUM(` or `SUM(A1,`). Once the argument is complete the unclosed-call
+    /// path in `parse_primary` reports the argument context without `Range`.
     fn set_argument_hint(&mut self, fn_name: &str, index: u32) {
         self.expecting_here = vec![
             ExpectedTokens::Argument(fn_name.to_string(), index),

--- a/base/src/expressions/parser/tests/test_partial_parsing.rs
+++ b/base/src/expressions/parser/tests/test_partial_parsing.rs
@@ -289,3 +289,85 @@ fn escaped_quotes_inside_string_stay_open() {
     let ctx = complete_at_end("SUM(\"say \"\"hi\"\"");
     assert_eq!(ctx.expecting, vec![ExpectedTokens::Other]);
 }
+
+// ---------------------------------------------------------------------------
+// (f) A completed operand inside an OPEN call is not a place where a fresh
+//     reference can start. A bare cell (`A1`) can still grow into a range
+//     (`A1:B2`), so offering `Range` there is fine — but an operand that ends
+//     in `)` (a nested call) or a finished range (`A1:B2`) cannot be extended,
+//     so `Range` must NOT be offered. At the top level the parser already gets
+//     this right (see the `A1+SUM(A3)|` / `A1:B2|` cases below); inside an open
+//     call it wrongly keeps offering `Range`.
+//
+//     These pin the Rust-side cause of the editor showing an "insert reference"
+//     hint at `=SUM(A1, SUM(A3)|)`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn completed_nested_call_in_argument_does_not_expect_range() {
+    // SUM(A1, SUM(A3)|)  → the second argument already holds a complete call;
+    // the next token can only be an operator / `,` / `)`, never a range.
+    let ctx = complete_at("SUM(A1, SUM(A3))", 15);
+    assert!(
+        !ctx.expecting.contains(&ExpectedTokens::Range),
+        "got {:?}",
+        ctx.expecting
+    );
+}
+
+#[test]
+fn completed_range_in_argument_does_not_expect_range() {
+    // SUM(A1:B2|)  → the argument is a finished range; nothing new starts here.
+    let ctx = complete_at("SUM(A1:B2)", 9);
+    assert!(
+        !ctx.expecting.contains(&ExpectedTokens::Range),
+        "got {:?}",
+        ctx.expecting
+    );
+}
+
+#[test]
+fn top_level_completed_call_does_not_expect_range() {
+    // A1+SUM(A3)|  → for contrast, the top level already handles this correctly:
+    // after a complete operand no range is offered.
+    let ctx = complete_at("A1+SUM(A3)", 10);
+    assert!(
+        !ctx.expecting.contains(&ExpectedTokens::Range),
+        "got {:?}",
+        ctx.expecting
+    );
+}
+
+#[test]
+fn dangling_operator_after_a_completed_call_expects_a_range() {
+    // 1+2*SUM(I3:J6, N13:O15+SUM(L12:L13)*|  → the trailing `*` needs a fresh
+    // operand, so a range is a valid completion even though the operator follows
+    // a completed nested call. Dropping the argument's `Range` hint on
+    // completion must not swallow this.
+    let ctx = complete_at_end("1+2*SUM(I3:J6,N13:O15+SUM(L12:L13)*");
+    assert!(
+        ctx.expecting.contains(&ExpectedTokens::Range),
+        "got {:?}",
+        ctx.expecting
+    );
+}
+
+#[test]
+fn nested_call_in_argument_keeps_the_outer_argument_index() {
+    // SUM(A1, SUM(A3)|)  → the cursor is in the SECOND argument of the outer
+    // SUM. A nested call in that argument must not leak its own inner index: we
+    // should report argument 2, not 1.
+    let ctx = complete_at("SUM(A1, SUM(A3))", 15);
+    assert!(
+        ctx.expecting
+            .contains(&ExpectedTokens::Argument("SUM".to_string(), 2)),
+        "got {:?}",
+        ctx.expecting
+    );
+    assert!(
+        !ctx.expecting
+            .contains(&ExpectedTokens::Argument("SUM".to_string(), 1)),
+        "got {:?}",
+        ctx.expecting
+    );
+}

--- a/webapp/IronCalc/src/components/Editor/util.tsx
+++ b/webapp/IronCalc/src/components/Editor/util.tsx
@@ -34,6 +34,30 @@ function isDynamicAnchor(
   return typeof structure === "object" && "DynamicAnchor" in structure;
 }
 
+// A token that begins an operand: a value, a name/function, a reference/range,
+// or an opening delimiter of a grouped expression or array. When such a token
+// sits right after the caret there is already an operand there, so the caret is
+// not in an empty slot and the reference-insertion hint must not be shown (e.g.
+// `=|SUM(...)`, where the function name follows the caret).
+function tokenStartsOperand(token: TokenType): boolean {
+  if (typeof token === "object") {
+    return (
+      "Ident" in token ||
+      "Number" in token ||
+      "String" in token ||
+      "Boolean" in token ||
+      "Reference" in token ||
+      "Range" in token
+    );
+  }
+  return token === "LeftParenthesis" || token === "LeftBrace";
+}
+
+// The argument separator tokens (`,` in English locales, `;` otherwise).
+function tokenIsArgumentSeparator(token: TokenType): boolean {
+  return token === "Comma" || token === "Semicolon";
+}
+
 // Returns true when the cursor sits at a position where the formula grammar
 // would accept a reference or range, so that arrow keys / clicking a cell can
 // insert one. This asks the engine for a partial parse of the formula up to the
@@ -167,11 +191,22 @@ function getFormulaHTML(
       const isReference = tokenIsReferenceType(token);
       const isRange = tokenIsRangeType(token);
 
-      // Insert the hint right before the first token that begins at/after the
-      // caret — unless that token is itself a reference/range, in which case a
-      // reference already follows the caret and no hint is needed.
+      // The hint belongs right before the first token that begins at/after the
+      // caret. Suppress it when the caret is not actually in an empty operand
+      // slot:
+      //   * the following token already starts an operand (`=|SUM(...)`,
+      //     `=A1+|B2`) — the reference/value is there, nothing to insert;
+      //   * the caret sits in an empty trailing argument, i.e. right after a
+      //     separator and immediately before `)` (`=SUM(A1,|)`). Note this is
+      //     distinct from `=SUM(|)`, whose previous token is `(`, not a
+      //     separator, and which does mark an insertable first argument.
       if (inReferenceMode && !hintHandled && start >= scalarCursor) {
-        if (!isReference && !isRange) {
+        const previousToken = index > 0 ? tokens[index - 1].token : undefined;
+        const emptyTrailingArgument =
+          token === "RightParenthesis" &&
+          previousToken !== undefined &&
+          tokenIsArgumentSeparator(previousToken);
+        if (!tokenStartsOperand(token) && !emptyTrailingArgument) {
           html.push(referenceHint);
         }
         hintHandled = true;

--- a/webapp/IronCalc/tests/getFormulaHTML.test.ts
+++ b/webapp/IronCalc/tests/getFormulaHTML.test.ts
@@ -147,6 +147,66 @@ test("a hint appears after a trailing operator", () => {
   expect(isHint(html[html.length - 1])).toBe(true);
 });
 
+// -----------------------------------------------------------------------------
+// The hint must not appear where the caret is NOT about to insert a fresh
+// reference. Each uses `=SUM(I7:I12,K18:K19)` (or a close variant) with `|` as
+// the caret. Cases 1-3 are handled here (JS placement); the nested-call case is
+// handled upstream by `getFormulaCompletion` no longer expecting a range there.
+// -----------------------------------------------------------------------------
+
+test("no hint with the caret before the leading '=' (|=SUM(...))", () => {
+  // `|=SUM(I7:I12,K18:K19)` — caret at 0, in front of the whole function call.
+  const { html } = getFormulaHTML(model, "=SUM(I7:I12,K18:K19)", 0);
+  expect(html.some(isHint)).toBe(false);
+});
+
+test("no hint with the caret right after '=' (=|SUM(...))", () => {
+  // `=|SUM(I7:I12,K18:K19)` — caret at 1, in front of the function name.
+  const { html } = getFormulaHTML(model, "=SUM(I7:I12,K18:K19)", 1);
+  expect(html.some(isHint)).toBe(false);
+});
+
+test("no hint in an empty trailing argument (=SUM(...,|))", () => {
+  // `=SUM(I7:I12,K18:K19,|)` — caret at 20, right after the trailing comma and
+  // immediately before `)`. Contrast with `=SUM(|)`, which does hint.
+  const { html } = getFormulaHTML(model, "=SUM(I7:I12,K18:K19,)", 20);
+  expect(html.some(isHint)).toBe(false);
+});
+
+test("no hint after a completed nested call (=SUM(A1, SUM(A3)|))", () => {
+  // `=SUM(A1, SUM(A3)|)` — caret at 16, just after the inner `)`.
+  const { html } = getFormulaHTML(model, "=SUM(A1, SUM(A3))", 16);
+  expect(html.some(isHint)).toBe(false);
+});
+
+test("an empty first argument still hints (=SUM(|)), unlike a trailing comma", () => {
+  // `=SUM(|)` — caret at 5, after `(` and before `)`: an insertable first
+  // argument, so the hint IS shown (the previous token is `(`, not a separator).
+  const { html } = getFormulaHTML(model, "=SUM()", 5);
+  const hintIndex = html.findIndex(isHint);
+  expect(hintIndex).toBeGreaterThanOrEqual(0);
+  expect(text(html[hintIndex + 1])).toBe(")");
+});
+
+test("a trailing operator after a completed nested call still hints", () => {
+  // `=1+2*SUM(I3:J6,N13:O15+SUM(L12:L13)*|` — the dangling `*` expects a fresh
+  // operand, so a reference can be inserted at the end despite following a call.
+  const formula = "=1+2*SUM(I3:J6,N13:O15+SUM(L12:L13)*";
+  const { html } = getFormulaHTML(model, formula, formula.length);
+  const hints = html.filter(isHint);
+  expect(hints).toHaveLength(1);
+  expect(isHint(html[html.length - 1])).toBe(true);
+});
+
+test("an argument being added at the end still hints (=SUM(A1,|)", () => {
+  // `=SUM(A1,|` — caret at 8, at the end after a separator: a fresh argument is
+  // expected here, so the hint IS shown.
+  const { html } = getFormulaHTML(model, "=SUM(A1,", 8);
+  const hints = html.filter(isHint);
+  expect(hints).toHaveLength(1);
+  expect(isHint(html[html.length - 1])).toBe(true);
+});
+
 test("a trailing newline adds a trailing span", () => {
   const { html } = getFormulaHTML(model, "=A1\n");
   expect(text(html[html.length - 1])).toBe("\n");


### PR DESCRIPTION
Rust side: Fixed an issue where entering a function argument
           was never cleared

JS side (getFormulaHTML): generalize the placement guard so the hint is
  suppressed when the following token already starts an operand
  (`=|SUM(...)`, `=A1+|B2`) and when the caret sits in an empty trailing
  argument — right after a separator and before `)` (`=SUM(A1,|)`). The
  latter is kept distinct from `=SUM(|)`, whose previous token is `(` and
  which still marks an insertable first argument.