### PR TITLE
fix(structural-edits): track frozen pane on insert/delete rows & columns

### DIFF
--- a/base/src/actions.rs
+++ b/base/src/actions.rs
@@ -550,6 +550,13 @@ impl<'a> Model<'a> {
 
         worksheet.cols = new_columns;
 
+        // Excel freeze-pane tracking: inserting columns within or before the frozen band
+        // (columns 1..=frozen_columns, 1-based) pushes the freeze boundary right, growing the
+        // band; inserting entirely to the right of the band leaves the boundary unchanged.
+        if column <= worksheet.frozen_columns {
+            worksheet.frozen_columns += column_count;
+        }
+
         Ok(())
     }
 
@@ -671,6 +678,15 @@ impl<'a> Model<'a> {
             }
         }
         worksheet.cols = new_columns;
+
+        // Excel freeze-pane tracking: deleting columns that fall within the frozen band
+        // (columns 1..=frozen_columns, 1-based) shrinks the band by the number of frozen columns
+        // removed; deletions entirely to the right of the band leave the boundary unchanged.
+        if column <= worksheet.frozen_columns {
+            let last_deleted = column + column_count - 1;
+            let deleted_in_band = last_deleted.min(worksheet.frozen_columns) - column + 1;
+            worksheet.frozen_columns -= deleted_in_band;
+        }
 
         Ok(())
     }
@@ -857,6 +873,14 @@ impl<'a> Model<'a> {
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
 
+        // Excel freeze-pane tracking: inserting rows within or above the frozen band
+        // (rows 1..=frozen_rows, 1-based) pushes the freeze boundary down, growing the band;
+        // inserting entirely below the band leaves the boundary unchanged.
+        let worksheet = self.workbook.worksheet_mut(sheet)?;
+        if row <= worksheet.frozen_rows {
+            worksheet.frozen_rows += row_count;
+        }
+
         Ok(())
     }
 
@@ -925,6 +949,17 @@ impl<'a> Model<'a> {
         };
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
+
+        // Excel freeze-pane tracking: deleting rows that fall within the frozen band
+        // (rows 1..=frozen_rows, 1-based) shrinks the band by the number of frozen rows removed;
+        // deletions entirely below the band leave the boundary unchanged.
+        let worksheet = self.workbook.worksheet_mut(sheet)?;
+        if row <= worksheet.frozen_rows {
+            let last_deleted = row + row_count - 1;
+            let deleted_in_band = last_deleted.min(worksheet.frozen_rows) - row + 1;
+            worksheet.frozen_rows -= deleted_in_band;
+        }
+
         Ok(())
     }
 

--- a/base/src/actions.rs
+++ b/base/src/actions.rs
@@ -600,6 +600,13 @@ impl<'a> Model<'a> {
 
         worksheet.cols = new_columns;
 
+        // Excel freeze-pane tracking: inserting columns within or before the frozen band
+        // (columns 1..=frozen_columns, 1-based) pushes the freeze boundary right, growing the
+        // band; inserting entirely to the right of the band leaves the boundary unchanged.
+        if column <= worksheet.frozen_columns {
+            worksheet.frozen_columns += column_count;
+        }
+
         Ok(())
     }
 
@@ -732,6 +739,15 @@ impl<'a> Model<'a> {
             }
         }
         worksheet.cols = new_columns;
+
+        // Excel freeze-pane tracking: deleting columns that fall within the frozen band
+        // (columns 1..=frozen_columns, 1-based) shrinks the band by the number of frozen columns
+        // removed; deletions entirely to the right of the band leave the boundary unchanged.
+        if column <= worksheet.frozen_columns {
+            let last_deleted = column + column_count - 1;
+            let deleted_in_band = last_deleted.min(worksheet.frozen_columns) - column + 1;
+            worksheet.frozen_columns -= deleted_in_band;
+        }
 
         Ok(())
     }
@@ -927,6 +943,14 @@ impl<'a> Model<'a> {
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
 
+        // Excel freeze-pane tracking: inserting rows within or above the frozen band
+        // (rows 1..=frozen_rows, 1-based) pushes the freeze boundary down, growing the band;
+        // inserting entirely below the band leaves the boundary unchanged.
+        let worksheet = self.workbook.worksheet_mut(sheet)?;
+        if row <= worksheet.frozen_rows {
+            worksheet.frozen_rows += row_count;
+        }
+
         Ok(())
     }
 
