### PR TITLE
fix: context menu positioning after refresh

### DIFF
--- a/webapp/IronCalc/src/components/Menu/Menu.tsx
+++ b/webapp/IronCalc/src/components/Menu/Menu.tsx
@@ -48,7 +48,9 @@ export function Menu(props: MenuProperties) {
   );
 
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
-  const open = isTriggerMode ? uncontrolledOpen : props.open;
+  const requestedOpen = isTriggerMode ? uncontrolledOpen : props.open;
+  // Won't open until the portal target resolves to avoid menu mispositioning.
+  const open = requestedOpen && portalAnchor !== null;
 
   const triggerPosition = useMenuPosition(isTriggerMode ? open : false);
   const anchorPosition = useAnchorPosition(


### PR DESCRIPTION
This PR fixes a visual bug by which the context menus were misplaced on first use, after refresh.