### PR TITLE
FIX: Have a dedicated endpoint for create/update named cell styles

### DIFF
--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -107,7 +107,9 @@ impl Styles {
             apply_protection: false,
             apply_font: false,
             apply_fill: false,
-            quote_prefix: style.quote_prefix,
+            // A quote prefix marks a cell's own apostrophe-escaped content;
+            // it is not a named-style category in Excel and is normalized out.
+            quote_prefix: false,
             alignment: style.alignment.clone(),
         });
         xf_id
@@ -225,6 +227,9 @@ impl Styles {
             || cell_xf.apply_border
             || cell_xf.apply_alignment
             || cell_xf.apply_protection
+            // A quote prefix is a cell's own apostrophe-escaped state, never
+            // part of a named style, so such an xf is not a plain representative.
+            || cell_xf.quote_prefix
     }
 
     // Same as `get_style_index_by_name` but creates the plain representative if
@@ -281,6 +286,8 @@ impl Styles {
         })
     }
 
+    /// Creates a named style. `style.quote_prefix` is ignored: a quote prefix
+    /// belongs to a cell's content, not to a named style.
     pub fn create_named_style(&mut self, style_name: &str, style: &Style) -> Result<(), String> {
         if self.get_xf_id_by_name(style_name).is_ok() {
             return Err("A style with that name already exists".to_string());
@@ -509,7 +516,8 @@ impl<'a> Model<'a> {
     ///   the style, except those a cell overrides locally (its `apply_*` flags).
     ///
     /// Cells keep their style index, so they pick up the new formatting without
-    /// being touched.
+    /// being touched. `style.quote_prefix` is ignored: a quote prefix belongs
+    /// to a cell's content, not to a named style, and is never propagated.
     pub fn update_named_style(
         &mut self,
         name: &str,

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -84,17 +84,15 @@ impl Styles {
     // when the style is applied to them). Returns the new `xf_id`.
     fn create_base_style(&mut self, style: &Style) -> i32 {
         let (num_fmt_id, font_id, fill_id, border_id) = self.get_or_create_component_ids(style);
+        // The apply* flags on a cellStyleXfs record mark which formatting
+        // categories the style includes; IronCalc styles include all of them
+        // (the default), otherwise Excel would treat the style as empty.
         self.cell_style_xfs.push(CellStyleXfs {
             num_fmt_id,
             font_id,
             fill_id,
             border_id,
-            apply_number_format: false,
-            apply_border: false,
-            apply_alignment: false,
-            apply_protection: false,
-            apply_font: false,
-            apply_fill: false,
+            ..Default::default()
         });
         let xf_id = self.cell_style_xfs.len() as i32 - 1;
         self.cell_xfs.push(CellXfs {
@@ -537,12 +535,7 @@ impl<'a> Model<'a> {
             font_id,
             fill_id,
             border_id,
-            apply_number_format: false,
-            apply_border: false,
-            apply_alignment: false,
-            apply_protection: false,
-            apply_font: false,
-            apply_fill: false,
+            ..Default::default()
         };
 
         for cell_xf in styles.cell_xfs.iter_mut().filter(|xf| xf.xf_id == xf_id) {

--- a/base/src/styles.rs
+++ b/base/src/styles.rs
@@ -1,7 +1,7 @@
 use crate::{
     model::Model,
     number_format::{get_default_num_fmt_id, get_new_num_fmt_index, get_num_fmt},
-    types::{Border, CellStyles, CellXfs, Dxf, Fill, Font, NumFmt, Style, Styles},
+    types::{Border, CellStyleXfs, CellStyles, CellXfs, Dxf, Fill, Font, NumFmt, Style, Styles},
 };
 
 impl Styles {
@@ -41,7 +41,9 @@ impl Styles {
         None
     }
 
-    pub fn create_new_style(&mut self, style: &Style) -> i32 {
+    // Returns `(num_fmt_id, font_id, fill_id, border_id)` for the style,
+    // adding any missing components to the pools.
+    fn get_or_create_component_ids(&mut self, style: &Style) -> (i32, i32, i32, i32) {
         let font = &style.font;
         let font_id = if let Some(index) = self.get_font_index(font) {
             index
@@ -74,6 +76,47 @@ impl Styles {
                 num_fmt_id,
             });
         }
+        (num_fmt_id, font_id, fill_id, border_id)
+    }
+
+    // Creates the base record of a named style: a new entry in `cell_style_xfs`
+    // together with its "plain representative" in `cell_xfs` (the xf cells get
+    // when the style is applied to them). Returns the new `xf_id`.
+    fn create_base_style(&mut self, style: &Style) -> i32 {
+        let (num_fmt_id, font_id, fill_id, border_id) = self.get_or_create_component_ids(style);
+        self.cell_style_xfs.push(CellStyleXfs {
+            num_fmt_id,
+            font_id,
+            fill_id,
+            border_id,
+            apply_number_format: false,
+            apply_border: false,
+            apply_alignment: false,
+            apply_protection: false,
+            apply_font: false,
+            apply_fill: false,
+        });
+        let xf_id = self.cell_style_xfs.len() as i32 - 1;
+        self.cell_xfs.push(CellXfs {
+            xf_id,
+            num_fmt_id,
+            font_id,
+            fill_id,
+            border_id,
+            apply_number_format: false,
+            apply_border: false,
+            apply_alignment: false,
+            apply_protection: false,
+            apply_font: false,
+            apply_fill: false,
+            quote_prefix: style.quote_prefix,
+            alignment: style.alignment.clone(),
+        });
+        xf_id
+    }
+
+    pub fn create_new_style(&mut self, style: &Style) -> i32 {
+        let (num_fmt_id, font_id, fill_id, border_id) = self.get_or_create_component_ids(style);
         self.cell_xfs.push(CellXfs {
             xf_id: 0,
             num_fmt_id,
@@ -94,6 +137,12 @@ impl Styles {
 
     pub fn get_style_index(&self, style: &Style) -> Option<i32> {
         for (index, cell_xf) in self.cell_xfs.iter().enumerate() {
+            // Only anonymous formats qualify: an xf parented to a named style
+            // (xf_id != 0) changes when the style is updated, so visually equal
+            // formatting must not be deduplicated into it.
+            if cell_xf.xf_id != 0 {
+                continue;
+            }
             let border_id = cell_xf.border_id as usize;
             let fill_id = cell_xf.fill_id as usize;
             let font_id = cell_xf.font_id as usize;
@@ -124,31 +173,31 @@ impl Styles {
         }
     }
 
-    /// Adds a named cell style from an existing index
-    /// Fails if the named style already exists or if there is not a style with that index
-    pub fn add_named_cell_style(
+    /// Adds a named cell style pointing to an existing `cell_style_xfs` record.
+    /// Fails if the named style already exists or if `xf_id` is not a valid index.
+    pub(crate) fn add_named_cell_style(
         &mut self,
         style_name: &str,
-        style_index: i32,
+        xf_id: i32,
     ) -> Result<(), String> {
-        if self.get_style_index_by_name(style_name).is_ok() {
+        if self.get_xf_id_by_name(style_name).is_ok() {
             return Err("A style with that name already exists".to_string());
         }
-        if self.cell_xfs.len() < style_index as usize {
-            return Err("There is no style with that index".to_string());
+        if xf_id < 0 || xf_id as usize >= self.cell_style_xfs.len() {
+            return Err("There is no cell style xf with that index".to_string());
         }
         let cell_style = CellStyles {
             name: style_name.to_string(),
-            xf_id: style_index,
+            xf_id,
             builtin_id: 0,
         };
         self.cell_styles.push(cell_style);
         Ok(())
     }
 
-    // Returns the index of the style or fails.
+    // Returns the `xf_id` (index into `cell_style_xfs`) of the named style or fails.
     // NB: this method is case sensitive
-    pub fn get_style_index_by_name(&self, style_name: &str) -> Result<i32, String> {
+    pub(crate) fn get_xf_id_by_name(&self, style_name: &str) -> Result<i32, String> {
         for cell_style in &self.cell_styles {
             if cell_style.name == style_name {
                 return Ok(cell_style.xf_id);
@@ -157,9 +206,89 @@ impl Styles {
         Err(format!("Style '{style_name}' not found"))
     }
 
+    // Returns the index in `cell_xfs` of the "plain representative" of the named
+    // style: an xf parented to the style's `xf_id` carrying no local overrides.
+    // This is the index cells get when the style is applied to them.
+    // NB: this method is case sensitive
+    pub fn get_style_index_by_name(&self, style_name: &str) -> Result<i32, String> {
+        let xf_id = self.get_xf_id_by_name(style_name)?;
+        for (index, cell_xf) in self.cell_xfs.iter().enumerate() {
+            if cell_xf.xf_id == xf_id && !Self::cell_xf_has_overrides(cell_xf) {
+                return Ok(index as i32);
+            }
+        }
+        Err(format!("Style '{style_name}' has no plain cell xf"))
+    }
+
+    fn cell_xf_has_overrides(cell_xf: &CellXfs) -> bool {
+        cell_xf.apply_number_format
+            || cell_xf.apply_font
+            || cell_xf.apply_fill
+            || cell_xf.apply_border
+            || cell_xf.apply_alignment
+            || cell_xf.apply_protection
+    }
+
+    // Same as `get_style_index_by_name` but creates the plain representative if
+    // the workbook lacks one (e.g. an imported named style applied to no cell).
+    pub(crate) fn get_or_create_style_index_by_name(
+        &mut self,
+        style_name: &str,
+    ) -> Result<i32, String> {
+        if let Ok(index) = self.get_style_index_by_name(style_name) {
+            return Ok(index);
+        }
+        let xf_id = self.get_xf_id_by_name(style_name)?;
+        let style_xf = self
+            .cell_style_xfs
+            .get(xf_id as usize)
+            .ok_or_else(|| format!("Style '{style_name}' points to an invalid xf id"))?;
+        self.cell_xfs.push(CellXfs {
+            xf_id,
+            num_fmt_id: style_xf.num_fmt_id,
+            font_id: style_xf.font_id,
+            fill_id: style_xf.fill_id,
+            border_id: style_xf.border_id,
+            apply_number_format: false,
+            apply_border: false,
+            apply_alignment: false,
+            apply_protection: false,
+            apply_font: false,
+            apply_fill: false,
+            quote_prefix: false,
+            alignment: None,
+        });
+        Ok(self.cell_xfs.len() as i32 - 1)
+    }
+
+    // Returns the `Style` of a named style. Reads the plain representative in
+    // `cell_xfs` when there is one (it also carries alignment); otherwise the
+    // style is reconstructed from its `cell_style_xfs` record.
+    pub(crate) fn get_style_by_name(&self, style_name: &str) -> Result<Style, String> {
+        if let Ok(index) = self.get_style_index_by_name(style_name) {
+            return self.get_style(index);
+        }
+        let xf_id = self.get_xf_id_by_name(style_name)?;
+        let style_xf = self
+            .cell_style_xfs
+            .get(xf_id as usize)
+            .ok_or_else(|| format!("Style '{style_name}' points to an invalid xf id"))?;
+        Ok(Style {
+            alignment: None,
+            num_fmt: get_num_fmt(style_xf.num_fmt_id, &self.num_fmts),
+            fill: self.fills[style_xf.fill_id as usize].clone(),
+            font: self.fonts[style_xf.font_id as usize].clone(),
+            border: self.borders[style_xf.border_id as usize].clone(),
+            quote_prefix: false,
+        })
+    }
+
     pub fn create_named_style(&mut self, style_name: &str, style: &Style) -> Result<(), String> {
-        let style_index = self.create_new_style(style);
-        self.add_named_cell_style(style_name, style_index)
+        if self.get_xf_id_by_name(style_name).is_ok() {
+            return Err("A style with that name already exists".to_string());
+        }
+        let xf_id = self.create_base_style(style);
+        self.add_named_cell_style(style_name, xf_id)
     }
 
     /// Returns the names of all named styles
@@ -188,13 +317,12 @@ impl Styles {
         Ok(())
     }
 
-    /// Updates the xf_id and name of an existing named style entry.
+    /// Renames an existing named style entry. Its `xf_id` never changes.
     /// Fails if the style does not exist.
-    pub(crate) fn update_named_style_entry(
+    pub(crate) fn rename_named_style_entry(
         &mut self,
         style_name: &str,
         new_name: &str,
-        new_xf_id: i32,
     ) -> Result<(), String> {
         let cs = self
             .cell_styles
@@ -202,7 +330,6 @@ impl Styles {
             .find(|cs| cs.name == style_name)
             .ok_or_else(|| format!("Style '{style_name}' not found"))?;
         cs.name = new_name.to_string();
-        cs.xf_id = new_xf_id;
         Ok(())
     }
 
@@ -303,14 +430,20 @@ impl<'a> Model<'a> {
         column: i32,
         style_name: &str,
     ) -> Result<(), String> {
-        let style_index = self.workbook.styles.get_style_index_by_name(style_name)?;
+        let style_index = self
+            .workbook
+            .styles
+            .get_or_create_style_index_by_name(style_name)?;
         self.workbook
             .worksheet_mut(sheet)?
             .set_cell_style(row, column, style_index)
     }
 
     pub fn set_sheet_style(&mut self, sheet: u32, style_name: &str) -> Result<(), String> {
-        let style_index = self.workbook.styles.get_style_index_by_name(style_name)?;
+        let style_index = self
+            .workbook
+            .styles
+            .get_or_create_style_index_by_name(style_name)?;
         self.workbook.worksheet_mut(sheet)?.set_style(style_index)?;
         Ok(())
     }
@@ -321,7 +454,10 @@ impl<'a> Model<'a> {
         row: i32,
         style_name: &str,
     ) -> Result<(), String> {
-        let style_index = self.workbook.styles.get_style_index_by_name(style_name)?;
+        let style_index = self
+            .workbook
+            .styles
+            .get_or_create_style_index_by_name(style_name)?;
         self.workbook
             .worksheet_mut(sheet)?
             .set_row_style(row, style_index)?;
@@ -334,7 +470,10 @@ impl<'a> Model<'a> {
         column: i32,
         style_name: &str,
     ) -> Result<(), String> {
-        let style_index = self.workbook.styles.get_style_index_by_name(style_name)?;
+        let style_index = self
+            .workbook
+            .styles
+            .get_or_create_style_index_by_name(style_name)?;
         self.workbook
             .worksheet_mut(sheet)?
             .set_column_style(column, style_index)?;
@@ -348,8 +487,7 @@ impl<'a> Model<'a> {
 
     /// Returns the `Style` associated with the named style.
     pub fn get_named_style(&self, name: &str) -> Result<Style, String> {
-        let xf_id = self.workbook.styles.get_style_index_by_name(name)?;
-        self.workbook.styles.get_style(xf_id)
+        self.workbook.styles.get_style_by_name(name)
     }
 
     /// Creates a new named style. Fails if a style with that name already exists.
@@ -367,54 +505,68 @@ impl<'a> Model<'a> {
     }
 
     /// Updates the formatting and optionally the name of a named style.
-    /// All cells, rows, and columns that use the old style are updated to the new formatting.
-    /// Fails if the style does not exist, is built-in, or if `new_name` is already taken (when renaming).
-    /// Returns `(old_xf_id, new_xf_id)` for diff tracking.
+    /// The style's `xf_id` never changes:
+    /// * The style's `cell_style_xfs` record is rewritten in place.
+    /// * The new components are propagated to every `cell_xfs` entry parented to
+    ///   the style, except those a cell overrides locally (its `apply_*` flags).
+    ///
+    /// Cells keep their style index, so they pick up the new formatting without
+    /// being touched.
     pub fn update_named_style(
         &mut self,
         name: &str,
         new_name: &str,
         style: &Style,
-    ) -> Result<(i32, i32), String> {
-        if self.workbook.styles.is_builtin_style(name) {
+    ) -> Result<(), String> {
+        let styles = &mut self.workbook.styles;
+        if styles.is_builtin_style(name) {
             return Err(format!("Cannot modify built-in style '{name}'"));
         }
-        let old_xf_id = self.workbook.styles.get_style_index_by_name(name)?;
-        if name != new_name
-            && self
-                .workbook
-                .styles
-                .get_style_index_by_name(new_name)
-                .is_ok()
-        {
+        let xf_id = styles.get_xf_id_by_name(name)?;
+        if name != new_name && styles.get_xf_id_by_name(new_name).is_ok() {
             return Err(format!("A style named '{new_name}' already exists"));
         }
-        let new_xf_id = self.workbook.styles.get_style_index_or_create(style);
-        if old_xf_id != new_xf_id {
-            for worksheet in &mut self.workbook.worksheets {
-                for row_data in worksheet.sheet_data.values_mut() {
-                    for cell in row_data.values_mut() {
-                        if cell.get_style() == old_xf_id {
-                            cell.set_style(new_xf_id);
-                        }
-                    }
-                }
-                for row in &mut worksheet.rows {
-                    if row.s == old_xf_id {
-                        row.s = new_xf_id;
-                    }
-                }
-                for col in &mut worksheet.cols {
-                    if col.style == Some(old_xf_id) {
-                        col.style = Some(new_xf_id);
-                    }
-                }
+        if xf_id < 0 || xf_id as usize >= styles.cell_style_xfs.len() {
+            return Err(format!("Style '{name}' points to an invalid xf id"));
+        }
+
+        let (num_fmt_id, font_id, fill_id, border_id) = styles.get_or_create_component_ids(style);
+
+        styles.cell_style_xfs[xf_id as usize] = CellStyleXfs {
+            num_fmt_id,
+            font_id,
+            fill_id,
+            border_id,
+            apply_number_format: false,
+            apply_border: false,
+            apply_alignment: false,
+            apply_protection: false,
+            apply_font: false,
+            apply_fill: false,
+        };
+
+        for cell_xf in styles.cell_xfs.iter_mut().filter(|xf| xf.xf_id == xf_id) {
+            if !cell_xf.apply_number_format {
+                cell_xf.num_fmt_id = num_fmt_id;
+            }
+            if !cell_xf.apply_font {
+                cell_xf.font_id = font_id;
+            }
+            if !cell_xf.apply_fill {
+                cell_xf.fill_id = fill_id;
+            }
+            if !cell_xf.apply_border {
+                cell_xf.border_id = border_id;
+            }
+            if !cell_xf.apply_alignment {
+                cell_xf.alignment = style.alignment.clone();
             }
         }
-        self.workbook
-            .styles
-            .update_named_style_entry(name, new_name, new_xf_id)?;
-        Ok((old_xf_id, new_xf_id))
+
+        if name != new_name {
+            styles.rename_named_style_entry(name, new_name)?;
+        }
+        Ok(())
     }
 }
 

--- a/base/src/test/test_styles.rs
+++ b/base/src/test/test_styles.rs
@@ -293,6 +293,36 @@ fn test_apply_named_style_without_representative() {
 }
 
 #[test]
+fn test_named_style_base_record_includes_all_categories() {
+    // In cellStyleXfs the apply* flags mean "the style includes this formatting
+    // category" (Excel's "Style Includes" checkboxes) and default to true.
+    // IronCalc styles are full styles, so records we create or update must have
+    // all flags true; false would export as applyX="0" and Excel would treat
+    // the style as including nothing.
+    fn assert_all_included(model: &crate::model::Model, name: &str) {
+        let styles = &model.workbook.styles;
+        let xf_id = styles.get_xf_id_by_name(name).unwrap();
+        let record = &styles.cell_style_xfs[xf_id as usize];
+        assert!(record.apply_number_format, "number format not included");
+        assert!(record.apply_font, "font not included");
+        assert!(record.apply_fill, "fill not included");
+        assert!(record.apply_border, "border not included");
+        assert!(record.apply_alignment, "alignment not included");
+        assert!(record.apply_protection, "protection not included");
+    }
+
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    assert_all_included(&model, "bold");
+
+    style.font.i = true;
+    model.update_named_style("bold", "bold", &style).unwrap();
+    assert_all_included(&model, "bold");
+}
+
+#[test]
 fn test_update_named_style_rejects_builtin() {
     let mut model = new_empty_model();
     let style = model.get_style_for_cell(0, 1, 1).unwrap();

--- a/base/src/test/test_styles.rs
+++ b/base/src/test/test_styles.rs
@@ -23,27 +23,6 @@ fn test_model_set_cells_with_values_styles() {
 }
 
 #[test]
-fn test_named_styles() {
-    let mut model = new_empty_model();
-    model._set("A1", "42");
-    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
-    style.font.b = true;
-    assert!(model.set_cell_style(0, 1, 1, &style).is_ok());
-    let bold_style_index = model.get_cell_style_index(0, 1, 1).unwrap();
-    let e = model
-        .workbook
-        .styles
-        .add_named_cell_style("bold", bold_style_index);
-    assert!(e.is_ok());
-    model._set("A2", "420");
-    let a2_style_index = model.get_cell_style_index(0, 2, 1).unwrap();
-    assert!(a2_style_index != bold_style_index);
-    let e = model.set_cell_style_by_name(0, 2, 1, "bold");
-    assert!(e.is_ok());
-    assert_eq!(model.get_cell_style_index(0, 2, 1), Ok(bold_style_index));
-}
-
-#[test]
 fn test_create_named_style() {
     let mut model = new_empty_model();
     model._set("A1", "42");
@@ -146,6 +125,171 @@ fn test_update_named_style_rename() {
     model.update_named_style("bold", "bold2", &style).unwrap();
     assert!(model.get_named_style("bold").is_err());
     assert!(model.get_named_style("bold2").is_ok());
+}
+
+#[test]
+fn test_named_style_tables() {
+    // Creating a named style adds one record to each of the three tables:
+    // cell_style_xfs (the base record), cell_xfs (the plain representative
+    // pointing at it) and cell_styles (the name).
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+
+    let styles = &model.workbook.styles;
+    let cell_style = styles
+        .cell_styles
+        .iter()
+        .find(|cs| cs.name == "bold")
+        .unwrap();
+    let xf_id = cell_style.xf_id;
+    assert_eq!(xf_id, styles.cell_style_xfs.len() as i32 - 1);
+
+    let representative = styles.get_style_index_by_name("bold").unwrap();
+    let cell_xf = &styles.cell_xfs[representative as usize];
+    assert_eq!(cell_xf.xf_id, xf_id);
+    let style_xf = &styles.cell_style_xfs[xf_id as usize];
+    assert_eq!(cell_xf.font_id, style_xf.font_id);
+    assert!(styles.fonts[style_xf.font_id as usize].b);
+}
+
+#[test]
+fn test_named_styles_with_same_format_are_independent() {
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold1", &style).unwrap();
+    model.create_named_style("bold2", &style).unwrap();
+
+    // Each named style has its own base record even if the formatting is equal
+    let xf_id1 = model.workbook.styles.get_xf_id_by_name("bold1").unwrap();
+    let xf_id2 = model.workbook.styles.get_xf_id_by_name("bold2").unwrap();
+    assert_ne!(xf_id1, xf_id2);
+
+    model.set_cell_style_by_name(0, 1, 1, "bold1").unwrap();
+    model.set_cell_style_by_name(0, 2, 1, "bold2").unwrap();
+
+    // Updating one of them must not affect the other
+    let mut new_style = style.clone();
+    new_style.font.i = true;
+    model
+        .update_named_style("bold1", "bold1", &new_style)
+        .unwrap();
+    assert!(model.get_style_for_cell(0, 1, 1).unwrap().font.i);
+    assert!(!model.get_style_for_cell(0, 2, 1).unwrap().font.i);
+    assert!(!model.get_named_style("bold2").unwrap().font.i);
+}
+
+#[test]
+fn test_update_named_style_leaves_anonymous_formatting_alone() {
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    // A1 uses the named style; A2 has identical but anonymous formatting
+    model.set_cell_style_by_name(0, 1, 1, "bold").unwrap();
+    model.set_cell_style(0, 2, 1, &style).unwrap();
+
+    let mut new_style = style.clone();
+    new_style.font.i = true;
+    model
+        .update_named_style("bold", "bold", &new_style)
+        .unwrap();
+
+    assert!(model.get_style_for_cell(0, 1, 1).unwrap().font.i);
+    assert!(!model.get_style_for_cell(0, 2, 1).unwrap().font.i);
+}
+
+#[test]
+fn test_update_named_style_respects_cell_overrides() {
+    use crate::types::Color;
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    model.set_cell_style_by_name(0, 1, 1, "bold").unwrap();
+
+    // Simulate an imported cell parented to "bold" with a local font override
+    // (applyFont="1"), as Excel produces when a styled cell is tweaked.
+    let representative = model
+        .workbook
+        .styles
+        .get_style_index_by_name("bold")
+        .unwrap();
+    let mut cell_xf = model.workbook.styles.cell_xfs[representative as usize].clone();
+    cell_xf.apply_font = true;
+    cell_xf.font_id = 0; // the default (non-bold) font
+    model.workbook.styles.cell_xfs.push(cell_xf);
+    let override_index = model.workbook.styles.cell_xfs.len() as i32 - 1;
+    model
+        .workbook
+        .worksheet_mut(0)
+        .unwrap()
+        .set_cell_style(2, 1, override_index)
+        .unwrap();
+
+    // Update the style: italic font and a yellow fill
+    let mut new_style = model.get_named_style("bold").unwrap();
+    new_style.font.i = true;
+    new_style.fill.color = Color::Rgb("#FFFF00".to_string());
+    model
+        .update_named_style("bold", "bold", &new_style)
+        .unwrap();
+
+    // The plain cell picks up both changes
+    let a1 = model.get_style_for_cell(0, 1, 1).unwrap();
+    assert!(a1.font.i);
+    assert_eq!(a1.fill.color, Color::Rgb("#FFFF00".to_string()));
+
+    // The overriding cell keeps its own font but inherits the new fill
+    let a2 = model.get_style_for_cell(0, 2, 1).unwrap();
+    assert!(!a2.font.i);
+    assert!(!a2.font.b);
+    assert_eq!(a2.fill.color, Color::Rgb("#FFFF00".to_string()));
+}
+
+#[test]
+fn test_apply_named_style_without_representative() {
+    use crate::types::{CellStyleXfs, CellStyles};
+    // Simulate an imported workbook where a named style is defined but applied
+    // to no cell: there is no cell_xfs entry parented to it.
+    let mut model = new_empty_model();
+    let styles = &mut model.workbook.styles;
+    styles.fonts.push(crate::types::Font {
+        b: true,
+        ..Default::default()
+    });
+    let font_id = styles.fonts.len() as i32 - 1;
+    styles.cell_style_xfs.push(CellStyleXfs {
+        font_id,
+        ..Default::default()
+    });
+    let xf_id = styles.cell_style_xfs.len() as i32 - 1;
+    styles.cell_styles.push(CellStyles {
+        name: "imported bold".to_string(),
+        xf_id,
+        builtin_id: 0,
+    });
+
+    // No representative yet
+    assert!(model
+        .workbook
+        .styles
+        .get_style_index_by_name("imported bold")
+        .is_err());
+    // But the style can be read and applied; the representative is created on demand
+    assert!(model.get_named_style("imported bold").unwrap().font.b);
+    model
+        .set_cell_style_by_name(0, 1, 1, "imported bold")
+        .unwrap();
+    assert!(model.get_style_for_cell(0, 1, 1).unwrap().font.b);
+    let index = model
+        .workbook
+        .styles
+        .get_style_index_by_name("imported bold")
+        .unwrap();
+    assert_eq!(model.workbook.styles.cell_xfs[index as usize].xf_id, xf_id);
 }
 
 #[test]

--- a/base/src/test/test_styles.rs
+++ b/base/src/test/test_styles.rs
@@ -323,6 +323,62 @@ fn test_named_style_base_record_includes_all_categories() {
 }
 
 #[test]
+fn test_named_style_ignores_quote_prefix() {
+    // A quote prefix marks a cell's own apostrophe-escaped content; it is not
+    // a named-style category and must be normalized out on create.
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    style.quote_prefix = true;
+    model.create_named_style("bold", &style).unwrap();
+    assert!(!model.get_named_style("bold").unwrap().quote_prefix);
+    // Applying the style to a cell does not add a quote prefix
+    model.set_cell_style_by_name(0, 1, 1, "bold").unwrap();
+    let cell_style = model.get_style_for_cell(0, 1, 1).unwrap();
+    assert!(cell_style.font.b);
+    assert!(!cell_style.quote_prefix);
+}
+
+#[test]
+fn test_update_named_style_keeps_cell_quote_prefix() {
+    // A cell parented to a named style can carry its own quote prefix (an
+    // imported "'123" cell); updating the style must not clobber it.
+    let mut model = new_empty_model();
+    let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
+    style.font.b = true;
+    model.create_named_style("bold", &style).unwrap();
+    let representative = model
+        .workbook
+        .styles
+        .get_style_index_by_name("bold")
+        .unwrap();
+    let mut cell_xf = model.workbook.styles.cell_xfs[representative as usize].clone();
+    cell_xf.quote_prefix = true;
+    model.workbook.styles.cell_xfs.push(cell_xf);
+    let quoted_index = model.workbook.styles.cell_xfs.len() as i32 - 1;
+    model
+        .workbook
+        .worksheet_mut(0)
+        .unwrap()
+        .set_cell_style(1, 1, quoted_index)
+        .unwrap();
+
+    let mut new_style = model.get_named_style("bold").unwrap();
+    new_style.font.i = true;
+    new_style.quote_prefix = true; // must be ignored
+    model
+        .update_named_style("bold", "bold", &new_style)
+        .unwrap();
+
+    // The quoted cell keeps its prefix and still picks up the new font
+    let a1 = model.get_style_for_cell(0, 1, 1).unwrap();
+    assert!(a1.quote_prefix);
+    assert!(a1.font.i);
+    // The named style itself carries no quote prefix
+    assert!(!model.get_named_style("bold").unwrap().quote_prefix);
+}
+
+#[test]
 fn test_update_named_style_rejects_builtin() {
     let mut model = new_empty_model();
     let style = model.get_style_for_cell(0, 1, 1).unwrap();

--- a/base/src/test/user_model/test_named_styles.rs
+++ b/base/src/test/user_model/test_named_styles.rs
@@ -196,6 +196,55 @@ fn apply_builtin_named_style_lazy_adds_to_model() {
 }
 
 #[test]
+fn apply_and_update_named_style_full_undo_redo() {
+    let mut model = new_empty_user_model();
+
+    // 1. Write "Hola" in D9
+    model.set_user_input(0, 9, 4, "Hola").unwrap();
+
+    // 2. Create a new named style
+    let mut style = model.get_cell_style(0, 9, 4).unwrap();
+    style.font.b = true;
+    model.create_named_style("greeting", &style).unwrap();
+
+    // 3. Apply it to D9
+    model.set_selected_cell(9, 4).unwrap();
+    model.set_selected_range(9, 4, 9, 4).unwrap();
+    model.on_apply_named_style("greeting").unwrap();
+    assert!(model.get_cell_style(0, 9, 4).unwrap().font.b);
+
+    // 4. Update the style with a text color
+    let red = Color::Rgb("#FF0000".to_string());
+    let mut new_style = model.get_named_style("greeting").unwrap();
+    new_style.font.color = red.clone();
+    model
+        .update_named_style("greeting", "greeting", &new_style)
+        .unwrap();
+    assert_eq!(model.get_cell_style(0, 9, 4).unwrap().font.color, red);
+
+    // 5. Undo everything
+    while model.can_undo() {
+        model.undo().unwrap();
+    }
+    assert_eq!(model.get_cell_content(0, 9, 4).unwrap(), "");
+    assert!(!model
+        .get_named_style_list()
+        .contains(&"greeting".to_string()));
+
+    // 6. Redo everything
+    while model.can_redo() {
+        model.redo().unwrap();
+    }
+
+    // D9 must show the style as of step 4 (red text), not as of step 3
+    assert_eq!(model.get_cell_content(0, 9, 4).unwrap(), "Hola");
+    assert_eq!(model.get_named_style("greeting").unwrap().font.color, red);
+    let d9 = model.get_cell_style(0, 9, 4).unwrap();
+    assert!(d9.font.b);
+    assert_eq!(d9.font.color, red);
+}
+
+#[test]
 fn apply_builtin_named_style_undo_redo() {
     let mut model = new_empty_user_model();
 

--- a/base/src/test/user_model/test_named_styles.rs
+++ b/base/src/test/user_model/test_named_styles.rs
@@ -160,6 +160,29 @@ fn update_named_style_rejects_builtin() {
 }
 
 #[test]
+fn apply_named_style_with_invalid_xf_id_errors() {
+    // A malformed workbook can contain a cellStyles entry pointing at a
+    // non-existent cellStyleXfs record. Applying it must surface that error,
+    // not fall back to the builtin styles.
+    let mut model = new_empty_user_model();
+    model
+        .model
+        .workbook
+        .styles
+        .cell_styles
+        .push(crate::types::CellStyles {
+            name: "corrupt".to_string(),
+            xf_id: 999,
+            builtin_id: 0,
+        });
+    let err = model.on_apply_named_style("corrupt").unwrap_err();
+    assert!(err.contains("invalid xf id"), "unexpected error: {err}");
+    // Nothing was added or applied
+    assert!(!model.get_cell_style(0, 1, 1).unwrap().font.b);
+    assert!(!model.can_undo());
+}
+
+#[test]
 fn get_named_style_list_includes_default() {
     let model = new_empty_user_model();
     let list = model.get_named_style_list();

--- a/base/src/user_model/history.rs
+++ b/base/src/user_model/history.rs
@@ -68,6 +68,15 @@ pub(crate) enum Diff {
         old_value: Box<Option<Style>>,
         new_value: Box<Style>,
     },
+    // Unlike `SetCellStyle`, applying a named style is recorded by name so that
+    // redo re-links the cell to the style instead of copying its formatting.
+    ApplyNamedStyle {
+        sheet: u32,
+        row: i32,
+        column: i32,
+        old_value: Box<Option<Style>>,
+        name: String,
+    },
     // Column and Row diffs
     SetColumnWidth {
         sheet: u32,
@@ -226,7 +235,7 @@ pub(crate) enum Diff {
     // Named style diffs
     CreateNamedStyle {
         name: String,
-        xf_id: i32,
+        style: Box<Style>,
     },
     DeleteNamedStyle {
         name: String,
@@ -235,8 +244,8 @@ pub(crate) enum Diff {
     UpdateNamedStyle {
         name: String,
         new_name: String,
-        old_xf_id: i32,
-        new_xf_id: i32,
+        old_style: Box<Style>,
+        new_style: Box<Style>,
     },
     // Conditional formatting diffs
     AddConditionalFormatting {

--- a/base/src/user_model/named_cell_styles.rs
+++ b/base/src/user_model/named_cell_styles.rs
@@ -67,27 +67,27 @@ impl<'a> UserModel<'a> {
         let mut diff_list = Vec::new();
 
         // Ensure the style exists in the model, adding it from builtins if needed.
-        let style_index = match self
-            .model
-            .workbook
-            .styles
-            .get_or_create_style_index_by_name(name)
-        {
-            Ok(style_index) => style_index,
-            Err(_) => {
-                let style = crate::builtin_styles::get_builtin_style(name)
-                    .ok_or_else(|| format!("Named style '{name}' not found"))?;
-                self.model
-                    .workbook
-                    .styles
-                    .create_named_style(name, &style)?;
-                let style_index = self.model.workbook.styles.get_style_index_by_name(name)?;
-                diff_list.push(Diff::CreateNamedStyle {
-                    name: name.to_string(),
-                    style: Box::new(style),
-                });
-                style_index
-            }
+        // Only fall back to the builtins when the name is genuinely absent;
+        // errors on an existing style (e.g. an invalid xf id in a malformed
+        // workbook) must surface as-is.
+        let style_index = if self.model.workbook.styles.get_xf_id_by_name(name).is_ok() {
+            self.model
+                .workbook
+                .styles
+                .get_or_create_style_index_by_name(name)?
+        } else {
+            let style = crate::builtin_styles::get_builtin_style(name)
+                .ok_or_else(|| format!("Named style '{name}' not found"))?;
+            self.model
+                .workbook
+                .styles
+                .create_named_style(name, &style)?;
+            let style_index = self.model.workbook.styles.get_style_index_by_name(name)?;
+            diff_list.push(Diff::CreateNamedStyle {
+                name: name.to_string(),
+                style: Box::new(style),
+            });
+            style_index
         };
 
         // Resolve the selection range.

--- a/base/src/user_model/named_cell_styles.rs
+++ b/base/src/user_model/named_cell_styles.rs
@@ -14,10 +14,9 @@ impl<'a> UserModel<'a> {
     /// Creates a new named style. Fails if a style with that name already exists.
     pub fn create_named_style(&mut self, name: &str, style: &Style) -> Result<(), String> {
         self.model.create_named_style(name, style)?;
-        let xf_id = self.model.workbook.styles.get_style_index_by_name(name)?;
         self.push_diff_list(vec![Diff::CreateNamedStyle {
             name: name.to_string(),
-            xf_id,
+            style: Box::new(style.clone()),
         }]);
         Ok(())
     }
@@ -25,7 +24,7 @@ impl<'a> UserModel<'a> {
     /// Deletes a named style. Fails if the style does not exist or is built-in.
     /// Cells that used this style keep their formatting.
     pub fn delete_named_style(&mut self, name: &str) -> Result<(), String> {
-        let old_xf_id = self.model.workbook.styles.get_style_index_by_name(name)?;
+        let old_xf_id = self.model.workbook.styles.get_xf_id_by_name(name)?;
         self.model.delete_named_style(name)?;
         self.push_diff_list(vec![Diff::DeleteNamedStyle {
             name: name.to_string(),
@@ -35,7 +34,7 @@ impl<'a> UserModel<'a> {
     }
 
     /// Updates the formatting and optionally the name of a named style.
-    /// All cells, rows, and columns using the old style are updated to the new formatting.
+    /// All cells, rows, and columns using the style pick up the new formatting.
     /// Fails if the style does not exist, is built-in, or if `new_name` is already taken.
     pub fn update_named_style(
         &mut self,
@@ -43,12 +42,13 @@ impl<'a> UserModel<'a> {
         new_name: &str,
         style: &Style,
     ) -> Result<(), String> {
-        let (old_xf_id, new_xf_id) = self.model.update_named_style(name, new_name, style)?;
+        let old_style = self.model.get_named_style(name)?;
+        self.model.update_named_style(name, new_name, style)?;
         self.push_diff_list(vec![Diff::UpdateNamedStyle {
             name: name.to_string(),
             new_name: new_name.to_string(),
-            old_xf_id,
-            new_xf_id,
+            old_style: Box::new(old_style),
+            new_style: Box::new(style.clone()),
         }]);
         Ok(())
     }
@@ -67,27 +67,28 @@ impl<'a> UserModel<'a> {
         let mut diff_list = Vec::new();
 
         // Ensure the style exists in the model, adding it from builtins if needed.
-        if self
+        let style_index = match self
             .model
             .workbook
             .styles
-            .get_style_index_by_name(name)
-            .is_err()
+            .get_or_create_style_index_by_name(name)
         {
-            let style = crate::builtin_styles::get_builtin_style(name)
-                .ok_or_else(|| format!("Named style '{name}' not found"))?;
-            self.model
-                .workbook
-                .styles
-                .create_named_style(name, &style)?;
-            let xf_id = self.model.workbook.styles.get_style_index_by_name(name)?;
-            diff_list.push(Diff::CreateNamedStyle {
-                name: name.to_string(),
-                xf_id,
-            });
-        }
-
-        let xf_id = self.model.workbook.styles.get_style_index_by_name(name)?;
+            Ok(style_index) => style_index,
+            Err(_) => {
+                let style = crate::builtin_styles::get_builtin_style(name)
+                    .ok_or_else(|| format!("Named style '{name}' not found"))?;
+                self.model
+                    .workbook
+                    .styles
+                    .create_named_style(name, &style)?;
+                let style_index = self.model.workbook.styles.get_style_index_by_name(name)?;
+                diff_list.push(Diff::CreateNamedStyle {
+                    name: name.to_string(),
+                    style: Box::new(style),
+                });
+                style_index
+            }
+        };
 
         // Resolve the selection range.
         let sheet = if let Some(view) = self.model.workbook.views.get(&self.model.view_id) {
@@ -106,20 +107,20 @@ impl<'a> UserModel<'a> {
         };
 
         let [row_start, column_start, row_end, column_end] = range;
-        let new_style = self.model.workbook.styles.get_style(xf_id)?;
         for row in row_start..=row_end {
             for column in column_start..=column_end {
                 let old_value = self.model.get_cell_style_or_none(sheet, row, column)?;
-                self.model
-                    .workbook
-                    .worksheet_mut(sheet)?
-                    .set_cell_style(row, column, xf_id)?;
-                diff_list.push(Diff::SetCellStyle {
+                self.model.workbook.worksheet_mut(sheet)?.set_cell_style(
+                    row,
+                    column,
+                    style_index,
+                )?;
+                diff_list.push(Diff::ApplyNamedStyle {
                     sheet,
                     row,
                     column,
                     old_value: Box::new(old_value),
-                    new_value: Box::new(new_style.clone()),
+                    name: name.to_string(),
                 });
             }
         }

--- a/base/src/user_model/undo_redo.rs
+++ b/base/src/user_model/undo_redo.rs
@@ -197,6 +197,13 @@ impl<'a> UserModel<'a> {
                     column,
                     old_value,
                     new_value: _,
+                }
+                | Diff::ApplyNamedStyle {
+                    sheet,
+                    row,
+                    column,
+                    old_value,
+                    name: _,
                 } => {
                     if let Some(old_style) = old_value.as_ref() {
                         self.model
@@ -504,7 +511,7 @@ impl<'a> UserModel<'a> {
                 } => {
                     self.model.set_timezone(old_value)?;
                 }
-                Diff::CreateNamedStyle { name, xf_id: _ } => {
+                Diff::CreateNamedStyle { name, style: _ } => {
                     self.model.workbook.styles.delete_named_style_entry(name)?;
                 }
                 Diff::DeleteNamedStyle { name, old_xf_id } => {
@@ -516,34 +523,10 @@ impl<'a> UserModel<'a> {
                 Diff::UpdateNamedStyle {
                     name,
                     new_name,
-                    old_xf_id,
-                    new_xf_id,
+                    old_style,
+                    new_style: _,
                 } => {
-                    if old_xf_id != new_xf_id {
-                        for worksheet in &mut self.model.workbook.worksheets {
-                            for row_data in worksheet.sheet_data.values_mut() {
-                                for cell in row_data.values_mut() {
-                                    if cell.get_style() == *new_xf_id {
-                                        cell.set_style(*old_xf_id);
-                                    }
-                                }
-                            }
-                            for row in &mut worksheet.rows {
-                                if row.s == *new_xf_id {
-                                    row.s = *old_xf_id;
-                                }
-                            }
-                            for col in &mut worksheet.cols {
-                                if col.style == Some(*new_xf_id) {
-                                    col.style = Some(*old_xf_id);
-                                }
-                            }
-                        }
-                    }
-                    self.model
-                        .workbook
-                        .styles
-                        .update_named_style_entry(new_name, name, *old_xf_id)?;
+                    self.model.update_named_style(new_name, name, old_style)?;
                 }
                 Diff::AddConditionalFormatting {
                     sheet, priority, ..
@@ -728,6 +711,24 @@ impl<'a> UserModel<'a> {
                 } => self
                     .model
                     .set_cell_style(*sheet, *row, *column, new_value)?,
+                Diff::ApplyNamedStyle {
+                    sheet,
+                    row,
+                    column,
+                    old_value: _,
+                    name,
+                } => {
+                    let style_index = self
+                        .model
+                        .workbook
+                        .styles
+                        .get_or_create_style_index_by_name(name)?;
+                    self.model.workbook.worksheet_mut(*sheet)?.set_cell_style(
+                        *row,
+                        *column,
+                        style_index,
+                    )?;
+                }
                 Diff::InsertRows { sheet, row, count } => {
                     self.model.insert_rows(*sheet, *row, *count)?;
                     needs_evaluation = true;
@@ -915,11 +916,8 @@ impl<'a> UserModel<'a> {
                 } => {
                     self.model.set_timezone(new_value)?;
                 }
-                Diff::CreateNamedStyle { name, xf_id } => {
-                    self.model
-                        .workbook
-                        .styles
-                        .add_named_cell_style(name, *xf_id)?;
+                Diff::CreateNamedStyle { name, style } => {
+                    self.model.workbook.styles.create_named_style(name, style)?;
                 }
                 Diff::DeleteNamedStyle { name, old_xf_id: _ } => {
                     self.model.workbook.styles.delete_named_style_entry(name)?;
@@ -927,34 +925,10 @@ impl<'a> UserModel<'a> {
                 Diff::UpdateNamedStyle {
                     name,
                     new_name,
-                    old_xf_id,
-                    new_xf_id,
+                    old_style: _,
+                    new_style,
                 } => {
-                    if old_xf_id != new_xf_id {
-                        for worksheet in &mut self.model.workbook.worksheets {
-                            for row_data in worksheet.sheet_data.values_mut() {
-                                for cell in row_data.values_mut() {
-                                    if cell.get_style() == *old_xf_id {
-                                        cell.set_style(*new_xf_id);
-                                    }
-                                }
-                            }
-                            for row in &mut worksheet.rows {
-                                if row.s == *old_xf_id {
-                                    row.s = *new_xf_id;
-                                }
-                            }
-                            for col in &mut worksheet.cols {
-                                if col.style == Some(*old_xf_id) {
-                                    col.style = Some(*new_xf_id);
-                                }
-                            }
-                        }
-                    }
-                    self.model
-                        .workbook
-                        .styles
-                        .update_named_style_entry(name, new_name, *new_xf_id)?;
+                    self.model.update_named_style(name, new_name, new_style)?;
                 }
                 Diff::AddConditionalFormatting {
                     sheet,

--- a/xlsx/src/export/test/test_export.rs
+++ b/xlsx/src/export/test/test_export.rs
@@ -202,6 +202,24 @@ fn test_named_styles() {
         .styles
         .get_style_index_by_name("bold & italics")
         .is_ok());
+    // After the roundtrip the style record must still include every formatting
+    // category (in cellStyleXfs absent apply* attributes mean "included";
+    // exporting applyX="0" would make Excel treat the style as empty).
+    let cell_style = model
+        .workbook
+        .styles
+        .cell_styles
+        .iter()
+        .find(|cs| cs.name == "bold & italics")
+        .unwrap();
+    let record = &model.workbook.styles.cell_style_xfs[cell_style.xf_id as usize];
+    assert!(record.apply_number_format);
+    assert!(record.apply_font);
+    assert!(record.apply_fill);
+    assert!(record.apply_border);
+    assert!(record.apply_alignment);
+    assert!(record.apply_protection);
+
     // The cell is still linked to the named style: updating it restyles the cell
     let mut style = model.get_named_style("bold & italics").unwrap();
     assert!(style.font.b);

--- a/xlsx/src/export/test/test_export.rs
+++ b/xlsx/src/export/test/test_export.rs
@@ -181,13 +181,14 @@ fn test_named_styles() {
     let mut style = model.get_style_for_cell(0, 1, 1).unwrap();
     style.font.b = true;
     style.font.i = true;
-    assert!(model.set_cell_style(0, 1, 1, &style).is_ok());
-    let bold_style_index = model.get_cell_style_index(0, 1, 1).unwrap();
     let e = model
         .workbook
         .styles
-        .add_named_cell_style("bold & italics", bold_style_index);
+        .create_named_style("bold & italics", &style);
     assert!(e.is_ok());
+    assert!(model
+        .set_cell_style_by_name(0, 1, 1, "bold & italics")
+        .is_ok());
 
     // noop
     model.evaluate();
@@ -195,12 +196,20 @@ fn test_named_styles() {
     let temp_file_name = "temp_file_test_named_styles.xlsx";
     save_to_xlsx(&model, temp_file_name).unwrap();
 
-    let model = load_from_xlsx(temp_file_name, "en", "UTC", "en").unwrap();
+    let mut model = load_from_xlsx(temp_file_name, "en", "UTC", "en").unwrap();
     assert!(model
         .workbook
         .styles
         .get_style_index_by_name("bold & italics")
         .is_ok());
+    // The cell is still linked to the named style: updating it restyles the cell
+    let mut style = model.get_named_style("bold & italics").unwrap();
+    assert!(style.font.b);
+    style.font.u = true;
+    model
+        .update_named_style("bold & italics", "bold & italics", &style)
+        .unwrap();
+    assert!(model.get_style_for_cell(0, 1, 1).unwrap().font.u);
     fs::remove_file(temp_file_name).unwrap();
 }
 


### PR DESCRIPTION
For posterity…

This PR is the first trying to deal with named styles in a proper manner.

An xlsx file has a file `styles.xml` with three structures:

1. `cellStyleXfs`
2. `cellXfs`
3. `cellStyles`

The most important one is 2. Cells in the spreadsheet have a style index (`s="12"` refers to the 13th, 0-based, entry in `cellXfs`) that tells you the fill, font, number format, borders, alignment and protection — every entry carries fully resolved ids, which is why **rendering a sheet needs only list 2**.

Every entry in 2 also has an `xfId` pointing to its parent entry in 1 (the named style it is based on; `xfId="0"` = Normal). Entries in 3 map style names to entries in 1.

Lists 1 and 3 matter when creating, applying or **updating** a named style:

* On a `cellXfs` entry, the `apply*` flags (`applyFont`, `applyFill`, …; absent = false) mark which components are the cell's **own local overrides**. When the base style in `cellStyleXfs` is edited, every component whose flag is false is rewritten to the style's new value; flagged components are left alone.
* On a `cellStyleXfs` entry the same attributes mean almost the opposite, and default to **true** because why not?. They mark which formatting categories the named style **includes** (Excel's "Style Includes" checkboxes). `applyFont="0"` means the style doesn't carry a font, so applying it leaves the cell's font untouched (e.g. "Percent" includes only the number format).

Some of those things I had wrong in my mind for >12 years. TIL
This PR only addresess only the API side. I'll continue...
