### PR TITLE
FIX: Set name goes through history

### DIFF
--- a/base/src/test/user_model/test_general.rs
+++ b/base/src/test/user_model/test_general.rs
@@ -138,3 +138,33 @@ fn get_and_set_name() {
     model.set_name("Another name");
     assert_eq!(model.get_name(), "Another name");
 }
+
+#[test]
+fn set_name_undo_redo() {
+    let mut model = UserModel::new_empty("MyWorkbook123", "en", "UTC", "en").unwrap();
+    model.set_name("Another name");
+    assert_eq!(model.get_name(), "Another name");
+
+    model.undo().unwrap();
+    assert_eq!(model.get_name(), "MyWorkbook123");
+
+    model.redo().unwrap();
+    assert_eq!(model.get_name(), "Another name");
+
+    let send_queue = model.flush_send_queue();
+
+    let mut model2 = UserModel::new_empty("MyWorkbook123", "en", "UTC", "en").unwrap();
+    model2.apply_external_diffs(&send_queue).unwrap();
+    assert_eq!(model2.get_name(), "Another name");
+}
+
+#[test]
+fn set_name_with_same_name_is_not_added_to_history() {
+    let mut model = UserModel::new_empty("MyWorkbook123", "en", "UTC", "en").unwrap();
+    model.set_name("Another name");
+    // A no-op rename must not push a new entry to the undo stack
+    model.set_name("Another name");
+
+    model.undo().unwrap();
+    assert_eq!(model.get_name(), "MyWorkbook123");
+}

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -307,6 +307,14 @@ impl<'a> UserModel<'a> {
 
     /// Sets the name of a workbook
     pub fn set_name(&mut self, name: &str) {
+        let old_value = self.model.workbook.name.clone();
+        if old_value == name {
+            return;
+        }
+        self.push_diff_list(vec![Diff::SetWorkbookName {
+            old_value,
+            new_value: name.to_string(),
+        }]);
         self.model.workbook.name = name.to_string();
     }
 

--- a/base/src/user_model/history.rs
+++ b/base/src/user_model/history.rs
@@ -234,6 +234,10 @@ pub(crate) enum Diff {
         old_value: String,
         new_value: String,
     },
+    SetWorkbookName {
+        old_value: String,
+        new_value: String,
+    },
     SetTimezone {
         old_value: String,
         new_value: String,

--- a/base/src/user_model/undo_redo.rs
+++ b/base/src/user_model/undo_redo.rs
@@ -525,6 +525,12 @@ impl<'a> UserModel<'a> {
                 } => {
                     self.model.set_timezone(old_value)?;
                 }
+                Diff::SetWorkbookName {
+                    old_value,
+                    new_value: _,
+                } => {
+                    self.model.workbook.name = old_value.clone();
+                }
                 Diff::CreateNamedStyle {
                     name,
                     style: _,
@@ -955,6 +961,12 @@ impl<'a> UserModel<'a> {
                     new_value,
                 } => {
                     self.model.set_timezone(new_value)?;
+                }
+                Diff::SetWorkbookName {
+                    old_value: _,
+                    new_value,
+                } => {
+                    self.model.workbook.name = new_value.clone();
                 }
                 Diff::CreateNamedStyle {
                     name,


### PR DESCRIPTION
This means now undo/redo work for setting the name of the workbook