### PR TITLE
update[functions]: add last missing functions to formula helper 

### DIFF
--- a/docs/src/functions/financial/amordegrc.md
+++ b/docs/src/functions/financial/amordegrc.md
@@ -7,6 +7,5 @@ lang: en-US
 # AMORDEGRC
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/amorlinc.md
+++ b/docs/src/functions/financial/amorlinc.md
@@ -7,6 +7,5 @@ lang: en-US
 # AMORLINC
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/coupdaybs.md
+++ b/docs/src/functions/financial/coupdaybs.md
@@ -7,6 +7,5 @@ lang: en-US
 # COUPDAYBS
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/coupdays.md
+++ b/docs/src/functions/financial/coupdays.md
@@ -7,6 +7,5 @@ lang: en-US
 # COUPDAYS
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/coupdaysnc.md
+++ b/docs/src/functions/financial/coupdaysnc.md
@@ -7,6 +7,5 @@ lang: en-US
 # COUPDAYSNC
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/coupncd.md
+++ b/docs/src/functions/financial/coupncd.md
@@ -7,6 +7,5 @@ lang: en-US
 # COUPNCD
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/coupnum.md
+++ b/docs/src/functions/financial/coupnum.md
@@ -7,6 +7,5 @@ lang: en-US
 # COUPNUM
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/couppcd.md
+++ b/docs/src/functions/financial/couppcd.md
@@ -7,6 +7,5 @@ lang: en-US
 # COUPPCD
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/oddfprice.md
+++ b/docs/src/functions/financial/oddfprice.md
@@ -7,6 +7,5 @@ lang: en-US
 # ODDFPRICE
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/oddfyield.md
+++ b/docs/src/functions/financial/oddfyield.md
@@ -7,6 +7,5 @@ lang: en-US
 # ODDFYIELD
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/oddlprice.md
+++ b/docs/src/functions/financial/oddlprice.md
@@ -7,6 +7,5 @@ lang: en-US
 # ODDLPRICE
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/oddlyield.md
+++ b/docs/src/functions/financial/oddlyield.md
@@ -7,6 +7,5 @@ lang: en-US
 # ODDLYIELD
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/docs/src/functions/financial/vdb.md
+++ b/docs/src/functions/financial/vdb.md
@@ -7,6 +7,5 @@ lang: en-US
 # VDB
 
 ::: warning
-🚧 This function is not yet available in IronCalc.
-[Follow development here](https://github.com/ironcalc/IronCalc/labels/Functions)
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
 :::

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -1152,6 +1152,25 @@
       "=COUNTIFS(B2:B100, \"West\", C2:C100, \">1000\") counts rows where region is West and sales exceed 1000."
     ]
   },
+  "coupdaybs": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the number of days from the start of the current coupon period to the settlement date. This is the span the seller has already earned interest over, so it drives the accrued interest a buyer must pay on top of the price.",
+    "examples": [
+      "=COUPDAYBS(A2, B2, 2, 0) returns the days elapsed in the coupon period at settlement."
+    ]
+  },
   "covar": {
     "tier": 0,
     "category": 11,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -1247,6 +1247,25 @@
       "=COUPNUM(A2, B2, 2) returns 10 for a semiannual bond with five years left to run."
     ]
   },
+  "couppcd": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention; accepted but not used"]
+    ],
+    "description": "Returns the most recent coupon date at or before the settlement date, the point from which interest has been accruing to the seller. The result is a serial number, so format the cell as a date to read it.",
+    "examples": [
+      "=COUPPCD(A2, B2, 2) returns the date of the last coupon paid before settlement."
+    ]
+  },
   "covar": {
     "tier": 0,
     "category": 11,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -1209,6 +1209,25 @@
       "=COUPDAYSNC(A2, B2, 2, 0) returns the days remaining until the next coupon is paid."
     ]
   },
+  "coupncd": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention; accepted but not used"]
+    ],
+    "description": "Returns the first coupon date falling after the settlement date, counting back from maturity at the given frequency. The result is a serial number, so format the cell as a date to read it.",
+    "examples": [
+      "=COUPNCD(A2, B2, 2) returns the date of the next coupon payment after settlement."
+    ]
+  },
   "covar": {
     "tier": 0,
     "category": 11,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -4386,6 +4386,30 @@
     "description": "Rounds a number up to the nearest odd integer. Use it when you need to ensure a value is odd - for example, certain packaging, layout, or algorithm requirements.",
     "examples": ["=ODD(4) returns 5; =ODD(-4) returns -5."]
   },
