### PR TITLE
fix: adapt some translations to sound more natural

### DIFF
--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -14,7 +14,7 @@
     "new": "Neu",
     "blank_workbook": "Leere Arbeitsmappe",
     "import_workbook": "Arbeitsmappe importieren",
-    "storage_warning": "<warn>Achtung!</warn> Diese App ist ein Proof of Concept und kein fertiges Produkt. Experimentieren, teilen sowie hoch- und herunterladen Sie Modelle gerne, aber teilen oder laden Sie keine Modelle mit sensiblen oder privaten Daten hoch. Daten werden regelmäßig gelöscht. <docsLink>Mehr erfahren</docsLink>",
+    "storage_warning": "<warn>Achtung!</warn> Diese App ist ein Proof of Concept und kein fertiges Produkt. Sie können Modelle gerne erkunden, teilen sowie hoch- und herunterladen, aber teilen oder laden Sie keine Modelle mit sensiblen oder privaten Daten hoch. Daten werden regelmäßig gelöscht. <docsLink>Mehr erfahren</docsLink>",
     "templates": {
       "choose_template": "Vorlage auswählen",
       "templates": "Vorlagen",

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -14,7 +14,7 @@
     "new": "Nuevo",
     "blank_workbook": "Libro en blanco",
     "import_workbook": "Importar libro",
-    "storage_warning": "<warn>¡Atención!</warn> Esta aplicación es una prueba de concepto y no un producto terminado. Siéntete libre de explorar, compartir y subir/descargar modelos, pero no compartas ni subas modelos con datos sensibles o privados. Los datos se eliminarán periódicamente. <docsLink>Leer más</docsLink>",
+    "storage_warning": "<warn>¡Atención!</warn> Esta aplicación es una prueba de concepto y no un producto terminado. Puedes explorar, compartir y subir/descargar modelos, pero no compartas ni subas modelos con datos sensibles o privados. Los datos se eliminarán periódicamente. <docsLink>Leer más</docsLink>",
     "templates": {
       "choose_template": "Elegir una plantilla",
       "templates": "Plantillas",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -14,7 +14,7 @@
     "new": "Nuovo",
     "blank_workbook": "Cartella di lavoro vuota",
     "import_workbook": "Importa cartella di lavoro",
-    "storage_warning": "<warn>Attenzione!</warn> Questa applicazione è una prova di concetto e non un prodotto finito. Sentiti libero di esplorare, condividere e caricare/scaricare modelli, ma non condividere o caricare modelli con dati sensibili o privati. I dati verranno eliminati periodicamente. <docsLink>Scopri di più</docsLink>",
+    "storage_warning": "<warn>Attenzione!</warn> Questa applicazione è una prova di concetto e non un prodotto finito. Puoi esplorare, condividere e caricare/scaricare modelli, ma non condividere o caricare modelli con dati sensibili o privati. I dati verranno eliminati periodicamente. <docsLink>Scopri di più</docsLink>",
     "templates": {
       "choose_template": "Scegli un modello",
       "templates": "Modelli",


### PR DESCRIPTION
In particular, tackling the storage warning message. Changes:
- es-ES: "Siéntete libre de explorar" (direct calque from English) to simply "Puedes explorar..."
- it-IT: "Sentiti libero di esplorare..." (same calque) to "Puoi esplorare..."
- de-DE: change of structure, from "Experimentieren, teilen sowie hoch- und herunterladen Sie Modelle gerne, aber..." to "Sie können Modelle gerne erkunden, teilen sowie hoch- und herunterladen, aber...", a more natural way of enunciating in German.