@@ -1007,6 +1031,17 @@ impl<'a> Model<'a> {
         };
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
+
+        // Excel freeze-pane tracking: deleting rows that fall within the frozen band
+        // (rows 1..=frozen_rows, 1-based) shrinks the band by the number of frozen rows removed;
+        // deletions entirely below the band leave the boundary unchanged.
+        let worksheet = self.workbook.worksheet_mut(sheet)?;
+        if row <= worksheet.frozen_rows {
+            let last_deleted = row + row_count - 1;
+            let deleted_in_band = last_deleted.min(worksheet.frozen_rows) - row + 1;
+            worksheet.frozen_rows -= deleted_in_band;
+        }
+
         Ok(())
     }
 

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -113,6 +113,7 @@ mod test_fn_tocol_torow;
 mod test_fn_transpose;
 mod test_fn_type;
 mod test_frozen_rows_and_columns;
+mod test_frozen_structural_edits;
 mod test_geomean;
 mod test_get_cell_content;
 mod test_implicit_intersection;

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -114,6 +114,7 @@ mod test_fn_tocol_torow;
 mod test_fn_transpose;
 mod test_fn_type;
 mod test_frozen_rows_and_columns;
+mod test_frozen_structural_edits;
 mod test_geomean;
 mod test_get_cell_content;
 mod test_implicit_intersection;

--- a/base/src/test/test_frozen_structural_edits.rs
+++ b/base/src/test/test_frozen_structural_edits.rs
@@ -1,0 +1,185 @@
+#![allow(clippy::unwrap_used)]
+
+//! Structural edits (insert/delete rows and columns) track the frozen-pane boundary the way
+//! Excel does: inserting within or above the frozen band grows it, deleting within it shrinks
+//! it, and edits entirely past the band leave it unchanged. The adjustment rides the same single
+//! undo step as the insert/delete itself.
+
+use crate::test::util::new_empty_model;
+use crate::UserModel;
+
+fn frozen_model() -> UserModel<'static> {
+    let mut model = UserModel::from_model(new_empty_model());
+    model.set_frozen_rows_count(0, 3).unwrap();
+    model.set_frozen_columns_count(0, 2).unwrap();
+    model
+}
+
+#[test]
+fn insert_rows_above_band_grows_and_round_trips() {
+    let mut model = frozen_model();
+    // Insert one row above the whole band (row 1, 1-based).
+    model.insert_rows(0, 1, 1).unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 4);
+    // Columns are untouched by a row insert.
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 2);
+
+    model.undo().unwrap();
+    assert_eq!(
+        model.get_frozen_rows_count(0).unwrap(),
+        3,
+        "undo restores M"
+    );
+    model.redo().unwrap();
+    assert_eq!(
+        model.get_frozen_rows_count(0).unwrap(),
+        4,
+        "redo re-applies"
+    );
+}
+
+#[test]
+fn insert_rows_within_band_grows_by_count() {
+    let mut model = frozen_model();
+    // Insert two rows within the band (before row 2).
+    model.insert_rows(0, 2, 2).unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 5);
+}
+
+#[test]
+fn insert_rows_at_last_frozen_track_grows() {
+    let mut model = frozen_model();
+    // Row 3 is the last frozen track (pos == frozen_rows, the `<=` upper edge): still within
+    // the band, so the boundary grows.
+    model.insert_rows(0, 3, 1).unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 4);
+}
+
+#[test]
+fn insert_rows_just_below_band_leaves_it() {
+    let mut model = frozen_model();
+    // Row 4 is the first scrollable row (M + 1); inserting there is below the band.
+    model.insert_rows(0, 4, 1).unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 3);
+}
+
+#[test]
+fn insert_rows_far_below_band_leaves_it() {
+    let mut model = frozen_model();
+    model.insert_rows(0, 50, 3).unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 3);
+}
+
+#[test]
+fn delete_rows_within_band_shrinks_and_round_trips() {
+    let mut model = frozen_model();
+    // Delete one frozen row (row 2).
+    model.delete_rows(0, 2, 1).unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 2);
+
+    model.undo().unwrap();
+    assert_eq!(
+        model.get_frozen_rows_count(0).unwrap(),
+        3,
+        "undo restores the shrunk band"
+    );
+    model.redo().unwrap();
+    assert_eq!(
+        model.get_frozen_rows_count(0).unwrap(),
+        2,
+        "redo re-shrinks"
+    );
+}
+
+#[test]
+fn delete_entire_band_collapses_to_zero_and_undo_restores() {
+    let mut model = frozen_model();
+    model.delete_rows(0, 1, 3).unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 0);
+    // Undo must regrow the fully-collapsed band — insert_rows alone cannot, so the snapshot does.
+    model.undo().unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 3);
+}
+
+#[test]
+fn delete_rows_spanning_band_boundary_removes_only_frozen_part() {
+    let mut model = frozen_model();
+    // Delete rows 2..=4: rows 2 and 3 are frozen (2 of them), row 4 is not.
+    model.delete_rows(0, 2, 3).unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 1);
+    model.undo().unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 3);
+}
+
+#[test]
+fn delete_rows_below_band_leaves_it() {
+    let mut model = frozen_model();
+    model.delete_rows(0, 10, 2).unwrap();
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 3);
+}
+
+#[test]
+fn insert_columns_within_band_grows_and_round_trips() {
+    let mut model = frozen_model();
+    model.insert_columns(0, 1, 2).unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 4);
+    // Rows untouched by a column insert.
+    assert_eq!(model.get_frozen_rows_count(0).unwrap(), 3);
+
+    model.undo().unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 2);
+    model.redo().unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 4);
+}
+
+#[test]
+fn insert_columns_at_last_frozen_track_grows() {
+    let mut model = frozen_model();
+    // Column 2 is the last frozen track (pos == frozen_columns, the `<=` upper edge): still
+    // within the band, so the boundary grows.
+    model.insert_columns(0, 2, 1).unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 3);
+}
+
+#[test]
+fn insert_columns_below_band_leaves_it() {
+    let mut model = frozen_model();
+    // Column 3 is the first scrollable column (K + 1).
+    model.insert_columns(0, 3, 1).unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 2);
+}
+
+#[test]
+fn delete_columns_spanning_band_boundary_removes_only_frozen_part() {
+    let mut model = frozen_model();
+    // Delete columns 2..=3: column 2 is frozen (1 of them), column 3 is not.
+    model.delete_columns(0, 2, 2).unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 1);
+    model.undo().unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 2);
+}
+
+#[test]
+fn delete_columns_within_band_shrinks_and_undo_restores() {
+    let mut model = frozen_model();
+    model.delete_columns(0, 1, 1).unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 1);
+    model.undo().unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 2);
+}
+
+#[test]
+fn delete_entire_column_band_collapses_and_undo_restores() {
+    let mut model = frozen_model();
+    model.delete_columns(0, 1, 2).unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 0);
+    model.undo().unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 2);
+}
+
+#[test]
+fn delete_columns_right_of_band_leaves_it() {
+    let mut model = frozen_model();
+    model.delete_columns(0, 10, 2).unwrap();
+    assert_eq!(model.get_frozen_columns_count(0).unwrap(), 2);
+}

