### PR TITLE
fix(xlsx): preserve font <name> on import

### DIFF
--- a/xlsx/src/import/styles.rs
+++ b/xlsx/src/import/styles.rs
@@ -125,8 +125,10 @@ pub(super) fn load_styles<R: Read + std::io::Seek>(
                 "strike" => {
                     strike = true;
                 }
-                "name" => name = "Inter".to_string(), // TODO: feature.attribute("val").unwrap_or("Calibri").to_string(),
-                // If there is a theme the font scheme and family overrides other properties like the name
+                // ECMA-376 §18.8.29 (`name`): the `val` attribute is the font's typeface.
+                "name" => {
+                    name = feature.attribute("val").unwrap_or("Inter").to_string();
+                }
                 "family" => {
                     family = feature
                         .attribute("val")

--- a/xlsx/tests/font_name_import.rs
+++ b/xlsx/tests/font_name_import.rs
@@ -1,0 +1,50 @@
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::panic)]
+
+use ironcalc::export::save_to_xlsx;
+use ironcalc::import::load_from_xlsx;
+use std::fs;
+
+#[test]
+// ECMA-376 §18.8.29: a <font>'s <name val="..."/> child carries the typeface. The importer
+// must preserve it rather than replacing every font with the default name.
+//
+// example.xlsx defines fonts using two distinct typefaces — "Calibri" and "Tahoma" — so a
+// correct import yields both names in the fonts table (and never silently collapses them to
+// the default "Inter").
+fn test_font_name_is_preserved_on_import() {
+    let model = load_from_xlsx("tests/example.xlsx", "en", "UTC", "en").unwrap();
+    let names: Vec<&str> = model
+        .workbook
+        .styles
+        .fonts
+        .iter()
+        .map(|f| f.name.as_str())
+        .collect();
+
+    assert!(
+        names.contains(&"Calibri"),
+        "expected a Calibri font, got {names:?}"
+    );
+    assert!(
+        names.contains(&"Tahoma"),
+        "expected the Tahoma font to survive import, got {names:?}"
+    );
+
+    // Round-trip: the preserved names must survive export → re-import.
+    let temp_file_name = "temp_file_test_font_name.xlsx";
+    save_to_xlsx(&model, temp_file_name).unwrap();
+    let reloaded = load_from_xlsx(temp_file_name, "en", "UTC", "en").unwrap();
+    fs::remove_file(temp_file_name).unwrap();
+    let reloaded_names: Vec<&str> = reloaded
+        .workbook
+        .styles
+        .fonts
+        .iter()
+        .map(|f| f.name.as_str())
+        .collect();
+    assert!(
+        reloaded_names.contains(&"Tahoma"),
+        "Tahoma must survive a save/reload round-trip, got {reloaded_names:?}"
+    );
+}


### PR DESCRIPTION
The styles importer hardcoded every font's name to the default (Inter), discarding the typeface declared in <font><name val=.../></font> (ECMA-376 §18.8.29). Any workbook using a non-default font (e.g. Century Gothic, Tahoma) lost it on import, so callers rendered the wrong face.

Read the name from the val attribute, falling back to the default when absent.

Tested on FreeCell