### PR TITLE
feat(base): add UserModel::set_user_inputs for batched single-undo write

### DIFF
--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -30,6 +30,7 @@ mod test_paste_csv;
 mod test_recursive;
 mod test_rename_sheet;
 mod test_row_column;
+mod test_set_user_inputs;
 mod test_sheet_state;
 mod test_sheets_undo_redo;
 mod test_styles;

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -33,6 +33,7 @@ mod test_paste_csv;
 mod test_recursive;
 mod test_rename_sheet;
 mod test_row_column;
+mod test_set_user_inputs;
 mod test_sheet_state;
 mod test_sheets_undo_redo;
 mod test_styles;

--- a/base/src/test/user_model/test_set_user_inputs.rs
+++ b/base/src/test/user_model/test_set_user_inputs.rs
@@ -124,6 +124,57 @@ fn batch_across_sheets_is_one_undo_step() {
 }
 
 #[test]
+fn batch_overwriting_a_dynamic_array_anchor_undoes_to_the_spill() {
+    let mut model = new_empty_user_model();
+    // Seed a dynamic array in A1 that spills into A1:A3.
+    model.set_user_input(0, 1, 2, "10").unwrap(); // B1
+    model.set_user_input(0, 2, 2, "20").unwrap(); // B2
+    model.set_user_input(0, 3, 2, "30").unwrap(); // B3
+    model.set_user_input(0, 1, 1, "=B1:B3").unwrap(); // A1 anchor
+    assert_eq!(model.get_formatted_cell_value(0, 2, 1).unwrap(), "20"); // A2 is a spill cell
+
+    // One batch overwrites the anchor (A1) — which clears the spill — AND a former
+    // spill cell (A2). Both old_values must be snapshotted *before* the A1 write
+    // clears the spill; otherwise a single undo could not restore the array.
+    model
+        .set_user_inputs(&[
+            (0, 1, 1, "x".to_string()), // A1, the anchor
+            (0, 2, 1, "y".to_string()), // A2, previously a spill cell
+        ])
+        .unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "x");
+    assert_eq!(model.get_cell_content(0, 2, 1).unwrap(), "y");
+    assert_eq!(model.get_cell_content(0, 3, 1).unwrap(), ""); // the rest of the spill is gone
+
+    // A single undo restores the dynamic array anchor and re-spills A2 and A3.
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "=B1:B3");
+    assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "10");
+    assert_eq!(model.get_formatted_cell_value(0, 2, 1).unwrap(), "20");
+    assert_eq!(model.get_formatted_cell_value(0, 3, 1).unwrap(), "30");
+}
+
+#[test]
+fn batch_with_repeated_cell_keeps_last_write_and_undoes_as_one() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "orig").unwrap(); // A1
+
+    // The same cell appears twice in the batch: the last value wins.
+    model
+        .set_user_inputs(&[
+            (0, 1, 1, "first".to_string()),
+            (0, 1, 1, "second".to_string()),
+        ])
+        .unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "second");
+
+    // A single undo reverts the whole batch back to the original value.
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "orig");
+    assert!(model.can_undo(), "only the seed edit remains");
+}
+
+#[test]
 fn batch_propagates_as_one_diff_list() {
     let mut model = new_empty_user_model();
     model

--- a/base/src/test/user_model/test_set_user_inputs.rs
+++ b/base/src/test/user_model/test_set_user_inputs.rs
@@ -1,0 +1,139 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::user_model::util::new_empty_user_model;
+
+#[test]
+fn batch_write_is_one_undo_step() {
+    let mut model = new_empty_user_model();
+    model
+        .set_user_inputs(&[
+            (0, 1, 1, "cat".to_string()),  // A1
+            (0, 1, 2, "dog".to_string()),  // B1
+            (0, 3, 5, "bird".to_string()), // E3 (scattered, non-contiguous)
+        ])
+        .unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "cat");
+    assert_eq!(model.get_cell_content(0, 1, 2).unwrap(), "dog");
+    assert_eq!(model.get_cell_content(0, 3, 5).unwrap(), "bird");
+
+    // The defining property: a SINGLE undo reverts the whole batch, and it is the
+    // only history entry.
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "");
+    assert_eq!(model.get_cell_content(0, 1, 2).unwrap(), "");
+    assert_eq!(model.get_cell_content(0, 3, 5).unwrap(), "");
+    assert!(!model.can_undo(), "the batch is a single history entry");
+
+    // A SINGLE redo re-applies the whole batch.
+    model.redo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "cat");
+    assert_eq!(model.get_cell_content(0, 1, 2).unwrap(), "dog");
+    assert_eq!(model.get_cell_content(0, 3, 5).unwrap(), "bird");
+}
+
+#[test]
+fn batch_overwrite_undo_restores_prior_values() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "old-a").unwrap();
+    model.set_user_input(0, 2, 2, "old-b").unwrap();
+
+    model
+        .set_user_inputs(&[
+            (0, 1, 1, "new-a".to_string()),
+            (0, 2, 2, "new-b".to_string()),
+        ])
+        .unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "new-a");
+    assert_eq!(model.get_cell_content(0, 2, 2).unwrap(), "new-b");
+
+    // A single undo restores BOTH prior (non-empty) values.
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "old-a");
+    assert_eq!(model.get_cell_content(0, 2, 2).unwrap(), "old-b");
+    // The two seed edits are still individually undoable — the batch was one entry.
+    assert!(model.can_undo());
+}
+
+#[test]
+fn batch_recomputes_dependent_formula() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 3, "=A1+B1").unwrap(); // C1 = A1 + B1 -> 0
+    assert_eq!(model.get_formatted_cell_value(0, 1, 3).unwrap(), "0");
+
+    model
+        .set_user_inputs(&[
+            (0, 1, 1, "2".to_string()), // A1
+            (0, 1, 2, "3".to_string()), // B1
+        ])
+        .unwrap();
+    // One evaluate at the end of the batch reflects both inputs.
+    assert_eq!(model.get_formatted_cell_value(0, 1, 3).unwrap(), "5");
+
+    // A single undo reverts both inputs and the dependent recomputes back to 0.
+    model.undo().unwrap();
+    assert_eq!(model.get_formatted_cell_value(0, 1, 3).unwrap(), "0");
+}
+
+#[test]
+fn empty_batch_is_a_noop() {
+    let mut model = new_empty_user_model();
+    model.set_user_inputs(&[]).unwrap();
+    // An empty batch records no history entry.
+    assert!(!model.can_undo());
+}
+
+#[test]
+fn out_of_range_batch_is_rejected_without_mutating() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "seed").unwrap();
+
+    // The second entry is out of range (row 0 is invalid — rows are 1-based).
+    let result = model.set_user_inputs(&[
+        (0, 2, 2, "written?".to_string()),
+        (0, 0, 1, "bad".to_string()),
+    ]);
+    assert!(result.is_err());
+    // All-or-nothing: the valid entry was NOT written, and no batch history entry
+    // exists beyond the seed edit.
+    assert_eq!(model.get_cell_content(0, 2, 2).unwrap(), "");
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "");
+    assert!(!model.can_undo(), "only the seed edit was ever recorded");
+}
+
+#[test]
+fn batch_across_sheets_is_one_undo_step() {
+    let mut model = new_empty_user_model();
+    model.new_sheet().unwrap(); // Sheet2 = index 1
+
+    model
+        .set_user_inputs(&[
+            (0, 1, 1, "on-sheet1".to_string()),
+            (1, 1, 1, "on-sheet2".to_string()),
+        ])
+        .unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "on-sheet1");
+    assert_eq!(model.get_cell_content(1, 1, 1).unwrap(), "on-sheet2");
+
+    // A single undo clears both sheets' cells (one history entry spans sheets).
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "");
+    assert_eq!(model.get_cell_content(1, 1, 1).unwrap(), "");
+    // Only the new_sheet remains undoable.
+    assert!(model.can_undo());
+}
+
+#[test]
+fn batch_propagates_as_one_diff_list() {
+    let mut model = new_empty_user_model();
+    model
+        .set_user_inputs(&[(0, 1, 1, "a".to_string()), (0, 2, 2, "b".to_string())])
+        .unwrap();
+    let send_queue = model.flush_send_queue();
+
+    // A fresh peer replays the batch as one external diff list.
+    let mut peer = new_empty_user_model();
+    peer.apply_external_diffs(&send_queue).unwrap();
+    assert_eq!(peer.get_cell_content(0, 1, 1).unwrap(), "a");
+    assert_eq!(peer.get_cell_content(0, 2, 2).unwrap(), "b");
+}