--- a/base/src/test/user_model/test_batch_row_column_diff.rs
+++ b/base/src/test/user_model/test_batch_row_column_diff.rs
@@ -112,6 +112,7 @@ fn diff_order_delete_rows() {
             row,
             count,
             old_data,
+            ..
         } => {
             assert_eq!(*sheet, 0);
             assert_eq!(*row, 5);
@@ -188,6 +189,7 @@ fn delete_empty_rows() {
             row,
             count,
             old_data,
+            ..
         } => {
             assert_eq!(*sheet, 0);
             assert_eq!(*row, 5);
@@ -231,6 +233,7 @@ fn delete_mixed_empty_and_filled_rows() {
             row,
             count,
             old_data,
+            ..
         } => {
             assert_eq!(*sheet, 0);
             assert_eq!(*row, 5);
@@ -364,6 +367,7 @@ fn bulk_delete_rows_round_trip() {
             row,
             count,
             old_data,
+            ..
         } => {
             assert_eq!(*sheet, 0);
             assert_eq!(*row, 3);
@@ -431,6 +435,7 @@ fn bulk_delete_columns_round_trip() {
             column,
             count,
             old_data,
+            ..
         } => {
             assert_eq!(*sheet, 0);
             assert_eq!(*column, 3);

--- a/base/src/test/user_model/test_diff_queue.rs
+++ b/base/src/test/user_model/test_diff_queue.rs
@@ -100,7 +100,9 @@ fn queue_undo_redo_multiple() {
 
     // Check everything is as expected
     assert_eq!(model2.get_frozen_columns_count(0), Ok(5));
-    assert_eq!(model2.get_frozen_rows_count(0), Ok(6));
+    // Frozen rows started at 6; the two `insert_rows(0, 3, 1)` above each land inside the frozen
+    // band (row 3 <= the boundary), so the band grows by two to 8 (Excel freeze-pane tracking).
+    assert_eq!(model2.get_frozen_rows_count(0), Ok(8));
     assert_eq!(model2.get_column_width(0, 7), Ok(300.0));
     // I inserted two rows
     assert_eq!(

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -1023,6 +1023,9 @@ impl<'a> UserModel<'a> {
             });
         }
 
+        // Snapshot the frozen-rows count before the delete shrinks it, so undo can restore it.
+        let old_frozen_rows = self.model.workbook.worksheet(sheet)?.frozen_rows;
+
         self.model.delete_rows(sheet, row, row_count)?;
 
         let diff_list = vec![Diff::DeleteRows {
@@ -1030,6 +1033,7 @@ impl<'a> UserModel<'a> {
             row,
             count: row_count,
             old_data,
+            old_frozen_rows,
         }];
         self.push_diff_list(diff_list);
         self.evaluate_if_not_paused();
@@ -1088,6 +1092,9 @@ impl<'a> UserModel<'a> {
             });
         }
 
+        // Snapshot the frozen-columns count before the delete shrinks it, so undo can restore it.
+        let old_frozen_columns = self.model.workbook.worksheet(sheet)?.frozen_columns;
+
         self.model.delete_columns(sheet, column, column_count)?;
 
         let diff_list = vec![Diff::DeleteColumns {
@@ -1095,6 +1102,7 @@ impl<'a> UserModel<'a> {
             column,
             count: column_count,
             old_data,
+            old_frozen_columns,
         }];
         self.push_diff_list(diff_list);
         self.evaluate_if_not_paused();

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -1155,6 +1155,8 @@ impl<'a> UserModel<'a> {
             });
         }
 
+        // Snapshot the frozen-rows count before the delete shrinks it, so undo can restore it.
+        let old_frozen_rows = self.model.workbook.worksheet(sheet)?.frozen_rows;
         // The links of the deleted rows cannot be restored by re-inserting the
         // rows: capture them for undo. Links below the deleted rows just shift
         // with their cells, [`Model::delete_rows`] takes care of them.
@@ -1173,6 +1175,7 @@ impl<'a> UserModel<'a> {
             row,
             count: row_count,
             old_data,
+            old_frozen_rows,
         });
         self.push_diff_list(diff_list);
         self.evaluate_if_not_paused();
@@ -1231,6 +1234,8 @@ impl<'a> UserModel<'a> {
             });
         }
 
