### PR TITLE
Fix ADDRESS to prefix ! for an empty sheet_text argument

### DIFF
--- a/base/src/functions/lookup_and_reference/address_areas.rs
+++ b/base/src/functions/lookup_and_reference/address_areas.rs
@@ -62,10 +62,12 @@ impl<'a> Model<'a> {
             true
         };
 
+        // When `sheet_text` is present the `!` separator is always emitted, even
+        // for an empty string: ADDRESS(1,1,1,TRUE,"") is "!$A$1" in Excel. A
+        // `sheet_text` that is omitted entirely produces no prefix.
         let sheet_prefix = if args.len() == 5 {
             match self.get_string(&args[4], cell) {
-                Ok(s) if !s.is_empty() => format!("{}!", quote_name(&s)),
-                Ok(_) => String::new(),
+                Ok(s) => format!("{}!", quote_name(&s)),
                 Err(e) => return e,
             }
         } else {

--- a/base/src/test/lookup_and_reference/test_fn_address_areas.rs
+++ b/base/src/test/lookup_and_reference/test_fn_address_areas.rs
@@ -68,6 +68,30 @@ fn test_address_large_column() {
     assert_eq!(model._get_text("A1"), "$AA$1");
 }
 
+#[test]
+fn test_address_empty_sheet_text() {
+    let mut model = new_empty_model();
+    // A present-but-empty sheet_text still emits the "!" separator.
+    model._set("A1", r#"=ADDRESS(1,1,1,TRUE,"")"#);
+    // An omitted sheet_text emits no prefix.
+    model._set("A2", "=ADDRESS(1,1)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "!$A$1");
+    assert_eq!(model._get_text("A2"), "$A$1");
+}
+
+#[test]
+fn test_address_quoted_sheet_text() {
+    let mut model = new_empty_model();
+    // A name that needs quoting is wrapped in single quotes.
+    model._set("A1", r#"=ADDRESS(1,1,1,TRUE,"My Sheet")"#);
+    // The maximum column still renders correctly with a sheet prefix.
+    model._set("A2", "=ADDRESS(1,16384)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), "'My Sheet'!$A$1");
+    assert_eq!(model._get_text("A2"), "$XFD$1");
+}
+
 // ── AREAS ─────────────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
ADDRESS(1,1,1,TRUE,"") is "!$A$1" in Excel: a present sheet_text argument always emits the "!" separator, even when it is an empty string. Only an omitted sheet_text produces no prefix. Previously an empty sheet_text was treated like an omitted one and produced "$A$1".

Quoting of the name is unchanged (an empty name needs no quoting).