### PR TITLE
feat(base): add UserModel::set_worksheet_index to reorder worksheets

### DIFF
--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -542,6 +542,35 @@ impl<'a> Model<'a> {
         Ok(())
     }
 
+    /// Moves the worksheet at `sheet_index` to `new_index`, shifting the other
+    /// sheets to accommodate. The moved worksheet ends up at exactly `new_index`.
+    ///
+    /// Sheet order is only a position in the worksheet vector; formulas key off
+    /// the sheet name (and defined names off the sheet id), so cross-sheet
+    /// references stay valid across a move — [reset_parsed_structures] re-resolves
+    /// every reference by name against the reordered vector.
+    ///
+    /// Fails if either index is out of range. Moving a sheet to its current
+    /// position is a no-op.
+    pub fn move_sheet(&mut self, sheet_index: u32, new_index: u32) -> Result<(), String> {
+        let sheet_count = self.workbook.worksheets.len() as u32;
+        if sheet_index >= sheet_count {
+            return Err("Sheet index too large".to_string());
+        }
+        if new_index >= sheet_count {
+            return Err("Target sheet index too large".to_string());
+        }
+        if sheet_index == new_index {
+            return Ok(());
+        }
+        let worksheet = self.workbook.worksheets.remove(sheet_index as usize);
+        self.workbook
+            .worksheets
+            .insert(new_index as usize, worksheet);
+        self.reset_parsed_structures();
+        Ok(())
+    }
+
     /// Deletes a sheet by name. Fails if:
     ///   * The sheet does not exists
     ///   * It is the last sheet

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -21,6 +21,7 @@ mod test_hidden_columns;
 mod test_keyboard_navigation;
 mod test_language_switch;
 mod test_last_empty_cell;
+mod test_move_sheet;
 mod test_multi_row_column;
 mod test_named_styles;
 mod test_on_area_selection;

