### PR TITLE
fix(xlsx): honour the workbook <indexedColors> palette override

### DIFF
--- a/xlsx/src/import/conditional_formatting.rs
+++ b/xlsx/src/import/conditional_formatting.rs
@@ -349,7 +349,7 @@ fn parse_x14_expression_rule(
     // Inline <x14:dxf> format; append it to the shared dxfs and reference by index.
     let dxf_id = match rule.children().find(|n| n.has_tag_name("dxf")) {
         Some(dxf_node) => {
-            let dxf = parse_dxf(dxf_node, theme)?;
+            let dxf = parse_dxf(dxf_node, theme, None)?;
             let id = dxfs.len() as u32;
             dxfs.push(dxf);
             id

--- a/xlsx/src/import/styles.rs
+++ b/xlsx/src/import/styles.rs
@@ -696,6 +696,12 @@ mod indexed_color_tests {
             resolve(r#"<c indexed="5"/>"#),
             Color::Rgb("#FFFF00".to_string())
         );
+        // Malformed negative index -> default fallback, not a panic (would underflow
+        // `index as usize` in `get_indexed_color` without the guard).
+        assert_eq!(
+            resolve(r#"<c indexed="-1"/>"#),
+            Color::Rgb("#000000".to_string())
+        );
         // theme= is unaffected by the indexed override.
         assert_eq!(
             resolve(r#"<c theme="3" tint="0.0"/>"#),

--- a/xlsx/src/import/styles.rs
+++ b/xlsx/src/import/styles.rs
@@ -8,9 +8,44 @@ use roxmltree::Node;
 
 use crate::error::XlsxError;
 
-use super::util::{get_attribute, get_bool, get_bool_false, get_color, get_number};
+use super::util::{get_attribute, get_bool, get_bool_false, get_color_indexed, get_number};
 
-fn get_border(node: Node, name: &str, theme: &Theme) -> Result<Option<BorderItem>, XlsxError> {
+/// Reads the workbook's `<colors><indexedColors>` palette override (OOXML §18.8.27) from the
+/// styleSheet root as `#RRGGBB` strings positioned by index. Returns `None` when the file
+/// supplies no override (the common case), so callers keep the legacy default indexed palette.
+/// A malformed entry becomes an empty string, which the colour resolver treats as "fall back".
+fn parse_indexed_colors(style_sheet: Node) -> Option<Vec<String>> {
+    let colors = style_sheet.children().find(|n| n.has_tag_name("colors"))?;
+    let indexed = colors
+        .children()
+        .find(|n| n.has_tag_name("indexedColors"))?;
+    let palette: Vec<String> = indexed
+        .children()
+        .filter(|n| n.has_tag_name("rgbColor"))
+        .map(|n| match n.attribute("rgb") {
+            // ARGB (drop the alpha byte) or bare RGB; `is_ascii` guards the byte slice.
+            Some(raw) if raw.len() == 8 && raw.is_ascii() => {
+                format!("#{}", raw[2..].to_ascii_uppercase())
+            }
+            Some(raw) if raw.len() == 6 && raw.is_ascii() => {
+                format!("#{}", raw.to_ascii_uppercase())
+            }
+            _ => String::new(),
+        })
+        .collect();
+    if palette.is_empty() {
+        None
+    } else {
+        Some(palette)
+    }
+}
+
+fn get_border(
+    node: Node,
+    name: &str,
+    theme: &Theme,
+    indexed: Option<&[String]>,
+) -> Result<Option<BorderItem>, XlsxError> {
     let style;
     let color;
     let border_nodes = node
@@ -40,7 +75,7 @@ fn get_border(node: Node, name: &str, theme: &Theme) -> Result<Option<BorderItem
             .filter(|n| n.has_tag_name("color"))
             .collect::<Vec<Node>>();
         if color_node.len() == 1 {
-            color = get_color(color_node[0], theme)?;
+            color = get_color_indexed(color_node[0], theme, indexed)?;
         } else {
             color = Color::None;
         }
@@ -62,6 +97,11 @@ pub(super) fn load_styles<R: Read + std::io::Seek>(
         .root()
         .first_child()
         .ok_or_else(|| XlsxError::Xml("Corrupt XML structure".to_string()))?;
+
+    // The workbook's `<colors><indexedColors>` override (if any), applied to every `indexed=`
+    // fill/font/border colour below so the file's palette wins over the legacy default one.
+    let indexed_colors = parse_indexed_colors(style_sheet);
+    let indexed = indexed_colors.as_deref();
 
     let mut num_fmts = Vec::new();
     let num_fmts_nodes = style_sheet
@@ -111,7 +151,7 @@ pub(super) fn load_styles<R: Read + std::io::Seek>(
                         .unwrap_or(11);
                 }
                 "color" => {
-                    color = get_color(feature, theme)?;
+                    color = get_color_indexed(feature, theme, indexed)?;
                 }
                 "u" => {
                     u = true;
@@ -188,10 +228,10 @@ pub(super) fn load_styles<R: Read + std::io::Seek>(
         for feature in pattern_fill.children() {
             match feature.tag_name().name() {
                 "fgColor" => {
-                    fg_color = get_color(feature, theme)?;
+                    fg_color = get_color_indexed(feature, theme, indexed)?;
                 }
                 "bgColor" => {
-                    bg_color = get_color(feature, theme)?;
+                    bg_color = get_color_indexed(feature, theme, indexed)?;
                 }
                 _ => {
                     println!("Unexpected pattern");
@@ -217,11 +257,11 @@ pub(super) fn load_styles<R: Read + std::io::Seek>(
     for border in border_nodes.children() {
         let diagonal_up = get_bool_false(border, "diagonal_up");
         let diagonal_down = get_bool_false(border, "diagonal_down");
-        let left = get_border(border, "left", theme)?;
-        let right = get_border(border, "right", theme)?;
-        let top = get_border(border, "top", theme)?;
-        let bottom = get_border(border, "bottom", theme)?;
-        let diagonal = get_border(border, "diagonal", theme)?;
+        let left = get_border(border, "left", theme, indexed)?;
+        let right = get_border(border, "right", theme, indexed)?;
+        let top = get_border(border, "top", theme, indexed)?;
+        let bottom = get_border(border, "bottom", theme, indexed)?;
+        let diagonal = get_border(border, "diagonal", theme, indexed)?;
         borders.push(Border {
             diagonal_up,
             diagonal_down,
@@ -375,7 +415,7 @@ pub(super) fn load_styles<R: Read + std::io::Seek>(
         });
     }
 
-    let dxfs = load_dxfs(style_sheet, theme)?;
+    let dxfs = load_dxfs(style_sheet, theme, indexed)?;
 
     Ok(Styles {
         num_fmts,
@@ -389,7 +429,11 @@ pub(super) fn load_styles<R: Read + std::io::Seek>(
     })
 }
 
-fn load_dxfs(style_sheet: Node, theme: &Theme) -> Result<Vec<Dxf>, XlsxError> {
+fn load_dxfs(
+    style_sheet: Node,
+    theme: &Theme,
+    indexed: Option<&[String]>,
+) -> Result<Vec<Dxf>, XlsxError> {
     let mut dxfs = Vec::new();
     let dxfs_nodes = style_sheet
         .children()
@@ -402,7 +446,7 @@ fn load_dxfs(style_sheet: Node, theme: &Theme) -> Result<Vec<Dxf>, XlsxError> {
         if !dxf_node.is_element() {
             continue;
         }
-        dxfs.push(parse_dxf(dxf_node, theme)?);
+        dxfs.push(parse_dxf(dxf_node, theme, indexed)?);
     }
     Ok(dxfs)
 }
@@ -410,7 +454,11 @@ fn load_dxfs(style_sheet: Node, theme: &Theme) -> Result<Vec<Dxf>, XlsxError> {
 /// Parses a single `<dxf>` (differential format) node into a [`Dxf`].
 /// Matches children by local tag name, so it also works on namespaced
 /// `<x14:dxf>` nodes found in conditional-formatting `extLst` extensions.
-pub(super) fn parse_dxf(dxf_node: Node, theme: &Theme) -> Result<Dxf, XlsxError> {
+pub(super) fn parse_dxf(
+    dxf_node: Node,
+    theme: &Theme,
+    indexed: Option<&[String]>,
+) -> Result<Dxf, XlsxError> {
     let mut font = None;
     let mut fill = None;
     let mut border = None;
@@ -424,7 +472,7 @@ pub(super) fn parse_dxf(dxf_node: Node, theme: &Theme) -> Result<Dxf, XlsxError>
                 for feat in child.children() {
                     match feat.tag_name().name() {
                         "color" => {
-                            f.color = get_color(feat, theme)?;
+                            f.color = get_color_indexed(feat, theme, indexed)?;
                         }
                         "b" => {
                             f.b = Some(true);
@@ -462,8 +510,8 @@ pub(super) fn parse_dxf(dxf_node: Node, theme: &Theme) -> Result<Dxf, XlsxError>
                     let mut bg_color = Color::None;
                     for feat in pf.children() {
                         match feat.tag_name().name() {
-                            "fgColor" => fg_color = get_color(feat, theme)?,
-                            "bgColor" => bg_color = get_color(feat, theme)?,
+                            "fgColor" => fg_color = get_color_indexed(feat, theme, indexed)?,
+                            "bgColor" => bg_color = get_color_indexed(feat, theme, indexed)?,
                             _ => {}
                         }
                     }
@@ -478,11 +526,11 @@ pub(super) fn parse_dxf(dxf_node: Node, theme: &Theme) -> Result<Dxf, XlsxError>
                 }
             }
             "border" => {
-                let left = get_border(child, "left", theme)?;
-                let right = get_border(child, "right", theme)?;
-                let top = get_border(child, "top", theme)?;
-                let bottom = get_border(child, "bottom", theme)?;
-                let diagonal = get_border(child, "diagonal", theme)?;
+                let left = get_border(child, "left", theme, indexed)?;
+                let right = get_border(child, "right", theme, indexed)?;
+                let top = get_border(child, "top", theme, indexed)?;
+                let bottom = get_border(child, "bottom", theme, indexed)?;
+                let diagonal = get_border(child, "diagonal", theme, indexed)?;
                 border = Some(Border {
                     diagonal_up: false,
                     diagonal_down: false,
@@ -533,4 +581,125 @@ pub(super) fn parse_dxf(dxf_node: Node, theme: &Theme) -> Result<Dxf, XlsxError>
         num_fmt,
         alignment,
     })
+}
+
+#[cfg(test)]
+mod indexed_color_tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use std::io::{Cursor, Write};
+
+    // A structurally complete styles.xml (no namespace, matching the other import tests) whose
+    // fill 2 uses `indexed="13"` and font 1 uses `indexed="14"`. `{colors}` is filled in per case.
+    fn styles_xml(colors: &str) -> String {
+        format!(
+            concat!(
+                "<styleSheet>",
+                "<fonts count=\"2\"><font><sz val=\"11\"/></font>",
+                "<font><color indexed=\"14\"/><sz val=\"11\"/></font></fonts>",
+                "<fills count=\"3\"><fill><patternFill patternType=\"none\"/></fill>",
+                "<fill><patternFill patternType=\"gray125\"/></fill>",
+                "<fill><patternFill patternType=\"solid\"><fgColor indexed=\"13\"/></patternFill></fill></fills>",
+                "<borders count=\"1\"><border><left/><right/><top/><bottom/><diagonal/></border></borders>",
+                "<cellStyleXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\"/></cellStyleXfs>",
+                "<cellXfs count=\"1\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/></cellXfs>",
+                "<cellStyles count=\"1\"><cellStyle name=\"Normal\" xfId=\"0\" builtinId=\"0\"/></cellStyles>",
+                "{}",
+                "</styleSheet>",
+            ),
+            colors
+        )
+    }
+
+    // The workbook's `<colors><indexedColors>` override: index 13 -> #FFD931, 14 -> #FE634D
+    // (mirrors a Numbers export). Standard entries fill 0..12.
+    const OVERRIDE: &str = concat!(
+        "<colors><indexedColors>",
+        "<rgbColor rgb=\"FF000000\"/><rgbColor rgb=\"FFFFFFFF\"/><rgbColor rgb=\"FFFF0000\"/>",
+        "<rgbColor rgb=\"FF00FF00\"/><rgbColor rgb=\"FF0000FF\"/><rgbColor rgb=\"FFFFFF00\"/>",
+        "<rgbColor rgb=\"FFFF00FF\"/><rgbColor rgb=\"FF00FFFF\"/><rgbColor rgb=\"FF000000\"/>",
+        "<rgbColor rgb=\"FFBDC0BF\"/><rgbColor rgb=\"FFA5A5A5\"/><rgbColor rgb=\"FF3F3F3F\"/>",
+        "<rgbColor rgb=\"FFDBDBDB\"/><rgbColor rgb=\"FFFFD931\"/><rgbColor rgb=\"FFFE634D\"/>",
+        "</indexedColors></colors>",
+    );
+
+    fn archive_of(styles: &str) -> zip::ZipArchive<Cursor<Vec<u8>>> {
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(Cursor::new(&mut buf));
+            zw.start_file("xl/styles.xml", zip::write::FileOptions::default())
+                .unwrap();
+            zw.write_all(styles.as_bytes()).unwrap();
+            zw.finish().unwrap();
+        }
+        zip::ZipArchive::new(Cursor::new(buf)).unwrap()
+    }
+
+    // With an `<indexedColors>` override, `indexed=` fills/fonts resolve to the FILE's palette.
+    #[test]
+    fn indexed_override_wins_over_default_palette() {
+        let mut archive = archive_of(&styles_xml(OVERRIDE));
+        let styles = load_styles(&mut archive, &Theme::default()).unwrap();
+        // fill 2: fgColor indexed=13 -> the file's #FFD931 (default 13 is #FFFF00).
+        assert_eq!(styles.fills[2].color, Color::Rgb("#FFD931".to_string()));
+        // font 1: color indexed=14 -> the file's #FE634D (default 14 is #FF00FF).
+        assert_eq!(styles.fonts[1].color, Color::Rgb("#FE634D".to_string()));
+    }
+
+    // Without an override, `indexed=` resolves against the legacy default palette (unchanged).
+    #[test]
+    fn no_override_keeps_default_palette() {
+        let mut archive = archive_of(&styles_xml(""));
+        let styles = load_styles(&mut archive, &Theme::default()).unwrap();
+        assert_eq!(styles.fills[2].color, Color::Rgb("#FFFF00".to_string()));
+        assert_eq!(styles.fonts[1].color, Color::Rgb("#FF00FF".to_string()));
+    }
+
+    // `parse_indexed_colors` reads the palette positionally and returns None when absent.
+    #[test]
+    fn parse_indexed_colors_reads_override_or_none() {
+        let with = styles_xml(OVERRIDE);
+        let doc = roxmltree::Document::parse(&with).unwrap();
+        let palette = parse_indexed_colors(doc.root_element()).unwrap();
+        assert_eq!(palette.len(), 15);
+        assert_eq!(palette[13], "#FFD931");
+        assert_eq!(palette[14], "#FE634D");
+
+        let without = styles_xml("");
+        let doc = roxmltree::Document::parse(&without).unwrap();
+        assert!(parse_indexed_colors(doc.root_element()).is_none());
+    }
+
+    // `get_color_indexed` precedence + guards, independent of the file path.
+    #[test]
+    fn get_color_indexed_precedence_and_guards() {
+        let theme = Theme::default();
+        let palette = vec!["#000000".to_string(), "#FFFFFF".to_string()];
+        let resolve = |xml: &str| {
+            let doc = roxmltree::Document::parse(xml).unwrap();
+            get_color_indexed(doc.root_element(), &theme, Some(&palette)).unwrap()
+        };
+        // In-range index -> the override slot.
+        assert_eq!(
+            resolve(r#"<c indexed="1"/>"#),
+            Color::Rgb("#FFFFFF".to_string())
+        );
+        // rgb= takes precedence over any palette.
+        assert_eq!(
+            resolve(r#"<c rgb="FF112233"/>"#),
+            Color::Rgb("#112233".to_string())
+        );
+        // System index 64 (transparent) -> None, never a palette lookup.
+        assert_eq!(resolve(r#"<c indexed="64"/>"#), Color::None);
+        // Out-of-range index -> default palette fallback (index 5 default = #FFFF00).
+        assert_eq!(
+            resolve(r#"<c indexed="5"/>"#),
+            Color::Rgb("#FFFF00".to_string())
+        );
+        // theme= is unaffected by the indexed override.
+        assert_eq!(
+            resolve(r#"<c theme="3" tint="0.0"/>"#),
+            Color::Theme(3, 0.0)
+        );
+    }
 }

--- a/xlsx/src/import/util.rs
+++ b/xlsx/src/import/util.rs
@@ -66,6 +66,12 @@ pub(super) fn get_color_indexed(
             // 64 is "transparent" in OOXML, but we don't have a good way to represent that, so we'll just ignore it
             return Ok(Color::None);
         }
+        if index < 0 {
+            // A malformed `indexed="-1"` would underflow `index as usize` inside
+            // `get_indexed_color` and panic; treat it like any other out-of-range index and
+            // fall back to the default palette entry.
+            return Ok(Color::Rgb(get_indexed_color(0)));
+        }
         // Prefer the file's `<indexedColors>` override entry (when the file supplies one and it
         // covers this index); otherwise fall back to the legacy default indexed palette.
         let rgb = indexed

--- a/xlsx/src/import/util.rs
+++ b/xlsx/src/import/util.rs
@@ -36,7 +36,20 @@ pub(super) fn get_value_or_default(node: &Node, tag_name: &str, default: &str) -
     }
 }
 
-pub(super) fn get_color(node: Node, _theme: &Theme) -> Result<Color, XlsxError> {
+pub(super) fn get_color(node: Node, theme: &Theme) -> Result<Color, XlsxError> {
+    get_color_indexed(node, theme, None)
+}
+
+/// Like [`get_color`], but resolves an `indexed="n"` colour against the workbook's
+/// `<colors><indexedColors>` palette override (OOXML §18.8.27) when the file supplies one.
+/// `indexed` is that override as `#RRGGBB` strings positioned by index; `None` (the common
+/// case, no override) keeps the legacy default indexed palette. An out-of-range or malformed
+/// override entry also falls back to the default palette.
+pub(super) fn get_color_indexed(
+    node: Node,
+    _theme: &Theme,
+    indexed: Option<&[String]>,
+) -> Result<Color, XlsxError> {
     // 18.3.1.15 color (Data Bar Color)
     if node.has_attribute("rgb") {
         let raw = node.attribute("rgb").unwrap();
@@ -53,7 +66,17 @@ pub(super) fn get_color(node: Node, _theme: &Theme) -> Result<Color, XlsxError> 
             // 64 is "transparent" in OOXML, but we don't have a good way to represent that, so we'll just ignore it
             return Ok(Color::None);
         }
-        let rgb = get_indexed_color(index);
+        // Prefer the file's `<indexedColors>` override entry (when the file supplies one and it
+        // covers this index); otherwise fall back to the legacy default indexed palette.
+        let rgb = indexed
+            .and_then(|palette| {
+                usize::try_from(index)
+                    .ok()
+                    .and_then(|i| palette.get(i))
+                    .filter(|s| !s.is_empty())
+                    .cloned()
+            })
+            .unwrap_or_else(|| get_indexed_color(index));
         Ok(Color::Rgb(rgb))
     } else if node.has_attribute("theme") {
         let theme_index = node.attribute("theme").unwrap().parse::<i32>()?;


### PR DESCRIPTION
## Problem

The importer resolves every `indexed="n"` colour against the hardcoded legacy
default palette (`get_indexed_color`) and never reads the workbook's own
`<colors><indexedColors>` override (OOXML 18.8.27). A file that redefines
palette entries (e.g. Numbers exports) therefore renders its indexed
fills/fonts/borders with the *default* colour n instead of the *file's* colour n.

### Repro

Open a workbook that ships an `<indexedColors>` override (Apple Numbers `.xlsx`
exports do this). Indexed fills render as the default palette (e.g. bright
blue / yellow / magenta) instead of the file's palette (e.g. greys / gold).

## Fix

Parse `<indexedColors>` once in `load_styles` and thread it through the
styles-path colour resolution (fills, fonts, borders, dxfs) via a new
`get_color_indexed`: when the file supplies an override the file's entry wins,
otherwise behaviour is unchanged. System index 64 and out-of-range/malformed
entries fall back to the previous behaviour.

## Scope

Tab colours and conditional-format colours still use the default resolver — a
documented follow-up, kept out of this change to keep it minimal.

## Tests

End-to-end `load_styles` with and without an override, `parse_indexed_colors`,
and `get_color_indexed` precedence/guards.

## Demo File

[numbers_table.xlsx](https://github.com/user-attachments/files/29780655/numbers_table.xlsx)
