### PR TITLE
update[docs]: add missing links, copy changes

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -1219,12 +1219,36 @@ export default defineConfig({
             link: "/functions/text",
             items: [
               {
+                text: "ARRAYTOTEXT",
+                link: "/functions/text/arraytotext",
+              },
+              {
+                text: "ASC",
+                link: "/functions/text/asc",
+              },
+              {
+                text: "CHAR",
+                link: "/functions/text/char",
+              },
+              {
+                text: "CLEAN",
+                link: "/functions/text/clean",
+              },
+              {
+                text: "CODE",
+                link: "/functions/text/code",
+              },
+              {
                 text: "CONCAT",
                 link: "/functions/text/concat",
               },
               {
                 text: "CONCATENATE",
                 link: "/functions/text/concatenate",
+              },
+              {
+                text: "DOLLAR",
+                link: "/functions/text/dollar",
               },
               {
                 text: "EXACT",
@@ -1235,12 +1259,28 @@ export default defineConfig({
                 link: "/functions/text/find",
               },
               {
+                text: "FINDB",
+                link: "/functions/text/findb",
+              },
+              {
+                text: "FIXED",
+                link: "/functions/text/fixed",
+              },
+              {
                 text: "LEFT",
                 link: "/functions/text/left",
               },
               {
+                text: "LEFTB",
+                link: "/functions/text/leftb",
+              },
+              {
                 text: "LEN",
                 link: "/functions/text/len",
+              },
+              {
+                text: "LENB",
+                link: "/functions/text/lenb",
               },
               {
                 text: "LOWER",
@@ -1283,8 +1323,8 @@ export default defineConfig({
                 link: "/functions/text/replace",
               },
               {
-                text: "REPLACEBS",
-                link: "/functions/text/replacebs",
+                text: "REPLACEB",
+                link: "/functions/text/replaceb",
               },
               {
                 text: "REPT",

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -224,6 +224,10 @@ export default defineConfig({
                 link: "/functions/lookup_and_reference/transpose",
               },
               {
+                text: "TRIMRANGE",
+                link: "/functions/lookup_and_reference/trimrange",
+              },
+              {
                 text: "UNIQUE",
                 link: "/functions/lookup_and_reference/unique",
               },
@@ -1215,6 +1219,34 @@ export default defineConfig({
             link: "/functions/text",
             items: [
               {
+                text: "CONCAT",
+                link: "/functions/text/concat",
+              },
+              {
+                text: "CONCATENATE",
+                link: "/functions/text/concatenate",
+              },
+              {
+                text: "EXACT",
+                link: "/functions/text/exact",
+              },
+              {
+                text: "FIND",
+                link: "/functions/text/find",
+              },
+              {
+                text: "LEFT",
+                link: "/functions/text/left",
+              },
+              {
+                text: "LEN",
+                link: "/functions/text/len",
+              },
+              {
+                text: "LOWER",
+                link: "/functions/text/lower",
+              },
+              {
                 text: "MID",
                 link: "/functions/text/mid",
               },
@@ -1233,6 +1265,18 @@ export default defineConfig({
               {
                 text: "PROPER",
                 link: "/functions/text/proper",
+              },
+              {
+                text: "REGEXEXTRACT",
+                link: "/functions/text/regexextract",
+              },
+              {
+                text: "REGEXREPLACE",
+                link: "/functions/text/regexreplace",
+              },
+              {
+                text: "REGEXTEST",
+                link: "/functions/text/regextest",
               },
               {
                 text: "REPLACE",
@@ -1929,29 +1973,6 @@ export default defineConfig({
               {
                 text: "TYPE",
                 link: "/functions/information/type",
-              },
-            ],
-          },
-          {
-            text: "Uncategorized",
-            collapsed: true,
-            link: "/functions/uncategorized",
-            items: [
-              {
-                text: "REGEXTEST",
-                link: "/functions/uncategorized/regextest",
-              },
-              {
-                text: "REGEXEXTRACT",
-                link: "/functions/uncategorized/regexextract",
-              },
-              {
-                text: "REGEXREPLACE",
-                link: "/functions/uncategorized/regexreplace:",
-              },
-              {
-                text: "TRIMRANGE",
-                link: "/functions/uncategorized/trimrange",
               },
             ],
           },

--- a/docs/src/features/unsupported-features.md
+++ b/docs/src/features/unsupported-features.md
@@ -8,7 +8,7 @@ lang: en-US
 
 Although IronCalc is ready for use, it’s important to understand its current limitations. Below, we list the most significant missing features of a modern spreadsheet engine. If you can live without these features for now, IronCalc might be the product you’re looking for.
 
-## **Collaboration** <Badge type="info" text="PlanWork in progress" />
+## **Collaboration** <Badge type="info" text="Work in progress" />
 
 Real-time collaboration (that is, where multiple users can view and edit the same spreadsheet simultaneously) is not yet available in IronCalc. Currently, spreadsheets cannot be edited concurrently from different devices or by different users. This feature is on the roadmap and is the top priority after the release of version 1.0.
 

--- a/docs/src/features/unsupported-features.md
+++ b/docs/src/features/unsupported-features.md
@@ -8,17 +8,14 @@ lang: en-US
 
 Although IronCalc is ready for use, it’s important to understand its current limitations. Below, we list the most significant missing features of a modern spreadsheet engine. If you can live without these features for now, IronCalc might be the product you’re looking for.
 
-## **Collaboration** <Badge type="info" text="Planned" />
+## **Collaboration** <Badge type="info" text="PlanWork in progress" />
 
 Real-time collaboration (that is, where multiple users can view and edit the same spreadsheet simultaneously) is not yet available in IronCalc. Currently, spreadsheets cannot be edited concurrently from different devices or by different users. This feature is on the roadmap and is the top priority after the release of version 1.0.
 
-## **Charts** <Badge type="info" text="Planned" />
+## **Charts** <Badge type="info" text="Work in progress" />
 
 Although charts are an essential feature for any serious spreadsheet program, they are not planned for version 1.0. Adding chart support will become a high priority after the release of version 1.0.
 
-## **Function Helper** <Badge type="info" text="Planned" />
-
-IronCalc does not yet offer formula suggestions while typing. The planned function helper will autocomplete function names, display the expected arguments, and explain what each function does.
 
 ## **Pivot Tables** <Badge type="info" text="Planned" />
 

--- a/docs/src/functions/text/arraytotext.md
+++ b/docs/src/functions/text/arraytotext.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# ARRAYTOTEXT
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/asc.md
+++ b/docs/src/functions/text/asc.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# ASC
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/char.md
+++ b/docs/src/functions/text/char.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# CHAR
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/clean.md
+++ b/docs/src/functions/text/clean.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# CLEAN
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/code.md
+++ b/docs/src/functions/text/code.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# CODE
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/dollar.md
+++ b/docs/src/functions/text/dollar.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# DOLLAR
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/findb.md
+++ b/docs/src/functions/text/findb.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# FINDB
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/fixed.md
+++ b/docs/src/functions/text/fixed.md
@@ -4,7 +4,7 @@ outline: deep
 lang: en-US
 ---
 
-# REPLACEBS
+# FIXED
 
 ::: warning
 🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).

--- a/docs/src/functions/text/leftb.md
+++ b/docs/src/functions/text/leftb.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# LEFTB
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/lenb.md
+++ b/docs/src/functions/text/lenb.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# LENB
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::

--- a/docs/src/functions/text/replaceb.md
+++ b/docs/src/functions/text/replaceb.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# REPLACEB
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+:::


### PR DESCRIPTION
This PR changes the following in the docs:

- Removes the Formula Helper paragraph from the 'Unsupported Features' page
- Moves REGEX functions to Text group and adds missing links to supported Text functions