### PR TITLE
update: read-only mode via canEdit

### DIFF
--- a/webapp/IronCalc/src/IronCalc.tsx
+++ b/webapp/IronCalc/src/IronCalc.tsx
@@ -16,7 +16,7 @@ interface IronCalcProperties {
   model: Model;
   themeVariables?: PartialIronCalcThemeVariables;
   rootContainer?: HTMLElement | null;
-  /** When false, renders without the toolbar/formula bar and blocks all edits. */
+  /** When false, renders without the toolbar, the formula bar is read-only and all edits are blocked. */
   canEdit?: boolean;
 }
 

--- a/webapp/IronCalc/src/IronCalc.tsx
+++ b/webapp/IronCalc/src/IronCalc.tsx
@@ -16,6 +16,8 @@ interface IronCalcProperties {
   model: Model;
   themeVariables?: PartialIronCalcThemeVariables;
   rootContainer?: HTMLElement | null;
+  /** When false, renders without the toolbar/formula bar and blocks all edits. */
+  canEdit?: boolean;
 }
 
 export interface IronCalcHandle {
@@ -23,7 +25,7 @@ export interface IronCalcHandle {
 }
 
 const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
-  ({ themeVariables, model, rootContainer }, ref) => {
+  ({ themeVariables, model, rootContainer, canEdit = true }, ref) => {
     const root = rootContainer ?? document.body;
     useEffect(() => {
       if (root.classList.contains("ic-root")) {
@@ -53,7 +55,11 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
     return (
       <div className="ic-widget">
         <I18nextProvider i18n={i18n}>
-          <Workbook model={model} workbookState={new WorkbookState()} />
+          <Workbook
+            model={model}
+            workbookState={new WorkbookState()}
+            canEdit={canEdit}
+          />
         </I18nextProvider>
       </div>
     );

--- a/webapp/IronCalc/src/components/Editor/Editor.tsx
+++ b/webapp/IronCalc/src/components/Editor/Editor.tsx
@@ -229,8 +229,7 @@ const Editor = (options: EditorOptions) => {
 
   const showEditor = cell !== null || type === "formula-bar";
   const mtext = cell ? workbookState.getEditingText() : originalText;
-  // In read-only mode the formula is rendered as plain grey text: reference
-  // highlighting (and its inline colors) only makes sense while editing.
+  // In read-only mode the formula is rendered as plain grey text
   const styledFormula = canEdit
     ? getFormulaHTML(model, mtext, cursor).html
     : mtext;

--- a/webapp/IronCalc/src/components/Editor/Editor.tsx
+++ b/webapp/IronCalc/src/components/Editor/Editor.tsx
@@ -227,9 +227,13 @@ const Editor = (options: EditorOptions) => {
 
   const cell = workbookState.getEditingCell();
 
-  const showEditor = cell !== null || type === "formula-bar" ? "block" : "none";
+  const showEditor = cell !== null || type === "formula-bar";
   const mtext = cell ? workbookState.getEditingText() : originalText;
-  const styledFormula = getFormulaHTML(model, mtext, cursor).html;
+  // In read-only mode the formula is rendered as plain grey text: reference
+  // highlighting (and its inline colors) only makes sense while editing.
+  const styledFormula = canEdit
+    ? getFormulaHTML(model, mtext, cursor).html
+    : mtext;
 
   // The formula helper is shown while editing a formula in whichever editor
   // currently has focus — the cell editor or the formula bar (both render this
@@ -329,16 +333,7 @@ const Editor = (options: EditorOptions) => {
         message={formulaError ?? undefined}
       />
       <div
-        style={{
-          position: "relative",
-          width: "100%",
-          height: "100%",
-          overflow: "hidden",
-          display: showEditor,
-          background: "#FFF",
-          fontFamily: "var(--palette-sheet-default-cell-font-family)",
-          fontSize: "12px",
-        }}
+        className={`ic-editor-container${showEditor ? "" : " ic-editor-container--hidden"}${canEdit ? "" : " ic-editor-container--readonly"}`}
       >
         <div
           ref={maskRef}

--- a/webapp/IronCalc/src/components/Editor/editor.css
+++ b/webapp/IronCalc/src/components/Editor/editor.css
@@ -1,3 +1,21 @@
+.ic-editor-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #fff;
+  font-family: var(--palette-sheet-default-cell-font-family);
+  font-size: 12px;
+}
+
+.ic-editor-container--hidden {
+  display: none;
+}
+
+.ic-editor-container--readonly {
+  color: var(--palette-grey-600);
+}
+
 .ic-insert-range-hint {
   margin: 0 2px;
   white-space: normal;

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTab.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTab.tsx
@@ -207,17 +207,17 @@ function SheetTab(props: SheetTabProps) {
           <>
             <div className="ic-sheet-tab-name">{name}</div>
             {props.canEdit && (
-            <button
-              ref={menuButtonRef}
-              className={`ic-sheet-tab-menu-button${menuOpen ? " ic-sheet-tab-menu-button--active" : ""}`}
-              onClick={handleOpenMenu}
-              type="button"
-              aria-label={t("sheet_tab.open_menu")}
-              aria-haspopup="menu"
-              aria-expanded={menuOpen}
-            >
-              <ChevronDown />
-            </button>
+              <button
+                ref={menuButtonRef}
+                className={`ic-sheet-tab-menu-button${menuOpen ? " ic-sheet-tab-menu-button--active" : ""}`}
+                onClick={handleOpenMenu}
+                type="button"
+                aria-label={t("sheet_tab.open_menu")}
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+              >
+                <ChevronDown />
+              </button>
             )}
           </>
         )}

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTab.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTab.tsx
@@ -83,7 +83,9 @@ function SheetTab(props: SheetTabProps) {
   }
 
   const handleOpenMenu = (event: React.MouseEvent) => {
-    if (!props.canEdit) return;
+    if (!props.canEdit) {
+      return;
+    }
     event.stopPropagation();
     event.preventDefault();
     if (menuOpen) {
@@ -97,7 +99,9 @@ function SheetTab(props: SheetTabProps) {
   };
 
   const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (!props.canEdit) return;
+    if (!props.canEdit) {
+      return;
+    }
     event.preventDefault();
     event.stopPropagation();
     onSelected();
@@ -111,7 +115,9 @@ function SheetTab(props: SheetTabProps) {
   };
 
   const handleStartEditing = () => {
-    if (!props.canEdit) return;
+    if (!props.canEdit) {
+      return;
+    }
     setEditingName(name);
     setInputWidth(Math.max(name.length * 7 + 8, 6));
     setIsEditing(true);

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTab.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTab.tsx
@@ -15,6 +15,7 @@ interface SheetTabProps {
   color: string;
   selected: boolean;
   onSelected: () => void;
+  canEdit: boolean;
   onColorChanged: (color: Color) => void;
   onRenamed: (name: string) => void;
   canDelete: boolean;
@@ -82,6 +83,7 @@ function SheetTab(props: SheetTabProps) {
   }
 
   const handleOpenMenu = (event: React.MouseEvent) => {
+    if (!props.canEdit) return;
     event.stopPropagation();
     event.preventDefault();
     if (menuOpen) {
@@ -95,6 +97,7 @@ function SheetTab(props: SheetTabProps) {
   };
 
   const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!props.canEdit) return;
     event.preventDefault();
     event.stopPropagation();
     onSelected();
@@ -108,6 +111,7 @@ function SheetTab(props: SheetTabProps) {
   };
 
   const handleStartEditing = () => {
+    if (!props.canEdit) return;
     setEditingName(name);
     setInputWidth(Math.max(name.length * 7 + 8, 6));
     setIsEditing(true);
@@ -202,6 +206,7 @@ function SheetTab(props: SheetTabProps) {
         ) : (
           <>
             <div className="ic-sheet-tab-name">{name}</div>
+            {props.canEdit && (
             <button
               ref={menuButtonRef}
               className={`ic-sheet-tab-menu-button${menuOpen ? " ic-sheet-tab-menu-button--active" : ""}`}
@@ -213,6 +218,7 @@ function SheetTab(props: SheetTabProps) {
             >
               <ChevronDown />
             </button>
+            )}
           </>
         )}
       </div>

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
@@ -25,6 +25,8 @@ export interface SheetTabBarProps {
   onHideSheet: () => void;
   model: Model;
   onOpenRegionalSettings: () => void;
+  /** When false, sheet add/rename/delete affordances are hidden. */
+  canEdit: boolean;
 }
 
 function SheetTabBar(props: SheetTabBarProps) {
@@ -45,13 +47,15 @@ function SheetTabBar(props: SheetTabBarProps) {
   return (
     <div className="ic-sheet-tab-bar-container">
       <div className="ic-sheet-tab-bar-left-buttons-container">
-        <Tooltip title={t("navigation.add_sheet")}>
-          <IconButton
-            aria-label={t("navigation.add_sheet")}
-            icon={<Plus />}
-            onClick={props.onAddBlankSheet}
-          />
-        </Tooltip>
+        {props.canEdit && (
+          <Tooltip title={t("navigation.add_sheet")}>
+            <IconButton
+              aria-label={t("navigation.add_sheet")}
+              icon={<Plus />}
+              onClick={props.onAddBlankSheet}
+            />
+          </Tooltip>
+        )}
         <Tooltip title={t("navigation.sheet_list")}>
           <Menu
             trigger={
@@ -75,6 +79,7 @@ function SheetTabBar(props: SheetTabBarProps) {
           {nonHiddenSheets.map((tab) => (
             <SheetTab
               key={tab.sheetId}
+              canEdit={props.canEdit}
               name={tab.name}
               color={tab.color}
               selected={tab.index === selectedIndex}

--- a/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
+++ b/webapp/IronCalc/src/components/SheetTabBar/SheetTabBar.tsx
@@ -25,7 +25,7 @@ export interface SheetTabBarProps {
   onHideSheet: () => void;
   model: Model;
   onOpenRegionalSettings: () => void;
-  /** When false, sheet add/rename/delete affordances are hidden. */
+  /** When false, sheet add/rename/delete and regional settings affordances are hidden. */
   canEdit: boolean;
 }
 
@@ -105,32 +105,34 @@ function SheetTabBar(props: SheetTabBarProps) {
           ))}
         </div>
       </div>
-      <div className="ic-sheet-tab-bar-right-container">
-        <Tooltip title={t("regional_settings.open_regional_settings")}>
-          <Button
-            className="ic-sheet-tab-bar-regional-settings-button"
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              props.onOpenRegionalSettings();
-            }}
-          >
-            {getLocaleDisplayName(props.model.getLocale())}
-            <div className="ic-sheet-tab-bar-text-divider" />
-            {t(
-              `regional_settings.language.display_language.${props.model.getLanguage()}`,
-            )}
-          </Button>
-        </Tooltip>
-        <Tooltip title={t("regional_settings.open_regional_settings")}>
-          <IconButton
-            className="ic-sheet-tab-bar-regional-settings-icon-button"
-            aria-label={t("regional_settings.open_regional_settings")}
-            icon={<Settings />}
-            onClick={props.onOpenRegionalSettings}
-          />
-        </Tooltip>
-      </div>
+      {props.canEdit && (
+        <div className="ic-sheet-tab-bar-right-container">
+          <Tooltip title={t("regional_settings.open_regional_settings")}>
+            <Button
+              className="ic-sheet-tab-bar-regional-settings-button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                props.onOpenRegionalSettings();
+              }}
+            >
+              {getLocaleDisplayName(props.model.getLocale())}
+              <div className="ic-sheet-tab-bar-text-divider" />
+              {t(
+                `regional_settings.language.display_language.${props.model.getLanguage()}`,
+              )}
+            </Button>
+          </Tooltip>
+          <Tooltip title={t("regional_settings.open_regional_settings")}>
+            <IconButton
+              className="ic-sheet-tab-bar-regional-settings-icon-button"
+              aria-label={t("regional_settings.open_regional_settings")}
+              icon={<Settings />}
+              onClick={props.onOpenRegionalSettings}
+            />
+          </Tooltip>
+        </div>
+      )}
     </div>
   );
 }

--- a/webapp/IronCalc/src/components/Workbook/Workbook.stories.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.stories.tsx
@@ -29,7 +29,7 @@ async function loadModel(): Promise<Model> {
   return new Model("Workbook1", "en", "UTC", "en");
 }
 
-function WorkbookWithInit() {
+function WorkbookWithInit({ canEdit }: { canEdit: boolean }) {
   const [model, setModel] = useState<Model | null>(null);
 
   useEffect(() => {
@@ -54,7 +54,11 @@ function WorkbookWithInit() {
         right: 0,
       }}
     >
-      <Workbook model={model} workbookState={new WorkbookState()} />
+      <Workbook
+        model={model}
+        workbookState={new WorkbookState()}
+        canEdit={canEdit}
+      />
     </div>
   );
 }
@@ -65,8 +69,12 @@ const meta = {
   parameters: {
     layout: "fullscreen",
   },
-  argTypes: {},
-  args: {},
+  argTypes: {
+    canEdit: { control: "boolean" },
+  },
+  args: {
+    canEdit: true,
+  },
 } satisfies Meta<typeof WorkbookWithInit>;
 
 export default meta;

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -49,8 +49,13 @@ function colorToParam(color: Color): string {
   return `[${color[0]}, ${color[1]}]`;
 }
 
-const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
-  const { model, workbookState } = props;
+const Workbook = (props: {
+  model: Model;
+  workbookState: WorkbookState;
+  /** When false, the toolbar/formula bar are hidden and all edits are blocked. */
+  canEdit?: boolean;
+}) => {
+  const { model, workbookState, canEdit = true } = props;
   const { t } = useTranslation();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const worksheetRef = useRef<{
@@ -274,6 +279,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
   // FIXME: I *think* we should have only one on onKeyPressed function that goes to
   // the Rust backend
   const { onKeyDown } = useKeyboardNavigation({
+    canEdit,
     onCellsDeleted: (): void => {
       const {
         sheet,
@@ -523,6 +529,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         }
       }}
       onPaste={(event: React.ClipboardEvent) => {
+        if (!canEdit) return;
         workbookState.clearCutRange();
         const { items } = event.clipboardData;
         if (!items) {
@@ -640,6 +647,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         event.stopPropagation();
       }}
       onCut={(event: React.ClipboardEvent) => {
+        if (!canEdit) return;
         const data = model.copyToClipboard();
         const sheet = model.getSelectedSheet();
         // '2024-10-18T14:07:37.599Z'
@@ -687,6 +695,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         setRedrawId((id) => id + 1);
       }}
     >
+      {canEdit && (
       <Toolbar
         canUndo={model.canUndo()}
         canRedo={model.canRedo()}
@@ -826,6 +835,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         onThemePicked={handleThemePicked}
         onOpenThemes={() => openDrawer("themes")}
       />
+      )}
       <div
         className="ic-workbook-worksheet-area-left"
         style={{
@@ -847,7 +857,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
           openDrawer={() => {
             openDrawer("namedRanges");
           }}
-          canEdit={isArrayFormula}
+          canEdit={canEdit && isArrayFormula}
         />
         <Worksheet
           model={model}
@@ -856,7 +866,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
             setRedrawId((id) => id + 1);
           }}
           ref={worksheetRef}
-          canEdit={isArrayFormula}
+          canEdit={canEdit && isArrayFormula}
           onCut={(): void => {
             focusWorkbook();
             document.execCommand("cut");
@@ -869,6 +879,7 @@ const Workbook = (props: { model: Model; workbookState: WorkbookState }) => {
         />
 
         <SheetTabBar
+          canEdit={canEdit}
           sheets={info}
           selectedIndex={model.getSelectedSheet()}
           workbookState={workbookState}

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -516,7 +516,7 @@ const Workbook = (props: {
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: This div needs to be focusable to handle keyboard events for the workbook
     <div
-      className={`ic-workbook-container${canEdit ? "" : " ic-workbook-container--no-toolbar"}`}
+      className={`ic-workbook-container${canEdit ? "" : " ic-workbook-container--readonly"}`}
       ref={rootRef}
       onKeyDown={onKeyDown}
       // biome-ignore lint/a11y/noNoninteractiveTabindex: This div needs to be focusable to handle keyboard events for the workbook

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -479,8 +479,8 @@ const Workbook = (props: {
     );
   }, [model]);
 
-  // Returns the formula value to be shown in the formula bar
-  // and whether the it is part of an array formula that cannot be edited directly
+  // Returns the formula bar value and whether it can be edited
+  // (false for array formulas)
   const getFormulaValue = (): [string, boolean] => {
     const cell = workbookState.getEditingCell();
     if (cell) {
@@ -503,7 +503,7 @@ const Workbook = (props: {
     return [model.getCellContent(sheet, row, column), true];
   };
 
-  const [formulaValue, isArrayFormula] = getFormulaValue();
+  const [formulaValue, canEditFormula] = getFormulaValue();
 
   const getCellStyle = useCallback(() => {
     const { sheet, row, column } = model.getSelectedView();
@@ -530,6 +530,8 @@ const Workbook = (props: {
       }}
       onPaste={(event: React.ClipboardEvent) => {
         if (!canEdit) {
+          event.preventDefault();
+          event.stopPropagation();
           return;
         }
         workbookState.clearCutRange();
@@ -650,6 +652,8 @@ const Workbook = (props: {
       }}
       onCut={(event: React.ClipboardEvent) => {
         if (!canEdit) {
+          event.preventDefault();
+          event.stopPropagation();
           return;
         }
         const data = model.copyToClipboard();
@@ -863,7 +867,7 @@ const Workbook = (props: {
           openDrawer={() => {
             openDrawer("namedRanges");
           }}
-          canEdit={canEdit && isArrayFormula}
+          canEdit={canEdit && canEditFormula}
         />
         <Worksheet
           model={model}
@@ -872,7 +876,7 @@ const Workbook = (props: {
             setRedrawId((id) => id + 1);
           }}
           ref={worksheetRef}
-          canEdit={canEdit && isArrayFormula}
+          canEdit={canEdit && canEditFormula}
           onCut={(): void => {
             focusWorkbook();
             document.execCommand("cut");

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -529,7 +529,9 @@ const Workbook = (props: {
         }
       }}
       onPaste={(event: React.ClipboardEvent) => {
-        if (!canEdit) return;
+        if (!canEdit) {
+          return;
+        }
         workbookState.clearCutRange();
         const { items } = event.clipboardData;
         if (!items) {
@@ -647,7 +649,9 @@ const Workbook = (props: {
         event.stopPropagation();
       }}
       onCut={(event: React.ClipboardEvent) => {
-        if (!canEdit) return;
+        if (!canEdit) {
+          return;
+        }
         const data = model.copyToClipboard();
         const sheet = model.getSelectedSheet();
         // '2024-10-18T14:07:37.599Z'

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -52,7 +52,7 @@ function colorToParam(color: Color): string {
 const Workbook = (props: {
   model: Model;
   workbookState: WorkbookState;
-  /** When false, the toolbar/formula bar are hidden and all edits are blocked. */
+  /** When false, the toolbar is hidden, the formula bar is read-only and all edits are blocked. */
   canEdit?: boolean;
 }) => {
   const { model, workbookState, canEdit = true } = props;
@@ -516,7 +516,7 @@ const Workbook = (props: {
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: This div needs to be focusable to handle keyboard events for the workbook
     <div
-      className="ic-workbook-container"
+      className={`ic-workbook-container${canEdit ? "" : " ic-workbook-container--no-toolbar"}`}
       ref={rootRef}
       onKeyDown={onKeyDown}
       // biome-ignore lint/a11y/noNoninteractiveTabindex: This div needs to be focusable to handle keyboard events for the workbook
@@ -696,145 +696,147 @@ const Workbook = (props: {
       }}
     >
       {canEdit && (
-      <Toolbar
-        canUndo={model.canUndo()}
-        canRedo={model.canRedo()}
-        onRedo={onRedo}
-        onUndo={onUndo}
-        onToggleUnderline={onToggleUnderline}
-        onToggleBold={onToggleBold}
-        onToggleItalic={onToggleItalic}
-        onToggleStrike={onToggleStrike}
-        onToggleHorizontalAlign={onToggleHorizontalAlign}
-        onToggleVerticalAlign={onToggleVerticalAlign}
-        onToggleWrapText={onToggleWrapText}
-        onCopyStyles={onCopyStyles}
-        onTextColorPicked={onTextColorPicked}
-        onFillColorPicked={onFillColorPicked}
-        onNumberFormatPicked={onNumberFormatPicked}
-        onClearFormatting={() => {
-          const {
-            sheet,
-            range: [rowStart, columnStart, rowEnd, columnEnd],
-          } = model.getSelectedView();
-          model.rangeClearFormatting(
-            sheet,
-            rowStart,
-            columnStart,
-            rowEnd,
-            columnEnd,
-          );
-          setRedrawId((id) => id + 1);
-        }}
-        onIncreaseFontSize={(delta: number) => {
-          onIncreaseFontSize(delta);
-        }}
-        onSetFontSize={(size: number) => {
-          onSetFontSize(size);
-        }}
-        onDownloadPNG={() => {
-          // creates a new canvas element in the visible part of the the selected area
-          const worksheetCanvas = worksheetRef.current?.getCanvas();
-          if (!worksheetCanvas) {
-            return;
+        <Toolbar
+          canUndo={model.canUndo()}
+          canRedo={model.canRedo()}
+          onRedo={onRedo}
+          onUndo={onUndo}
+          onToggleUnderline={onToggleUnderline}
+          onToggleBold={onToggleBold}
+          onToggleItalic={onToggleItalic}
+          onToggleStrike={onToggleStrike}
+          onToggleHorizontalAlign={onToggleHorizontalAlign}
+          onToggleVerticalAlign={onToggleVerticalAlign}
+          onToggleWrapText={onToggleWrapText}
+          onCopyStyles={onCopyStyles}
+          onTextColorPicked={onTextColorPicked}
+          onFillColorPicked={onFillColorPicked}
+          onNumberFormatPicked={onNumberFormatPicked}
+          onClearFormatting={() => {
+            const {
+              sheet,
+              range: [rowStart, columnStart, rowEnd, columnEnd],
+            } = model.getSelectedView();
+            model.rangeClearFormatting(
+              sheet,
+              rowStart,
+              columnStart,
+              rowEnd,
+              columnEnd,
+            );
+            setRedrawId((id) => id + 1);
+          }}
+          onIncreaseFontSize={(delta: number) => {
+            onIncreaseFontSize(delta);
+          }}
+          onSetFontSize={(size: number) => {
+            onSetFontSize(size);
+          }}
+          onDownloadPNG={() => {
+            // creates a new canvas element in the visible part of the the selected area
+            const worksheetCanvas = worksheetRef.current?.getCanvas();
+            if (!worksheetCanvas) {
+              return;
+            }
+            const {
+              range: [rowStart, columnStart, rowEnd, columnEnd],
+            } = model.getSelectedView();
+            // NB: cells outside of the displayed area are not rendered
+            // I think the only reasonable way to do this would be server side.
+            let [x, y] = worksheetCanvas.getCoordinatesByCell(
+              rowStart,
+              columnStart,
+            );
+            const [x1, y1] = worksheetCanvas.getCoordinatesByCell(
+              rowEnd + 1,
+              columnEnd + 1,
+            );
+            const width = (x1 - x) * devicePixelRatio;
+            const height = (y1 - y) * devicePixelRatio;
+            x *= devicePixelRatio;
+            y *= devicePixelRatio;
+
+            const capturedCanvas = document.createElement("canvas");
+            capturedCanvas.width = width;
+            capturedCanvas.height = height;
+            const ctx = capturedCanvas.getContext("2d");
+            if (!ctx) {
+              return;
+            }
+
+            ctx.drawImage(
+              worksheetCanvas.canvas,
+              x,
+              y,
+              width,
+              height,
+              0,
+              0,
+              width,
+              height,
+            );
+
+            const downloadLink = document.createElement("a");
+            downloadLink.href = capturedCanvas.toDataURL("image/png");
+            downloadLink.download = "ironcalc.png";
+            downloadLink.click();
+          }}
+          onBorderChanged={(border: BorderOptions): void => {
+            const {
+              sheet,
+              range: [rowStart, columnStart, rowEnd, columnEnd],
+            } = model.getSelectedView();
+            const row = Math.min(rowStart, rowEnd);
+            const column = Math.min(columnStart, columnEnd);
+
+            const width = Math.abs(columnEnd - columnStart) + 1;
+            const height = Math.abs(rowEnd - rowStart) + 1;
+            const borderArea = {
+              type: border.border,
+              item: border,
+            };
+            model.setAreaWithBorder(
+              { sheet, row, column, width, height },
+              borderArea,
+            );
+            setRedrawId((id) => id + 1);
+          }}
+          fillColor={style.fill.color}
+          fontColor={style.font.color}
+          fontSize={style.font.sz}
+          bold={style.font.b}
+          underline={style.font.u}
+          italic={style.font.i}
+          strike={style.font.strike}
+          horizontalAlign={
+            style.alignment ? style.alignment.horizontal : "general"
           }
-          const {
-            range: [rowStart, columnStart, rowEnd, columnEnd],
-          } = model.getSelectedView();
-          // NB: cells outside of the displayed area are not rendered
-          // I think the only reasonable way to do this would be server side.
-          let [x, y] = worksheetCanvas.getCoordinatesByCell(
-            rowStart,
-            columnStart,
-          );
-          const [x1, y1] = worksheetCanvas.getCoordinatesByCell(
-            rowEnd + 1,
-            columnEnd + 1,
-          );
-          const width = (x1 - x) * devicePixelRatio;
-          const height = (y1 - y) * devicePixelRatio;
-          x *= devicePixelRatio;
-          y *= devicePixelRatio;
-
-          const capturedCanvas = document.createElement("canvas");
-          capturedCanvas.width = width;
-          capturedCanvas.height = height;
-          const ctx = capturedCanvas.getContext("2d");
-          if (!ctx) {
-            return;
+          verticalAlign={
+            style.alignment?.vertical ? style.alignment.vertical : "bottom"
           }
-
-          ctx.drawImage(
-            worksheetCanvas.canvas,
-            x,
-            y,
-            width,
-            height,
-            0,
-            0,
-            width,
-            height,
-          );
-
-          const downloadLink = document.createElement("a");
-          downloadLink.href = capturedCanvas.toDataURL("image/png");
-          downloadLink.download = "ironcalc.png";
-          downloadLink.click();
-        }}
-        onBorderChanged={(border: BorderOptions): void => {
-          const {
-            sheet,
-            range: [rowStart, columnStart, rowEnd, columnEnd],
-          } = model.getSelectedView();
-          const row = Math.min(rowStart, rowEnd);
-          const column = Math.min(columnStart, columnEnd);
-
-          const width = Math.abs(columnEnd - columnStart) + 1;
-          const height = Math.abs(rowEnd - rowStart) + 1;
-          const borderArea = {
-            type: border.border,
-            item: border,
-          };
-          model.setAreaWithBorder(
-            { sheet, row, column, width, height },
-            borderArea,
-          );
-          setRedrawId((id) => id + 1);
-        }}
-        fillColor={style.fill.color}
-        fontColor={style.font.color}
-        fontSize={style.font.sz}
-        bold={style.font.b}
-        underline={style.font.u}
-        italic={style.font.i}
-        strike={style.font.strike}
-        horizontalAlign={
-          style.alignment ? style.alignment.horizontal : "general"
-        }
-        verticalAlign={
-          style.alignment?.vertical ? style.alignment.vertical : "bottom"
-        }
-        wrapText={style.alignment?.wrap_text || false}
-        canEdit={true}
-        numFmt={style.num_fmt}
-        showGridLines={model.getShowGridLines(model.getSelectedSheet())}
-        onToggleShowGridLines={(show) => {
-          const sheet = model.getSelectedSheet();
-          model.setShowGridLines(sheet, show);
-          setRedrawId((id) => id + 1);
-        }}
-        formatOptions={fmtSettings}
-        onOpenConditionalFormatting={() => openDrawer("conditionalFormatting")}
-        isConditionalFormattingOpen={
-          isDrawerOpen && drawerType === "conditionalFormatting"
-        }
-        onOpenNamedStyles={() => openDrawer("namedStyles")}
-        isNamedStylesOpen={isDrawerOpen && drawerType === "namedStyles"}
-        themes={themes}
-        currentTheme={currentTheme}
-        onThemePicked={handleThemePicked}
-        onOpenThemes={() => openDrawer("themes")}
-      />
+          wrapText={style.alignment?.wrap_text || false}
+          canEdit={true}
+          numFmt={style.num_fmt}
+          showGridLines={model.getShowGridLines(model.getSelectedSheet())}
+          onToggleShowGridLines={(show) => {
+            const sheet = model.getSelectedSheet();
+            model.setShowGridLines(sheet, show);
+            setRedrawId((id) => id + 1);
+          }}
+          formatOptions={fmtSettings}
+          onOpenConditionalFormatting={() =>
+            openDrawer("conditionalFormatting")
+          }
+          isConditionalFormattingOpen={
+            isDrawerOpen && drawerType === "conditionalFormatting"
+          }
+          onOpenNamedStyles={() => openDrawer("namedStyles")}
+          isNamedStylesOpen={isDrawerOpen && drawerType === "namedStyles"}
+          themes={themes}
+          currentTheme={currentTheme}
+          onThemePicked={handleThemePicked}
+          onOpenThemes={() => openDrawer("themes")}
+        />
       )}
       <div
         className="ic-workbook-worksheet-area-left"

--- a/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
+++ b/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
@@ -34,6 +34,8 @@ interface Options {
   onEscape: () => void;
   onSelectColumn: () => void;
   onSelectRow: () => void;
+  /** When false, editing/mutation keys are ignored (navigation still works). */
+  canEdit: boolean;
   root: RefObject<HTMLDivElement | null>;
 }
 
@@ -103,19 +105,19 @@ const useKeyboardNavigation = (
             break;
           }
           case "b": {
-            options.onBold();
+            if (options.canEdit) options.onBold();
             event.stopPropagation();
             event.preventDefault();
             break;
           }
           case "i": {
-            options.onItalic();
+            if (options.canEdit) options.onItalic();
             event.stopPropagation();
             event.preventDefault();
             break;
           }
           case "u": {
-            options.onUnderline();
+            if (options.canEdit) options.onUnderline();
             event.stopPropagation();
             event.preventDefault();
             break;
@@ -204,7 +206,7 @@ const useKeyboardNavigation = (
         return;
       }
 
-      if (isEditingKey(key) || key === "Backspace") {
+      if (options.canEdit && (isEditingKey(key) || key === "Backspace")) {
         const initText = key === "Backspace" ? "" : key;
         options.onEditKeyPressStart(initText);
         event.stopPropagation();
@@ -215,7 +217,7 @@ const useKeyboardNavigation = (
         // Other combinations with Shift are not handled
         return;
       }
-      if (key === "F2") {
+      if (key === "F2" && options.canEdit) {
         options.onCellEditStart();
         event.stopPropagation();
         event.preventDefault();
@@ -250,7 +252,7 @@ const useKeyboardNavigation = (
           break;
         }
         case "Delete": {
-          options.onCellsDeleted();
+          if (options.canEdit) options.onCellsDeleted();
           break;
         }
         case "PageDown": {

--- a/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
+++ b/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
@@ -105,19 +105,25 @@ const useKeyboardNavigation = (
             break;
           }
           case "b": {
-            if (options.canEdit) options.onBold();
+            if (options.canEdit) {
+              options.onBold();
+            }
             event.stopPropagation();
             event.preventDefault();
             break;
           }
           case "i": {
-            if (options.canEdit) options.onItalic();
+            if (options.canEdit) {
+              options.onItalic();
+            }
             event.stopPropagation();
             event.preventDefault();
             break;
           }
           case "u": {
-            if (options.canEdit) options.onUnderline();
+            if (options.canEdit) {
+              options.onUnderline();
+            }
             event.stopPropagation();
             event.preventDefault();
             break;
@@ -252,7 +258,9 @@ const useKeyboardNavigation = (
           break;
         }
         case "Delete": {
-          if (options.canEdit) options.onCellsDeleted();
+          if (options.canEdit) {
+            options.onCellsDeleted();
+          }
           break;
         }
         case "PageDown": {

--- a/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
+++ b/webapp/IronCalc/src/components/Workbook/useKeyboardNavigation.ts
@@ -93,13 +93,17 @@ const useKeyboardNavigation = (
         // Ctrl+...
         switch (lowerKey) {
           case "z": {
-            options.onUndo();
+            if (options.canEdit) {
+              options.onUndo();
+            }
             event.stopPropagation();
             event.preventDefault();
             break;
           }
           case "y": {
-            options.onRedo();
+            if (options.canEdit) {
+              options.onRedo();
+            }
             event.stopPropagation();
             event.preventDefault();
             break;

--- a/webapp/IronCalc/src/components/Workbook/workbook.css
+++ b/webapp/IronCalc/src/components/Workbook/workbook.css
@@ -15,3 +15,9 @@
 .ic-workbook-container:focus {
   outline: none;
 }
+
+/* In read-only mode the toolbar is not rendered, so collapse the space
+   reserved for it (worksheet area and right drawer offset by it). */
+.ic-workbook-container--no-toolbar {
+  --toolbar-height: 0px;
+}

--- a/webapp/IronCalc/src/components/Workbook/workbook.css
+++ b/webapp/IronCalc/src/components/Workbook/workbook.css
@@ -18,6 +18,6 @@
 
 /* In read-only mode the toolbar is not rendered, so collapse the space
    reserved for it (worksheet area and right drawer offset by it). */
-.ic-workbook-container--no-toolbar {
+.ic-workbook-container--readonly {
   --toolbar-height: 0px;
 }

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -319,6 +319,12 @@ const Worksheet = forwardRef(
             event.preventDefault();
             event.stopPropagation();
 
+            // The context menus only offer editing actions (insert/delete,
+            // cut/paste), so they are not shown in read-only mode.
+            if (!canEdit) {
+              return;
+            }
+
             // Store mouse position for menu placement
             setContextMenuPosition({
               top: event.clientY,

--- a/webapp/IronCalc/src/components/Worksheet/worksheet.css
+++ b/webapp/IronCalc/src/components/Worksheet/worksheet.css
@@ -8,6 +8,11 @@
   border: 1px solid white;
 }
 
+/* The handle auto-fills (drags) cell content, so it is an edit affordance. */
+.ic-workbook-container--readonly .ironcalc-cell-handle {
+  display: none;
+}
+
 /* Spacer */
 .ic-worksheet-spacer {
   position: absolute;


### PR DESCRIPTION
(This PR completes #1116)

### Changes

When `canEdit` is off:

- The toolbar is not rendered, and the space it reserves is collapsed so the formula bar sits right at the top edge.
- Cell editing is not possible, and some keyboard shortcuts are ignored (navigation and copy still work).
- The drag handle on the cell selector is hidden so ranges can't be dragged to auto-fill.
- The sheet tab bar hides 'add sheet' button, the tab context menu and the regional settings buttons.
- Also sheet renaming is blocked.
- Context menus (cell, column header, row header) don't open on right-click.
- The formula bar stays visible so formulas can be inspected, but it's non-editable and renders its text in grey.

> I'd also like to put some order in `useKeyboardNavigation.ts` but I'll leave that for a future PR to avoid making this one too large. We want to add more shortcuts in the next weeks so that file will change anyways.

cc @sylvinus @nhatcher 