--- a/base/src/test/user_model/test_move_sheet.rs
+++ b/base/src/test/user_model/test_move_sheet.rs
@@ -1,0 +1,159 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::user_model::util::new_empty_user_model;
+
+/// Returns the worksheet names in workbook (tab) order.
+fn sheet_names(model: &crate::UserModel) -> Vec<String> {
+    model
+        .get_worksheets_properties()
+        .iter()
+        .map(|p| p.name.clone())
+        .collect()
+}
+
+/// Name of the currently selected sheet, so we can assert the selection follows
+/// a sheet across a reorder by identity (not by slot).
+fn selected_name(model: &crate::UserModel) -> String {
+    let properties = model.get_worksheets_properties();
+    properties[model.get_selected_sheet() as usize].name.clone()
+}
+
+#[test]
+fn move_reorders_sheets() {
+    let mut model = new_empty_user_model();
+    model.new_sheet().unwrap();
+    model.new_sheet().unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet1", "Sheet2", "Sheet3"]);
+
+    // Move the first sheet to the end.
+    model.set_worksheet_index(0, 2).unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet2", "Sheet3", "Sheet1"]);
+
+    // Move the last sheet to the front.
+    model.set_worksheet_index(2, 0).unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet1", "Sheet2", "Sheet3"]);
+
+    // Move a middle sheet.
+    model.set_worksheet_index(1, 2).unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet1", "Sheet3", "Sheet2"]);
+}
+
+#[test]
+fn move_undo_redo() {
+    let mut model = new_empty_user_model();
+    model.new_sheet().unwrap();
+    model.new_sheet().unwrap();
+
+    model.set_worksheet_index(0, 2).unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet2", "Sheet3", "Sheet1"]);
+
+    model.undo().unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet1", "Sheet2", "Sheet3"]);
+
+    model.redo().unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet2", "Sheet3", "Sheet1"]);
+}
+
+#[test]
+fn move_to_same_index_is_noop() {
+    let mut model = new_empty_user_model();
+    model.new_sheet().unwrap();
+
+    model.set_worksheet_index(1, 1).unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet1", "Sheet2"]);
+    // A no-op move records no history: the only undoable action is the
+    // `new_sheet`, so a single undo drops back to one sheet.
+    model.undo().unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet1"]);
+    assert!(!model.can_undo());
+}
+
+#[test]
+fn move_out_of_range_is_rejected() {
+    let mut model = new_empty_user_model();
+    model.new_sheet().unwrap();
+
+    assert!(model.set_worksheet_index(2, 0).is_err());
+    assert!(model.set_worksheet_index(0, 2).is_err());
+    // A rejected move leaves the order untouched and records no history: the
+    // only undoable action is the `new_sheet`.
+    assert_eq!(sheet_names(&model), ["Sheet1", "Sheet2"]);
+    model.undo().unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet1"]);
+    assert!(!model.can_undo());
+}
+
+#[test]
+fn move_preserves_cross_sheet_references() {
+    let mut model = new_empty_user_model();
+    model.new_sheet().unwrap();
+    model.new_sheet().unwrap();
+    // Sheet1=0, Sheet2=1, Sheet3=2.
+    model.set_user_input(1, 1, 1, "42").unwrap(); // Sheet2!A1 = 42
+    model.set_user_input(0, 1, 1, "=Sheet2!A1").unwrap(); // Sheet1!A1
+    model.set_user_input(2, 1, 1, "=Sheet2!A1").unwrap(); // Sheet3!A1
+    assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "42");
+    assert_eq!(model.get_formatted_cell_value(2, 1, 1).unwrap(), "42");
+
+    // Reorder: move Sheet2 (the referenced sheet) to the front.
+    model.set_worksheet_index(1, 0).unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet2", "Sheet1", "Sheet3"]);
+    // The formulas moved with their sheets and still resolve by name.
+    // Sheet1 is now at index 1, Sheet3 at index 2, Sheet2 at index 0.
+    assert_eq!(model.get_formatted_cell_value(1, 1, 1).unwrap(), "42");
+    assert_eq!(model.get_formatted_cell_value(2, 1, 1).unwrap(), "42");
+    assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "42");
+
+    // A dependent recompute still flows across the reorder.
+    model.set_user_input(0, 1, 1, "100").unwrap(); // Sheet2!A1 = 100
+    assert_eq!(model.get_formatted_cell_value(1, 1, 1).unwrap(), "100");
+
+    // Undo the value edit and the move; references remain intact throughout.
+    model.undo().unwrap();
+    model.undo().unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet1", "Sheet2", "Sheet3"]);
+    assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "42");
+    assert_eq!(model.get_formatted_cell_value(2, 1, 1).unwrap(), "42");
+}
+
+#[test]
+fn move_keeps_the_same_sheet_selected() {
+    let mut model = new_empty_user_model();
+    model.new_sheet().unwrap();
+    model.new_sheet().unwrap();
+
+    // Select a sheet that is not the one being moved.
+    model.set_selected_sheet(1).unwrap();
+    assert_eq!(selected_name(&model), "Sheet2");
+
+    // Move a different sheet; selection follows Sheet2 by identity.
+    model.set_worksheet_index(0, 2).unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet2", "Sheet3", "Sheet1"]);
+    assert_eq!(selected_name(&model), "Sheet2");
+
+    // Moving the selected sheet keeps it selected at its new slot.
+    model.set_worksheet_index(0, 2).unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet3", "Sheet1", "Sheet2"]);
+    assert_eq!(selected_name(&model), "Sheet2");
+
+    // Undo restores order and the same sheet stays selected.
+    model.undo().unwrap();
+    assert_eq!(sheet_names(&model), ["Sheet2", "Sheet3", "Sheet1"]);
+    assert_eq!(selected_name(&model), "Sheet2");
+}
+
+#[test]
+fn move_propagates() {
+    let mut model = new_empty_user_model();
+    model.new_sheet().unwrap();
+    model.new_sheet().unwrap();
+    model.set_worksheet_index(0, 2).unwrap();
+
+    let send_queue = model.flush_send_queue();
+
+    // A fresh peer replays the whole queue (the two `new_sheet`s and the move).
+    let mut model2 = new_empty_user_model();
+    model2.apply_external_diffs(&send_queue).unwrap();
+
+    assert_eq!(sheet_names(&model2), ["Sheet2", "Sheet3", "Sheet1"]);
+}

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -216,6 +216,27 @@ pub struct UserModel<'a> {
     pause_evaluation: bool,
 }
 
