### PR TITLE
FIX: When editing a spill cell we should show no content

### DIFF
--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -13,6 +13,7 @@ mod test_delete_row_column_formatting;
 mod test_diff_queue;
 mod test_duplicate_sheet;
 mod test_dynamic_arrays;
+mod test_editable_cell_content;
 mod test_evaluation;
 mod test_fn_formulatext;
 mod test_general;

--- a/base/src/test/user_model/test_editable_cell_content.rs
+++ b/base/src/test/user_model/test_editable_cell_content.rs
@@ -1,0 +1,37 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::user_model::util::new_empty_user_model;
+
+#[test]
+fn dynamic_arrays() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "=SEQUENCE(10)").unwrap();
+
+    assert_eq!(
+        model.get_editable_cell_content(0, 1, 1).unwrap(),
+        "=SEQUENCE(10)"
+    );
+    assert_eq!(model.get_editable_cell_content(0, 2, 1).unwrap(), "");
+    assert_eq!(model.get_editable_cell_content(0, 3, 1).unwrap(), "");
+    assert_eq!(model.get_cell_content(0, 2, 1).unwrap(), "2");
+}
+
+#[test]
+fn array_formulas() {
+    let mut model = new_empty_user_model();
+    model
+        .set_user_array_formula(0, 1, 1, 2, 2, "={1,2;3,4}")
+        .unwrap();
+    assert_eq!(
+        model.get_editable_cell_content(0, 1, 1).unwrap(),
+        "={1,2;3,4}"
+    );
+    assert_eq!(model.get_editable_cell_content(0, 1, 2).unwrap(), "");
+    assert_eq!(model.get_editable_cell_content(0, 2, 1).unwrap(), "");
+    assert_eq!(model.get_editable_cell_content(0, 2, 2).unwrap(), "");
+
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "={1,2;3,4}");
+    assert_eq!(model.get_cell_content(0, 1, 2).unwrap(), "2");
+    assert_eq!(model.get_cell_content(0, 2, 1).unwrap(), "3");
+    assert_eq!(model.get_cell_content(0, 2, 2).unwrap(), "4");
+}

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -457,10 +457,37 @@ impl<'a> UserModel<'a> {
     /// Returns the content of a cell
     ///
     /// See also:
-    /// * [Model::get_cell_content]
+    /// * [Model::get_localized_cell_content]
     #[inline]
     pub fn get_cell_content(&self, sheet: u32, row: i32, column: i32) -> Result<String, String> {
         self.model.get_localized_cell_content(sheet, row, column)
+    }
+
+    /// Returns the editable content of a cell.
+    /// If a cell is part of a dynamic array or an array formula, it will return an empty string.
+    /// Otherwise it will return the content of the cell.
+    ///
+    /// See also:
+    /// * [Model::get_localized_cell_content]
+    /// * [UserModel::get_cell_array_structure]
+    /// * [UserModel::get_cell_content]
+    #[inline]
+    pub fn get_editable_cell_content(
+        &self,
+        sheet: u32,
+        row: i32,
+        column: i32,
+    ) -> Result<String, String> {
+        let structure = self.get_cell_array_structure(sheet, row, column)?;
+        match structure {
+            CellArrayStructure::SingleCell
+            | CellArrayStructure::DynamicAnchor(_, _)
+            | CellArrayStructure::ArrayAnchor(_, _) => {
+                self.model.get_localized_cell_content(sheet, row, column)
+            }
+            CellArrayStructure::DynamicChild(_, _, _, _)
+            | CellArrayStructure::ArrayChild(_, _, _, _) => Ok("".to_string()),
+        }
     }
 
     /// Returns completion information for a formula being edited in a cell.

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -191,6 +191,18 @@ impl Model {
             .map_err(to_js_error)
     }
 
+    #[wasm_bindgen(js_name = "getEditableCellContent")]
+    pub fn get_editable_cell_content(
+        &self,
+        sheet: u32,
+        row: i32,
+        column: i32,
+    ) -> Result<String, JsError> {
+        self.model
+            .get_editable_cell_content(sheet, row, column)
+            .map_err(to_js_error)
+    }
+
     /// Returns completion information for a formula being edited in a cell.
     /// `formula` is the raw cell input (it may start with `=`) and `cursor` is a
     /// char offset into it.

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -327,7 +327,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
     onCellEditStart: (): void => {
       // User presses F2, we start editing at the edn of the text
       const { sheet, row, column } = model.getSelectedView();
-      const text = model.getCellContent(sheet, row, column);
+      const text = model.getEditableCellContent(sheet, row, column);
       const editorWidth =
         model.getColumnWidth(sheet, column) * COLUMN_WIDTH_SCALE;
       const editorHeight = model.getRowHeight(sheet, row) * ROW_HEIGH_SCALE;

--- a/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
+++ b/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
@@ -55,6 +55,7 @@ interface Options {
 // * F2: start editing
 // * Ctrl+Space: select column
 // * Shift+Space: select row
+// * F4: cycle through absolute/relative references
 //
 // # Not implemented yet:
 // * Ctrl+a: select all (continuous area around the selection, if it exists,

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -434,7 +434,7 @@ const Worksheet = forwardRef(
               return;
             }
             const { sheet, row, column } = model.getSelectedView();
-            const text = model.getCellContent(sheet, row, column);
+            const text = model.getEditableCellContent(sheet, row, column);
             const editorWidth =
               model.getColumnWidth(sheet, column) * COLUMN_WIDTH_SCALE;
             const editorHeight =


### PR DESCRIPTION
This shows an empty string when editing a "spill" cell where previously we would show the value.
It is still not clear to me what we should do.
For dynamic arrays:

What should we show in the anchor and spill cells both in the cell editor and the formula bar, both when editing and when only displaying content

this is what Excel onthe web does:

<img width="532" height="375" alt="image" src="https://github.com/user-attachments/assets/540fb579-8c14-421c-b346-09397b0434d5" />

<img width="532" height="375" alt="image" src="https://github.com/user-attachments/assets/f3c73784-0966-4b58-8650-e02e9a3f0a2c" />

Google sheets does this:

<img width="668" height="343" alt="image" src="https://github.com/user-attachments/assets/5dd365ba-6c4f-49d5-90d2-2578517a5035" />

(formula is not displayed)

That is close to what we do in IronCalc now.

This is what zoho does:

<img width="668" height="343" alt="image" src="https://github.com/user-attachments/assets/6ae90411-a842-476d-b078-1c5f7a3c0001" />

(yes their implementation of SEQUENCE is wrong)

Waiting on your input @dg-ac 
