### PR TITLE
update[functions]: add a few missing functions to formula helper

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -1514,6 +1514,10 @@ export default defineConfig({
                 link: "/functions/math_and_trigonometry/odd",
               },
               {
+                text: "PERCENTOF",
+                link: "/functions/math_and_trigonometry/percentof",
+              },
+              {
                 text: "PI",
                 link: "/functions/math_and_trigonometry/pi",
               },

--- a/docs/src/functions/financial/duration.md
+++ b/docs/src/functions/financial/duration.md
@@ -7,6 +7,5 @@ lang: en-US
 # DURATION
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/mduration.md
+++ b/docs/src/functions/financial/mduration.md
@@ -7,6 +7,5 @@ lang: en-US
 # MDURATION
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/math_and_trigonometry/percentof.md
+++ b/docs/src/functions/math_and_trigonometry/percentof.md
@@ -4,7 +4,7 @@ outline: deep
 lang: en-US
 ---
 
-# YIELD
+# PERCENTOF
 
 ::: warning
 🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -4445,6 +4445,19 @@
     "description": "Returns the k-th percentile of a dataset, including the 0th (minimum) and 100th (maximum) percentiles.",
     "examples": ["=PERCENTILE.INC(A2:A20, 0.9) returns the 90th percentile."]
   },
+  "percentof": {
+    "tier": 0,
+    "category": 8,
+    "tags": [],
+    "args": [
+      ["data_subset", "number_or_range", "The values making up the subset"],
+      ["data_all", "number_or_range", "The values making up the whole set"]
+    ],
+    "description": "Returns the share a subset represents of a whole, equivalent to =SUM(data_subset)/SUM(data_all). Mostly used inside GROUPBY and PIVOTBY. The result is a fraction, so format the cell as a percentage.",
+    "examples": [
+      "=PERCENTOF(B2:B5, B2:B20) returns the share the first four values contribute to the whole range."
+    ]
+  },
   "percentrank": {
     "tier": 0,
     "category": 11,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -6975,6 +6975,28 @@
       "=YEARFRAC(A2, B2, 1) returns the actual fraction of a year between the two dates."
     ]
   },
+  "yield": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      ["rate", "number", "Annual coupon rate as a decimal"],
+      ["pr", "number", "Price per $100 face value"],
+      ["redemption", "number", "Redemption value per $100 face value"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the annual yield of a security that pays periodic interest, the return earned by holding a bond bought at a given price to maturity. It is the inverse of PRICE: the yield at which the bond's cash flows discount back to pr.",
+    "examples": [
+      "=YIELD(A2, B2, 0.05, 98, 100, 2, 0) returns the yield of a semiannual bond bought below par."
+    ]
+  },
   "yielddisc": {
     "tier": 0,
     "category": 4,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -1741,6 +1741,27 @@
       "=DSUM(A1:D100, \"Revenue\", F1:F2) sums all revenue rows where the criteria are met."
     ]
   },
+  "duration": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      ["coupon", "number", "Annual coupon rate as a decimal"],
+      ["yld", "number", "Annual yield as a decimal"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the Macaulay duration of a bond paying periodic interest: the weighted-average time in years until its cash flows are received. Use it to compare how sensitive different bonds are to a change in interest rates.",
+    "examples": [
+      "=DURATION(A2, B2, 0.05, 0.04, 2, 0) returns the duration in years of a semiannual bond."
+    ]
+  },
   "dvar": {
     "tier": 0,
     "category": 1,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -2372,6 +2372,25 @@
     "description": "Returns the value of the gamma function Γ(x), which extends the factorial to non-integer values (Γ(n) = (n-1)! for positive integers). Use it in advanced probability and statistics.",
     "examples": ["=GAMMA(5) returns 24 (= 4!)."]
   },
+  "gamma.dist": {
+    "tier": 0,
+    "category": 9,
+    "tags": [],
+    "args": [
+      ["x", "number", "Non-negative value to evaluate"],
+      ["alpha", "number", "Shape parameter (must be positive)"],
+      ["beta", "number", "Scale parameter (must be positive)"],
+      [
+        "cumulative",
+        "logical",
+        "TRUE for the cumulative distribution; FALSE for the probability density"
+      ]
+    ],
+    "description": "Returns the gamma distribution probability (CDF or PDF). Use it to model waiting times and other positive-valued data.",
+    "examples": [
+      "=GAMMA.DIST(2, 2, 1, TRUE) returns the cumulative probability."
+    ]
+  },
   "gamma.inv": {
     "tier": 0,
     "category": 9,
@@ -2386,7 +2405,7 @@
   },
   "gammadist": {
     "tier": 0,
-    "category": 9,
+    "category": 11,
     "tags": [],
     "args": [
       ["x", "number", "Non-negative value to evaluate"],

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -4712,6 +4712,28 @@
       "=PPMT(rate, period, nper, pv) returns the principal for that period."
     ]
   },
+  "price": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      ["rate", "number", "Annual coupon rate as a decimal"],
+      ["yld", "number", "Annual yield as a decimal"],
+      ["redemption", "number", "Redemption value per $100 face value"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the price per $100 face value of a security that pays periodic interest. Use it to value a coupon bond at a given yield: the price comes out above 100 when the coupon beats the yield, and below when it trails.",
+    "examples": [
+      "=PRICE(A2, B2, 0.05, 0.04, 100, 2, 0) prices a semiannual bond yielding less than its coupon."
+    ]
+  },
   "pricedisc": {
     "tier": 0,
     "category": 4,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -3769,6 +3769,27 @@
     "description": "Returns the determinant of a square matrix. Use it in linear algebra - for instance, to check whether a system of equations has a unique solution (a non-zero determinant) or to apply Cramer's rule.",
     "examples": ["=MDETERM(A1:D4) returns the determinant of the 4×4 matrix."]
   },
+  "mduration": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      ["coupon", "number", "Annual coupon rate as a decimal"],
+      ["yld", "number", "Annual yield as a decimal"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the modified Macaulay duration of a bond with an assumed par value of $100. It rescales DURATION by the yield per period, giving the approximate percentage change in price for a one-point change in yield.",
+    "examples": [
+      "=MDURATION(A2, B2, 0.05, 0.04, 2, 0) returns the modified duration of a semiannual bond."
+    ]
+  },
   "median": {
     "tier": 0,
     "category": 9,


### PR DESCRIPTION
This PR adds some functions that were missing from `functions.json`: GAMMA.DIST, PERCENTOF, DURATION, MDURATION, PRICE, YIELD

It also corrects the wording on their respective docs pages, and adds a missing page for PERCENTOF