+/// Given the index of the currently selected sheet, returns the index that same
+/// sheet occupies after the worksheet at `from` is moved to `to`. This lets the
+/// selection follow a sheet by identity across a reorder instead of pointing at
+/// whichever sheet lands in the old slot.
+pub(crate) fn selected_sheet_after_move(selected: u32, from: u32, to: u32) -> u32 {
+    if selected == from {
+        return to;
+    }
+    // Mirror `Model::move_sheet`: remove at `from`, then insert at `to`.
+    let after_remove = if selected > from {
+        selected - 1
+    } else {
+        selected
+    };
+    if after_remove >= to {
+        after_remove + 1
+    } else {
+        after_remove
+    }
+}
+
 impl<'a> Debug for UserModel<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UserModel").finish()
@@ -585,6 +606,41 @@ impl<'a> UserModel<'a> {
             index: sheet,
             old_value,
             new_value: new_name.to_string(),
+        }]);
+        Ok(())
+    }
+
+    /// Moves the worksheet at `sheet_index` to `new_index` within the workbook,
+    /// shifting the other sheets to accommodate. The moved worksheet ends up at
+    /// exactly `new_index`.
+    ///
+    /// The reorder is undoable/redoable, and the new order is preserved when the
+    /// workbook is saved. Cross-sheet formula references stay valid across the
+    /// move (sheet order is a position, not an identity — references key off the
+    /// sheet name/id). The selection follows the same sheet across the move.
+    ///
+    /// Moving a sheet to its current position is a no-op (no history entry). Fails
+    /// if either index is out of range.
+    ///
+    /// See also:
+    /// * [Model::move_sheet]
+    pub fn set_worksheet_index(&mut self, sheet_index: u32, new_index: u32) -> Result<(), String> {
+        let sheet_count = self.model.workbook.worksheets.len() as u32;
+        if sheet_index >= sheet_count {
+            return Err(format!("Invalid sheet index {sheet_index}"));
+        }
+        if new_index >= sheet_count {
+            return Err(format!("Invalid target index {new_index}"));
+        }
+        if sheet_index == new_index {
+            return Ok(());
+        }
+        let selected = self.get_selected_sheet();
+        self.model.move_sheet(sheet_index, new_index)?;
+        self.set_selected_sheet(selected_sheet_after_move(selected, sheet_index, new_index))?;
+        self.push_diff_list(vec![Diff::MoveSheet {
+            sheet_index,
+            new_index,
         }]);
         Ok(())
     }