+        // Snapshot the frozen-columns count before the delete shrinks it, so undo can restore it.
+        let old_frozen_columns = self.model.workbook.worksheet(sheet)?.frozen_columns;
         // The links of the deleted columns cannot be restored by re-inserting
         // the columns: capture them for undo. Links to the right of the deleted
         // columns just shift with their cells, [`Model::delete_columns`] takes
@@ -1250,6 +1255,7 @@ impl<'a> UserModel<'a> {
             column,
             count: column_count,
             old_data,
+            old_frozen_columns,
         });
         self.push_diff_list(diff_list);
         self.evaluate_if_not_paused();

--- a/base/src/user_model/history.rs
+++ b/base/src/user_model/history.rs
@@ -134,6 +134,9 @@ pub(crate) enum Diff {
         row: i32,
         count: i32,
         old_data: Vec<RowData>,
+        // Frozen-rows count before the delete. Undo re-inserts the rows via `insert_rows`, which
+        // can only regrow the frozen band partially, so the pre-delete count is restored directly.
+        old_frozen_rows: i32,
     },
     InsertColumns {
         sheet: u32,
@@ -145,6 +148,8 @@ pub(crate) enum Diff {
         column: i32,
         count: i32,
         old_data: Vec<ColumnData>,
+        // Frozen-columns count before the delete (see `DeleteRows::old_frozen_rows`).
+        old_frozen_columns: i32,
     },
     DeleteSheet {
         sheet: u32,

--- a/base/src/user_model/undo_redo.rs
+++ b/base/src/user_model/undo_redo.rs
@@ -247,6 +247,7 @@ impl<'a> UserModel<'a> {
                     row,
                     count: _,
                     old_data,
+                    old_frozen_rows,
                 } => {
                     needs_evaluation = true;
                     self.model
@@ -259,6 +260,9 @@ impl<'a> UserModel<'a> {
                         }
                         worksheet.sheet_data.insert(r, row_data.data.clone());
                     }
+                    // `insert_rows` only regrows the frozen band partially; restore the exact
+                    // pre-delete count so a delete that shrank the band round-trips on undo.
+                    worksheet.frozen_rows = *old_frozen_rows;
                 }
                 Diff::InsertColumns {
                     sheet,
@@ -273,6 +277,7 @@ impl<'a> UserModel<'a> {
                     column,
                     count: _,
                     old_data,
+                    old_frozen_columns,
                 } => {
                     needs_evaluation = true;
                     self.model
@@ -290,6 +295,9 @@ impl<'a> UserModel<'a> {
                             worksheet.set_column_width_and_style(c, width, hidden, style)?;
                         }
                     }
+                    // `insert_columns` only regrows the frozen band partially; restore the exact
+                    // pre-delete count so a delete that shrank the band round-trips on undo.
+                    worksheet.frozen_columns = *old_frozen_columns;
                 }
                 Diff::SetFrozenRowsCount {
                     sheet,
@@ -752,6 +760,7 @@ impl<'a> UserModel<'a> {
                     row,
                     count,
                     old_data: _,
+                    old_frozen_rows: _,
                 } => {
                     self.model.delete_rows(*sheet, *row, *count)?;
                     needs_evaluation = true;
@@ -769,6 +778,7 @@ impl<'a> UserModel<'a> {
                     column,
                     count,
                     old_data: _,
+                    old_frozen_columns: _,
                 } => {
                     self.model.delete_columns(*sheet, *column, *count)?;
                     needs_evaluation = true;

--- a/base/src/user_model/undo_redo.rs
+++ b/base/src/user_model/undo_redo.rs
@@ -248,6 +248,7 @@ impl<'a> UserModel<'a> {
                     row,
                     count: _,
                     old_data,
+                    old_frozen_rows,
                 } => {
                     needs_evaluation = true;
                     self.model
@@ -260,6 +261,9 @@ impl<'a> UserModel<'a> {
                         }
                         worksheet.sheet_data.insert(r, row_data.data.clone());
                     }
+                    // `insert_rows` only regrows the frozen band partially; restore the exact
+                    // pre-delete count so a delete that shrank the band round-trips on undo.
+                    worksheet.frozen_rows = *old_frozen_rows;
                 }
                 Diff::InsertColumns {
                     sheet,
@@ -274,6 +278,7 @@ impl<'a> UserModel<'a> {
                     column,
                     count: _,
                     old_data,
+                    old_frozen_columns,
                 } => {
                     needs_evaluation = true;
                     self.model
@@ -291,6 +296,9 @@ impl<'a> UserModel<'a> {
                             worksheet.set_column_width_and_style(c, width, hidden, style)?;
                         }
                     }
+                    // `insert_columns` only regrows the frozen band partially; restore the exact
+                    // pre-delete count so a delete that shrank the band round-trips on undo.
+                    worksheet.frozen_columns = *old_frozen_columns;
                 }
                 Diff::SetFrozenRowsCount {
                     sheet,
@@ -784,6 +792,7 @@ impl<'a> UserModel<'a> {
                     row,
                     count,
                     old_data: _,
+                    old_frozen_rows: _,
                 } => {
                     self.model.delete_rows(*sheet, *row, *count)?;
                     needs_evaluation = true;
@@ -801,6 +810,7 @@ impl<'a> UserModel<'a> {
                     column,
                     count,
                     old_data: _,
+                    old_frozen_columns: _,
                 } => {
                     self.model.delete_columns(*sheet, *column, *count)?;
                     needs_evaluation = true;


### PR DESCRIPTION
Other spreadsheets adjusts the frozen-pane boundary when rows or columns are inserted or deleted: inserting within or above the frozen band grows it, deleting within it shrinks it by the number of frozen tracks removed, and edits entirely past the band leave it unchanged. IronCalc's insert_rows/delete_rows/insert_columns/ delete_columns previously left frozen_rows/frozen_columns untouched.

Adjust the pane inside the four Model structural ops so the boundary tracks the edit. The adjustment rides the op's single undo step: undo of an insert is the symmetric delete (and vice versa), and delete-undo (which re-inserts via insert_rows, only able to regrow the band partially) restores the exact pre-delete count from a snapshot added to the DeleteRows/DeleteColumns diffs.

Adds base/src/test/test_frozen_structural_edits.rs covering grow/shrink/ unchanged for both axes plus undo/redo round-trips, including full-band collapse.