+  "oddfprice": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      ["issue", "date", "Issue date of the security"],
+      ["first_coupon", "date", "First coupon date of the security"],
+      ["rate", "number", "Annual coupon rate as a decimal"],
+      ["yld", "number", "Annual yield as a decimal"],
+      ["redemption", "number", "Redemption value per $100 face value"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the price per $100 face value of a security whose first period is odd, meaning the first coupon covers a shorter or longer span than the regular ones. Use it for bonds issued between coupon dates, where PRICE would misstate the value.",
+    "examples": [
+      "=ODDFPRICE(A2, B2, C2, D2, 0.05, 0.04, 100, 2, 0) prices a bond with a short first coupon."
+    ]
+  },
   "offset": {
     "tier": 0,
     "category": 7,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -1228,6 +1228,25 @@
       "=COUPNCD(A2, B2, 2) returns the date of the next coupon payment after settlement."
     ]
   },
+  "coupnum": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention; accepted but not used"]
+    ],
+    "description": "Returns how many coupon payments are still due between settlement and maturity, counting the next one and rounding up to a whole coupon. Use it to size a bond's remaining cash flows.",
+    "examples": [
+      "=COUPNUM(A2, B2, 2) returns 10 for a semiannual bond with five years left to run."
+    ]
+  },
   "covar": {
     "tier": 0,
     "category": 11,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -135,6 +135,28 @@
       "=AMORDEGRC(10000, A2, B2, 1000, 1, 0.15) returns the second period's depreciation."
     ]
   },
+  "amorlinc": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["cost", "number", "Purchase cost of the asset"],
+      ["date_purchased", "date", "Date the asset was bought"],
+      ["first_period", "date", "End date of the first accounting period"],
+      ["salvage", "number", "Residual value at the end of the asset's life"],
+      ["period", "integer", "Accounting period to depreciate, starting at 0"],
+      ["rate", "number", "Annual depreciation rate as a decimal"],
+      [
+        "basis*",
+        "integer",
+        "Year basis: 0=360-day NASD (default), 1=actual, 3=365-day, 4=360-day European; 2 is not allowed"
+      ]
+    ],
+    "description": "Returns the depreciation of an asset for one accounting period under the French straight-line system, prorating the first period when the asset is bought part way through it. Each full period writes off the same amount, unlike AMORDEGRC which front-loads it.",
+    "examples": [
+      "=AMORLINC(10000, A2, B2, 1000, 1, 0.15) returns the second period's depreciation."
+    ]
+  },
   "and": {
     "tier": 0,
     "category": 6,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -4434,6 +4434,29 @@
       "=ODDFYIELD(A2, B2, C2, D2, 0.05, 98, 100, 2, 0) returns the yield of a bond with a short first coupon bought below par."
     ]
   },
+  "oddlprice": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      ["last_interest", "date", "Last coupon date of the security"],
+      ["rate", "number", "Annual coupon rate as a decimal"],
+      ["yld", "number", "Annual yield as a decimal"],
+      ["redemption", "number", "Redemption value per $100 face value"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the price per $100 face value of a security whose last period is odd, meaning the final coupon covers a shorter or longer span than the regular ones. Use it for bonds that mature between coupon dates, where PRICE would misstate the value.",
+    "examples": [
+      "=ODDLPRICE(A2, B2, C2, 0.05, 0.04, 100, 2, 0) prices a bond with an irregular final coupon."
+    ]
+  },
   "offset": {
     "tier": 0,
     "category": 7,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -4410,6 +4410,30 @@
       "=ODDFPRICE(A2, B2, C2, D2, 0.05, 0.04, 100, 2, 0) prices a bond with a short first coupon."
     ]
   },
+  "oddfyield": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      ["issue", "date", "Issue date of the security"],
+      ["first_coupon", "date", "First coupon date of the security"],
+      ["rate", "number", "Annual coupon rate as a decimal"],
+      ["pr", "number", "Price per $100 face value"],
+      ["redemption", "number", "Redemption value per $100 face value"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the annual yield of a security whose first period is odd, meaning the first coupon covers a shorter or longer span than the regular ones. It is the inverse of ODDFPRICE: the yield at which the bond's cash flows discount back to pr.",
+    "examples": [
+      "=ODDFYIELD(A2, B2, C2, D2, 0.05, 98, 100, 2, 0) returns the yield of a bond with a short first coupon bought below par."
+    ]
+  },
   "offset": {
     "tier": 0,
     "category": 7,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -4457,6 +4457,29 @@
       "=ODDLPRICE(A2, B2, C2, 0.05, 0.04, 100, 2, 0) prices a bond with an irregular final coupon."
     ]
   },
+  "oddlyield": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      ["last_interest", "date", "Last coupon date of the security"],
+      ["rate", "number", "Annual coupon rate as a decimal"],
+      ["pr", "number", "Price per $100 face value"],
+      ["redemption", "number", "Redemption value per $100 face value"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the annual yield of a security whose last period is odd, meaning the final coupon covers a shorter or longer span than the regular ones. It is the inverse of ODDLPRICE: the yield implied by buying the bond at pr and holding it to maturity.",
+    "examples": [
+      "=ODDLYIELD(A2, B2, C2, 0.05, 98, 100, 2, 0) returns the yield of a bond with an irregular final coupon bought below par."
+    ]
+  },
   "offset": {
     "tier": 0,
     "category": 7,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -6913,6 +6913,36 @@
     "description": "Like VAR.P but includes text and logical values. Use it for population variance over a mixed-type range.",
     "examples": ["=VARPA(A2:A100)."]
   },