@@ -2153,8 +2209,25 @@ impl<'a> UserModel<'a> {
 mod tests {
     use crate::{
         types::{HorizontalAlignment, VerticalAlignment},
-        user_model::common::{horizontal, vertical},
+        user_model::common::{horizontal, selected_sheet_after_move, vertical},
     };
+
+    #[test]
+    fn test_selected_sheet_after_move() {
+        // The moved sheet is followed to its destination.
+        assert_eq!(selected_sheet_after_move(0, 0, 2), 2);
+        assert_eq!(selected_sheet_after_move(3, 3, 0), 0);
+
+        // A sheet between the source and destination shifts by one.
+        // [A,B,C,D], select C (2), move A (0) -> 2 => [B,C,A,D], C is at 1.
+        assert_eq!(selected_sheet_after_move(2, 0, 2), 1);
+        // [A,B,C,D], select A (0), move C (2) -> 0 => [C,A,B,D], A is at 1.
+        assert_eq!(selected_sheet_after_move(0, 2, 0), 1);
+
+        // A sheet outside the moved span keeps its index.
+        // [A,B,C,D], select D (3), move B (1) -> 2 => [A,C,B,D], D still at 3.
+        assert_eq!(selected_sheet_after_move(3, 1, 2), 3);
+    }
 
     #[test]
     fn test_vertical() {

--- a/base/src/user_model/history.rs
+++ b/base/src/user_model/history.rs
@@ -175,6 +175,12 @@ pub(crate) enum Diff {
         old_value: String,
         new_value: String,
     },
+    MoveSheet {
+        /// Index of the worksheet before the move.
+        sheet_index: u32,
+        /// Index the worksheet was moved to.
+        new_index: u32,
+    },
     SetSheetColor {
         index: u32,
         old_value: Color,

--- a/base/src/user_model/undo_redo.rs
+++ b/base/src/user_model/undo_redo.rs
@@ -8,6 +8,7 @@ use crate::{
     UserModel,
 };
 
+use crate::user_model::common::selected_sheet_after_move;
 use crate::user_model::history::{Diff, DiffList};
 
 impl<'a> UserModel<'a> {
@@ -329,6 +330,19 @@ impl<'a> UserModel<'a> {
                     new_value: _,
                 } => {
                     self.model.rename_sheet_by_index(*index, old_value)?;
+                }
+                Diff::MoveSheet {
+                    sheet_index,
+                    new_index,
+                } => {
+                    // Undo a move by moving the sheet back to its original index.
+                    let selected = self.get_selected_sheet();
+                    self.model.move_sheet(*new_index, *sheet_index)?;
+                    self.set_selected_sheet(selected_sheet_after_move(
+                        selected,
+                        *new_index,
+                        *sheet_index,
+                    ))?;
                 }
                 Diff::SetSheetColor {
                     index,
@@ -809,6 +823,18 @@ impl<'a> UserModel<'a> {
                     new_value,
                 } => {
                     self.model.rename_sheet_by_index(*index, new_value)?;
+                }
+                Diff::MoveSheet {
+                    sheet_index,
+                    new_index,
+                } => {
+                    let selected = self.get_selected_sheet();
+                    self.model.move_sheet(*sheet_index, *new_index)?;
+                    self.set_selected_sheet(selected_sheet_after_move(
+                        selected,
+                        *sheet_index,
+                        *new_index,
+                    ))?;
                 }
                 Diff::SetSheetColor {
                     index,

--- a/xlsx/src/export/test/test_export.rs
+++ b/xlsx/src/export/test/test_export.rs
@@ -176,6 +176,38 @@ fn test_sheets() {
 }
 
 #[test]
+fn test_move_sheet_order_roundtrips() {
+    let mut model = new_empty_model();
+    model.add_sheet("Second").unwrap();
+    model.add_sheet("Third").unwrap();
+    // A cross-sheet reference so we can confirm it survives the reorder + save.
+    model.set_user_input(1, 1, 1, "42".to_string()).unwrap(); // Second!A1
+    model
+        .set_user_input(0, 1, 1, "=Second!A1".to_string())
+        .unwrap(); // Sheet1!A1
+
+    // Reorder: Sheet1 goes to the end.
+    model.move_sheet(0, 2).unwrap();
+    assert_eq!(
+        model.workbook.get_worksheet_names(),
+        vec!["Second", "Third", "Sheet1"]
+    );
+
+    let temp_file_name = "temp_file_test_move_sheet_order.xlsx";
+    save_to_xlsx(&model, temp_file_name).unwrap();
+
+    let model = load_from_xlsx(temp_file_name, "en", "UTC", "en").unwrap();
+    // The saved order is preserved on reload.
+    assert_eq!(
+        model.workbook.get_worksheet_names(),
+        vec!["Second", "Third", "Sheet1"]
+    );
+    // Sheet1 (now index 2) still resolves its reference to Second by name.
+    assert_eq!(model.get_formatted_cell_value(2, 1, 1).unwrap(), "42");
+    fs::remove_file(temp_file_name).unwrap();
+}
+
+#[test]
 fn test_named_styles() {
     let mut model = new_empty_model();
     model.set_user_input(0, 1, 1, "5.5".to_string()).unwrap();


### PR DESCRIPTION
There was no way to change the order of worksheets in a workbook. Add `UserModel::set_worksheet_index(sheet_index, new_index)` (backed by `Model::move_sheet`) which moves the worksheet at `sheet_index` so it ends up at exactly `new_index`, shifting the intervening sheets to accommodate.

The reorder is:

  * Undoable/redoable — it records a `MoveSheet` diff, so undo moves the sheet back to its original slot and redo re-applies the move (the diff is symmetric; a reverse move is its own inverse).
  * Order-preserving on save — worksheets are written in workbook-vector order, so the new order round-trips through xlsx save/load.
  * Reference-safe — sheet order is only a position in the worksheet vector; formulas key off the sheet name and defined names off the sheet id, so `reset_parsed_structures` re-resolves every cross-sheet reference by name against the reordered vector and nothing dangles.

Selection follows the moved (and any other selected) sheet by identity across the reorder rather than pointing at whichever sheet lands in the old slot. Moving a sheet to its current position is a no-op with no history entry, and an out-of-range index is rejected.

Tests cover reordering, undo/redo, the same-index no-op, out-of-range rejection, cross-sheet reference survival (including a dependent recompute), selection-follows-sheet, diff propagation, the pure selection-remap helper, and an xlsx save/load order round-trip.