--- a/base/src/test/user_model/test_set_user_inputs.rs
+++ b/base/src/test/user_model/test_set_user_inputs.rs
@@ -124,6 +124,57 @@ fn batch_across_sheets_is_one_undo_step() {
 }
 
 #[test]
+fn batch_overwriting_a_dynamic_array_anchor_undoes_to_the_spill() {
+    let mut model = new_empty_user_model();
+    // Seed a dynamic array in A1 that spills into A1:A3.
+    model.set_user_input(0, 1, 2, "10").unwrap(); // B1
+    model.set_user_input(0, 2, 2, "20").unwrap(); // B2
+    model.set_user_input(0, 3, 2, "30").unwrap(); // B3
+    model.set_user_input(0, 1, 1, "=B1:B3").unwrap(); // A1 anchor
+    assert_eq!(model.get_formatted_cell_value(0, 2, 1).unwrap(), "20"); // A2 is a spill cell
+
+    // One batch overwrites the anchor (A1) — which clears the spill — AND a former
+    // spill cell (A2). Both old_values must be snapshotted *before* the A1 write
+    // clears the spill; otherwise a single undo could not restore the array.
+    model
+        .set_user_inputs(&[
+            (0, 1, 1, "x".to_string()), // A1, the anchor
+            (0, 2, 1, "y".to_string()), // A2, previously a spill cell
+        ])
+        .unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "x");
+    assert_eq!(model.get_cell_content(0, 2, 1).unwrap(), "y");
+    assert_eq!(model.get_cell_content(0, 3, 1).unwrap(), ""); // the rest of the spill is gone
+
+    // A single undo restores the dynamic array anchor and re-spills A2 and A3.
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "=B1:B3");
+    assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "10");
+    assert_eq!(model.get_formatted_cell_value(0, 2, 1).unwrap(), "20");
+    assert_eq!(model.get_formatted_cell_value(0, 3, 1).unwrap(), "30");
+}
+
+#[test]
+fn batch_with_repeated_cell_keeps_last_write_and_undoes_as_one() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "orig").unwrap(); // A1
+
+    // The same cell appears twice in the batch: the last value wins.
+    model
+        .set_user_inputs(&[
+            (0, 1, 1, "first".to_string()),
+            (0, 1, 1, "second".to_string()),
+        ])
+        .unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "second");
+
+    // A single undo reverts the whole batch back to the original value.
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "orig");
+    assert!(model.can_undo(), "only the seed edit remains");
+}
+
+#[test]
 fn batch_propagates_as_one_diff_list() {
     let mut model = new_empty_user_model();
     model
@@ -136,4 +187,40 @@ fn batch_propagates_as_one_diff_list() {
     peer.apply_external_diffs(&send_queue).unwrap();
     assert_eq!(peer.get_cell_content(0, 1, 1).unwrap(), "a");
     assert_eq!(peer.get_cell_content(0, 2, 2).unwrap(), "b");
+}
+
+#[test]
+fn mid_batch_write_failure_rolls_back_the_writes_already_made() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "seed A1").unwrap();
+    model.set_user_input(0, 1, 3, "1").unwrap(); // C1
+    model.set_user_input(0, 2, 3, "2").unwrap(); // C2
+
+    // B1:B2 is a CSE array formula: writing into it is rejected by
+    // `Model::set_user_input`, which is how a batch fails *mid-write* rather than
+    // during the up-front coordinate validation.
+    model
+        .set_user_array_formula(0, 1, 2, 1, 2, "=C1:C2")
+        .unwrap();
+
+    let result = model.set_user_inputs(&[
+        (0, 1, 1, "written".to_string()), // A1 — succeeds, then must be rolled back
+        (0, 1, 2, "boom".to_string()),    // B1 — part of the array formula, fails
+        (0, 5, 5, "never".to_string()),   // E5 — never attempted
+    ]);
+    assert!(result.is_err(), "writing into an array formula must fail");
+
+    // The successful write is undone and the untouched cell was never written.
+    assert_eq!(model.get_cell_content(0, 1, 1).unwrap(), "seed A1");
+    assert_eq!(model.get_cell_content(0, 5, 5).unwrap(), "");
+    // The array formula survived intact.
+    assert_eq!(model.get_formatted_cell_value(0, 1, 2).unwrap(), "1");
+    assert_eq!(model.get_formatted_cell_value(0, 2, 2).unwrap(), "2");
+
+    // No history entry was recorded for the rejected batch: undoing walks back to
+    // the array formula, then the seed edits.
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 1, 2).unwrap(), "");
+    model.undo().unwrap();
+    assert_eq!(model.get_cell_content(0, 2, 3).unwrap(), "");
 }

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -467,37 +467,34 @@ impl<'a> UserModel<'a> {
     /// Unlike [`paste_csv_string`](UserModel::paste_csv_string) it does not clear a
     /// rectangle first: only the listed cells are touched, so unrelated cells
     /// (formulas, array formulas, typed values) sitting between the targets are left
-    /// untouched. Coordinates are validated up front, so an out-of-range entry is
-    /// rejected without mutating the model. An empty slice is a no-op (no history
-    /// entry).
+    /// untouched. The batch is atomic: coordinates are validated up front and, should
+    /// any write fail part-way, the writes already made are rolled back — so a
+    /// rejected batch never leaves a partial write behind. An empty slice is a no-op
+    /// (no history entry).
     ///
     /// See also:
     /// * [UserModel::set_user_input]
     /// * [UserModel::paste_csv_string]
     pub fn set_user_inputs(&mut self, inputs: &[(u32, i32, i32, String)]) -> Result<(), String> {
-        // Validate every coordinate up front (read-only) so a bad entry cannot leave
-        // a partial write with no matching history entry — the batch is all-or-nothing.
-        for &(sheet, row, column, _) in inputs {
-            self.model.workbook.worksheet(sheet)?;
+        // Validate every coordinate AND snapshot every target's pre-batch value up
+        // front — before writing anything. Reading everything first is what makes the
+        // batch all-or-nothing:
+        //   * a bad coordinate is rejected without mutating the model, and
+        //   * every `old_value` is captured before the first write, so it reflects the
+        //     true pre-batch state (never a value that an earlier write in this same
+        //     batch already changed — e.g. by clearing a dynamic spill), and a
+        //     mid-batch write failure can be rolled back to exactly that state.
+        let mut diff_list = Vec::with_capacity(inputs.len());
+        for (sheet, row, column, value) in inputs {
+            let (sheet, row, column) = (*sheet, *row, *column);
+            let worksheet = self.model.workbook.worksheet(sheet)?;
             if !is_valid_column_number(column) {
                 return Err("Invalid column".to_string());
             }
             if !is_valid_row(row) {
                 return Err("Invalid row".to_string());
             }
-        }
-        if inputs.is_empty() {
-            return Ok(());
-        }
-        let mut diff_list = Vec::with_capacity(inputs.len());
-        for (sheet, row, column, value) in inputs {
-            let (sheet, row, column) = (*sheet, *row, *column);
-            let old_value = self
-                .model
-                .workbook
-                .worksheet(sheet)?
-                .cell(row, column)
-                .cloned();
+            let old_value = worksheet.cell(row, column).cloned();
             // A spill cell's value derives from its anchor, so record the old value as
             // None (mirrors set_user_input) — undo re-spills it from the anchor.
             let old_value = if matches!(old_value, Some(Cell::SpillCell { .. })) {
@@ -505,8 +502,6 @@ impl<'a> UserModel<'a> {
             } else {
                 old_value
             };
-            self.model
-                .set_user_input(sheet, row, column, value.to_string())?;
             diff_list.push(Diff::SetCellValue {
                 sheet,
                 row,
@@ -515,6 +510,28 @@ impl<'a> UserModel<'a> {
                 old_value: Box::new(old_value),
             });
         }
+        if diff_list.is_empty() {
+            return Ok(());
+        }
+
+        // Apply the writes. Because every old_value was snapshotted above, if a write
+        // fails part-way we can restore the writes already made (and any partial
+        // mutation from the failing call) to their pre-batch values before surfacing
+        // the error, keeping the batch all-or-nothing.
+        for (index, (sheet, row, column, value)) in inputs.iter().enumerate() {
+            if let Err(e) = self
+                .model
+                .set_user_input(*sheet, *row, *column, value.to_string())
+            {
+                // Revert cells 0..=index from their snapshots (apply_undo_diff_list
+                // restores in reverse and re-evaluates). Ignore a secondary error so
+                // the original cause is what the caller sees.
+                let revert = diff_list[..=index].to_vec();
+                let _ = self.apply_undo_diff_list(&revert);
+                return Err(e);
+            }
+        }
+
         // One diff list => one history/send-queue entry => a single undo reverts the
         // whole batch. Evaluate once at the end (a no-op while a caller has evaluation
         // paused; one coalesced recompute otherwise) — the paste_csv_string pattern.

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -454,6 +454,75 @@ impl<'a> UserModel<'a> {
         Ok(())
     }
 
+    /// Sets the raw input of many cells as a **single** undoable action.
+    ///
+    /// Each tuple is `(sheet, row, column, value)`. Every input is applied and
+    /// recorded into **one** history entry, so a single [`undo`](UserModel::undo)
+    /// reverts the whole batch (and a single [`redo`](UserModel::redo) re-applies
+    /// it), and the workbook evaluates once at the end. This is the scattered-cell
+    /// analogue of [`set_user_input`](UserModel::set_user_input): use it when a set
+    /// of non-contiguous cells must change together — e.g. a find-and-replace across
+    /// a sheet — instead of paying one undo step per cell.
+    ///
+    /// Unlike [`paste_csv_string`](UserModel::paste_csv_string) it does not clear a
+    /// rectangle first: only the listed cells are touched, so unrelated cells
+    /// (formulas, array formulas, typed values) sitting between the targets are left
+    /// untouched. Coordinates are validated up front, so an out-of-range entry is
+    /// rejected without mutating the model. An empty slice is a no-op (no history
+    /// entry).
+    ///
+    /// See also:
+    /// * [UserModel::set_user_input]
+    /// * [UserModel::paste_csv_string]
+    pub fn set_user_inputs(&mut self, inputs: &[(u32, i32, i32, String)]) -> Result<(), String> {
+        // Validate every coordinate up front (read-only) so a bad entry cannot leave
+        // a partial write with no matching history entry — the batch is all-or-nothing.
+        for &(sheet, row, column, _) in inputs {
+            self.model.workbook.worksheet(sheet)?;
+            if !is_valid_column_number(column) {
+                return Err("Invalid column".to_string());
+            }
+            if !is_valid_row(row) {
+                return Err("Invalid row".to_string());
+            }
+        }
+        if inputs.is_empty() {
+            return Ok(());
+        }
+        let mut diff_list = Vec::with_capacity(inputs.len());
+        for (sheet, row, column, value) in inputs {
+            let (sheet, row, column) = (*sheet, *row, *column);
+            let old_value = self
+                .model
+                .workbook
+                .worksheet(sheet)?
+                .cell(row, column)
+                .cloned();
+            // A spill cell's value derives from its anchor, so record the old value as
+            // None (mirrors set_user_input) — undo re-spills it from the anchor.
+            let old_value = if matches!(old_value, Some(Cell::SpillCell { .. })) {
+                None
+            } else {
+                old_value
+            };
+            self.model
+                .set_user_input(sheet, row, column, value.to_string())?;
+            diff_list.push(Diff::SetCellValue {
+                sheet,
+                row,
+                column,
+                new_value: value.to_string(),
+                old_value: Box::new(old_value),
+            });
+        }
+        // One diff list => one history/send-queue entry => a single undo reverts the
+        // whole batch. Evaluate once at the end (a no-op while a caller has evaluation
+        // paused; one coalesced recompute otherwise) — the paste_csv_string pattern.
+        self.push_diff_list(diff_list);
+        self.evaluate_if_not_paused();
+        Ok(())
+    }
+
     /// Returns the content of a cell
     ///
     /// See also:

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -495,37 +495,41 @@ impl<'a> UserModel<'a> {
     /// Unlike [`paste_csv_string`](UserModel::paste_csv_string) it does not clear a
     /// rectangle first: only the listed cells are touched, so unrelated cells
     /// (formulas, array formulas, typed values) sitting between the targets are left
-    /// untouched. Coordinates are validated up front, so an out-of-range entry is
-    /// rejected without mutating the model. An empty slice is a no-op (no history
-    /// entry).
+    /// untouched. Coordinates are validated up front, so a bad entry is rejected
+    /// without mutating the model, and should a write fail part-way the **values**
+    /// already written are restored — a rejected batch leaves no partial values
+    /// behind. An empty slice is a no-op (no history entry).
+    ///
+    /// **The rollback covers values only.** [`Model::set_user_input`] auto-links
+    /// URL-shaped input (and styles a newly created link), and this method records
+    /// only cell-value changes, so neither the rollback nor a later
+    /// [`undo`](UserModel::undo) removes a link the batch created. A batch containing
+    /// URL-shaped values is therefore not yet fully reversible; a future revision will
+    /// record the link changes too.
     ///
     /// See also:
     /// * [UserModel::set_user_input]
     /// * [UserModel::paste_csv_string]
     pub fn set_user_inputs(&mut self, inputs: &[(u32, i32, i32, String)]) -> Result<(), String> {
-        // Validate every coordinate up front (read-only) so a bad entry cannot leave
-        // a partial write with no matching history entry — the batch is all-or-nothing.
-        for &(sheet, row, column, _) in inputs {
-            self.model.workbook.worksheet(sheet)?;
+        // Validate every coordinate AND snapshot every target's pre-batch value up
+        // front — before writing anything. Reading everything first is what makes the
+        // batch all-or-nothing:
+        //   * a bad coordinate is rejected without mutating the model, and
+        //   * every `old_value` is captured before the first write, so it reflects the
+        //     true pre-batch state (never a value that an earlier write in this same
+        //     batch already changed — e.g. by clearing a dynamic spill), and a
+        //     mid-batch write failure can be rolled back to exactly that state.
+        let mut diff_list = Vec::with_capacity(inputs.len());
+        for (sheet, row, column, value) in inputs {
+            let (sheet, row, column) = (*sheet, *row, *column);
+            let worksheet = self.model.workbook.worksheet(sheet)?;
             if !is_valid_column_number(column) {
                 return Err("Invalid column".to_string());
             }
             if !is_valid_row(row) {
                 return Err("Invalid row".to_string());
             }
-        }
-        if inputs.is_empty() {
-            return Ok(());
-        }
-        let mut diff_list = Vec::with_capacity(inputs.len());
-        for (sheet, row, column, value) in inputs {
-            let (sheet, row, column) = (*sheet, *row, *column);
-            let old_value = self
-                .model
-                .workbook
-                .worksheet(sheet)?
-                .cell(row, column)
-                .cloned();
+            let old_value = worksheet.cell(row, column).cloned();
             // A spill cell's value derives from its anchor, so record the old value as
             // None (mirrors set_user_input) — undo re-spills it from the anchor.
             let old_value = if matches!(old_value, Some(Cell::SpillCell { .. })) {
@@ -533,8 +537,6 @@ impl<'a> UserModel<'a> {
             } else {
                 old_value
             };
-            self.model
-                .set_user_input(sheet, row, column, value.to_string())?;
             diff_list.push(Diff::SetCellValue {
                 sheet,
                 row,
@@ -543,6 +545,29 @@ impl<'a> UserModel<'a> {
                 old_value: Box::new(old_value),
             });
         }
+        if diff_list.is_empty() {
+            return Ok(());
+        }
+
+        // Apply the writes. Because every old_value was snapshotted above, if a write
+        // fails part-way we can restore the values already written (and any partial
+        // mutation from the failing call) to their pre-batch state before surfacing
+        // the error. The snapshots are `SetCellValue` diffs, so this restores values
+        // only — see the doc comment on the auto-link gap.
+        for (index, (sheet, row, column, value)) in inputs.iter().enumerate() {
+            if let Err(e) = self
+                .model
+                .set_user_input(*sheet, *row, *column, value.to_string())
+            {
+                // Revert cells 0..=index from their snapshots (apply_undo_diff_list
+                // restores in reverse and re-evaluates). Ignore a secondary error so
+                // the original cause is what the caller sees.
+                let revert = diff_list[..=index].to_vec();
+                let _ = self.apply_undo_diff_list(&revert);
+                return Err(e);
+            }
+        }
+
         // One diff list => one history/send-queue entry => a single undo reverts the
         // whole batch. Evaluate once at the end (a no-op while a caller has evaluation
         // paused; one coalesced recompute otherwise) — the paste_csv_string pattern.

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -482,6 +482,75 @@ impl<'a> UserModel<'a> {
         Ok(())
     }
 
+    /// Sets the raw input of many cells as a **single** undoable action.
+    ///
+    /// Each tuple is `(sheet, row, column, value)`. Every input is applied and
+    /// recorded into **one** history entry, so a single [`undo`](UserModel::undo)
+    /// reverts the whole batch (and a single [`redo`](UserModel::redo) re-applies
+    /// it), and the workbook evaluates once at the end. This is the scattered-cell
+    /// analogue of [`set_user_input`](UserModel::set_user_input): use it when a set
+    /// of non-contiguous cells must change together — e.g. a find-and-replace across
+    /// a sheet — instead of paying one undo step per cell.
+    ///
+    /// Unlike [`paste_csv_string`](UserModel::paste_csv_string) it does not clear a
+    /// rectangle first: only the listed cells are touched, so unrelated cells
+    /// (formulas, array formulas, typed values) sitting between the targets are left
+    /// untouched. Coordinates are validated up front, so an out-of-range entry is
+    /// rejected without mutating the model. An empty slice is a no-op (no history
+    /// entry).
+    ///
+    /// See also:
+    /// * [UserModel::set_user_input]
+    /// * [UserModel::paste_csv_string]
+    pub fn set_user_inputs(&mut self, inputs: &[(u32, i32, i32, String)]) -> Result<(), String> {
+        // Validate every coordinate up front (read-only) so a bad entry cannot leave
+        // a partial write with no matching history entry — the batch is all-or-nothing.
+        for &(sheet, row, column, _) in inputs {
+            self.model.workbook.worksheet(sheet)?;
+            if !is_valid_column_number(column) {
+                return Err("Invalid column".to_string());
+            }
+            if !is_valid_row(row) {
+                return Err("Invalid row".to_string());
+            }
+        }
+        if inputs.is_empty() {
+            return Ok(());
+        }
+        let mut diff_list = Vec::with_capacity(inputs.len());
+        for (sheet, row, column, value) in inputs {
+            let (sheet, row, column) = (*sheet, *row, *column);
+            let old_value = self
+                .model
+                .workbook
+                .worksheet(sheet)?
+                .cell(row, column)
+                .cloned();
+            // A spill cell's value derives from its anchor, so record the old value as
+            // None (mirrors set_user_input) — undo re-spills it from the anchor.
+            let old_value = if matches!(old_value, Some(Cell::SpillCell { .. })) {
+                None
+            } else {
+                old_value
+            };
+            self.model
+                .set_user_input(sheet, row, column, value.to_string())?;
+            diff_list.push(Diff::SetCellValue {
+                sheet,
+                row,
+                column,
+                new_value: value.to_string(),
+                old_value: Box::new(old_value),
+            });
+        }
+        // One diff list => one history/send-queue entry => a single undo reverts the
+        // whole batch. Evaluate once at the end (a no-op while a caller has evaluation
+        // paused; one coalesced recompute otherwise) — the paste_csv_string pattern.
+        self.push_diff_list(diff_list);
+        self.evaluate_if_not_paused();
+        Ok(())
+    }
+
     /// Calls [`Model::set_user_input`] and appends to `diff_list` the diffs for the
     /// side effects it has on the cell link: URL-like values are auto-linked (which
     /// also applies the link style when the cell was not linked before) and an empty


### PR DESCRIPTION
There was no public way to change a set of scattered (non-contiguous) cells as a single undoable action. `set_user_input` records one history entry per cell, and the multi-cell single-undo mechanism (`push_diff_list`) is crate -private; the only public multi-cell writers are the rectangle pastes, which clear and rewrite a whole bounding box and so are unusable for a sparse set of targets.

**Why**: a Find + Replace All feature resulted in many undo entries for a single user action. 

Add `UserModel::set_user_inputs(&[(sheet, row, column, value)])`, which applies every listed input and records them into a single `diff_list`, so:

  * one undo reverts the whole batch and one redo re-applies it;
  * the workbook evaluates once, at the end of the batch;
  * only the listed cells are touched — unlike `paste_csv_string` there is no rectangle clear, so unrelated cells (formulas, array formulas, typed values) between the targets are left untouched.

Coordinates are validated up front, so an out-of-range entry is rejected without partially mutating the model, and an empty slice is a no-op with no history entry. A spill cell's old value is recorded as None (as `set_user_input` does) so undo re-spills it from its anchor. The batch may span multiple sheets in one entry.

Tests cover the single undo/redo step, restoring prior (non-empty) values, a dependent formula recompute, the empty no-op, out-of-range rejection without mutation, a cross-sheet batch, and diff propagation to a peer.