+  "vdb": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["cost", "number", "Initial cost of the asset"],
+      ["salvage", "number", "Residual value at end of useful life"],
+      ["life", "number", "Number of periods in the asset's useful life"],
+      [
+        "start_period",
+        "number",
+        "First period to depreciate, in units of life"
+      ],
+      ["end_period", "number", "Last period to depreciate, in units of life"],
+      [
+        "factor*",
+        "number",
+        "Depreciation rate multiplier; defaults to 2 for double-declining balance"
+      ],
+      [
+        "no_switch*",
+        "logical",
+        "TRUE keeps declining balance throughout; FALSE (default) switches to straight line once that gives more"
+      ]
+    ],
+    "description": "Returns the depreciation of an asset over a span of periods using the variable declining balance method. Unlike DDB it covers a range rather than a single period, accepts partial periods, and by default switches to straight line once that writes off more.",
+    "examples": [
+      "=VDB(10000, 1000, 10, 0, 0.5) returns the depreciation for the first half of year one."
+    ]
+  },
   "vlookup": {
     "tier": 0,
     "category": 7,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -1190,6 +1190,25 @@
       "=COUPDAYS(A2, B2, 2, 0) returns 180 for a semiannual bond on a 30/360 basis."
     ]
   },
+  "coupdaysnc": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the number of days from the settlement date to the next coupon date. It tells a buyer how long they must wait for the first interest payment, and completes the coupon period alongside COUPDAYBS.",
+    "examples": [
+      "=COUPDAYSNC(A2, B2, 2, 0) returns the days remaining until the next coupon is paid."
+    ]
+  },
   "covar": {
     "tier": 0,
     "category": 11,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -113,6 +113,28 @@
     "description": "Returns a cell address as a text string given a row number and column number. Use it to build dynamic cell references you can then pass to INDIRECT - for instance, constructing a reference from a formula-driven row and column.",
     "examples": ["=ADDRESS(2, 3) returns \"$C$2\"."]
   },
+  "amordegrc": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["cost", "number", "Purchase cost of the asset"],
+      ["date_purchased", "date", "Date the asset was bought"],
+      ["first_period", "date", "End date of the first accounting period"],
+      ["salvage", "number", "Residual value at the end of the asset's life"],
+      ["period", "integer", "Accounting period to depreciate, starting at 0"],
+      ["rate", "number", "Annual depreciation rate as a decimal"],
+      [
+        "basis*",
+        "integer",
+        "Year basis: 0=360-day NASD (default), 1=actual, 3=365-day, 4=360-day European; 2 is not allowed"
+      ]
+    ],
+    "description": "Returns the depreciation of an asset for one accounting period under the French declining-balance system, prorating the first period when the asset is bought part way through it. It works like AMORLINC but applies a coefficient set by the asset's life, so depreciation is heavier in the early periods.",
+    "examples": [
+      "=AMORDEGRC(10000, A2, B2, 1000, 1, 0.15) returns the second period's depreciation."
+    ]
+  },
   "and": {
     "tier": 0,
     "category": 6,

--- a/webapp/IronCalc/src/components/FormulaHelper/functions.json
+++ b/webapp/IronCalc/src/components/FormulaHelper/functions.json
@@ -1171,6 +1171,25 @@
       "=COUPDAYBS(A2, B2, 2, 0) returns the days elapsed in the coupon period at settlement."
     ]
   },
+  "coupdays": {
+    "tier": 0,
+    "category": 4,
+    "tags": [],
+    "args": [
+      ["settlement", "date", "Settlement date of the security"],
+      ["maturity", "date", "Maturity date of the security"],
+      [
+        "frequency",
+        "integer",
+        "Coupon payments per year: 1=annual, 2=semiannual, 4=quarterly"
+      ],
+      ["basis*", "integer", "Day-count convention (0=US 30/360 default)"]
+    ],
+    "description": "Returns the total number of days in the coupon period that contains the settlement date. It is the denominator when working out what fraction of a coupon has accrued, so COUPDAYBS divided by COUPDAYS gives the share the seller has earned.",
+    "examples": [
+      "=COUPDAYS(A2, B2, 2, 0) returns 180 for a semiannual bond on a 30/360 basis."
+    ]
+  },
   "covar": {
     "tier": 0,
     "category": 11,


### PR DESCRIPTION
This PR adds the remaining functions to the list in `functions.json`: AMORDEGRC, AMORLINC, VDB, ODDFPRICE, ODDFYIELD, ODDLPRICE, ODDLYIELD, COUPDAYBS, COUPDAYS, COUPDAYSNC, COUPNCD, COUPNUM, COUPPCD

It also updates the wording in their respective documentation pages so they are treated as implemented.