### PR TITLE
Two implicit intersection fixes

### DIFF
--- a/base/src/implicit_intersection.rs
+++ b/base/src/implicit_intersection.rs
@@ -5,24 +5,33 @@ use crate::{calc_result::Range, expressions::types::CellReferenceIndex};
 ///  * i_i(B5, A2:A9) -> B5
 ///  * i_i(B5, A7:A9) -> None
 ///  * i_i(B5, A2:D2) -> B2
+///
+/// Excel-parity, cross-sheet:
+///  * a 1x1 range always dereferences, regardless of the consuming cell's
+///    position or sheet (Excel: `=@Sheet2!D5` and OFFSET/INDIRECT results in
+///    scalar context return the single cell's value);
+///  * row/column-aligned intersection works across sheets — the intersection
+///    happens in the range's own coordinate space (Excel: `=Data!D1:D5`
+///    entered on another sheet's C3 returns Data!D3). The resulting reference
+///    lives on the RANGE's sheet.
 pub(crate) fn implicit_intersection(
     cell_reference: &CellReferenceIndex,
     range: &Range,
 ) -> Option<CellReferenceIndex> {
     let left = &range.left;
     let right = &range.right;
-    // A single-cell "range" intersects to itself, on its own sheet. This holds
-    // even when that sheet differs from the calling cell's — e.g. `@Sheet2!B3`,
-    // or an `@`-decorated `OFFSET(INDIRECT("Sheet2!B3"),..)` that resolves to a
-    // single cross-sheet cell. Handle it before the same-sheet guard below, which
-    // would otherwise reject the cross-sheet case and yield #VALUE!.
-    if left.sheet == right.sheet && left.row == right.row && left.column == right.column {
-        return Some(*left);
-    }
-    let sheet = cell_reference.sheet;
-    // If they are not all in the same sheet there is no intersection
-    if sheet != left.sheet && sheet != right.sheet {
+    // A range spanning two sheets never intersects.
+    if left.sheet != right.sheet {
         return None;
+    }
+    let sheet = left.sheet;
+    // Single-cell range: always dereference (position- and sheet-independent).
+    if left.row == right.row && left.column == right.column {
+        return Some(CellReferenceIndex {
+            sheet,
+            row: left.row,
+            column: left.column,
+        });
     }
     let row = cell_reference.row;
     let column = cell_reference.column;

--- a/base/src/implicit_intersection.rs
+++ b/base/src/implicit_intersection.rs
@@ -11,6 +11,14 @@ pub(crate) fn implicit_intersection(
 ) -> Option<CellReferenceIndex> {
     let left = &range.left;
     let right = &range.right;
+    // A single-cell "range" intersects to itself, on its own sheet. This holds
+    // even when that sheet differs from the calling cell's — e.g. `@Sheet2!B3`,
+    // or an `@`-decorated `OFFSET(INDIRECT("Sheet2!B3"),..)` that resolves to a
+    // single cross-sheet cell. Handle it before the same-sheet guard below, which
+    // would otherwise reject the cross-sheet case and yield #VALUE!.
+    if left.sheet == right.sheet && left.row == right.row && left.column == right.column {
+        return Some(*left);
+    }
     let sheet = cell_reference.sheet;
     // If they are not all in the same sheet there is no intersection
     if sheet != left.sheet && sheet != right.sheet {
@@ -35,13 +43,6 @@ pub(crate) fn implicit_intersection(
             sheet,
             row: left.row,
             column,
-        });
-    } else if left.row == right.row && left.column == right.column {
-        // If the range is a single cell, then return it.
-        return Some(CellReferenceIndex {
-            sheet,
-            row: left.row,
-            column: right.column,
         });
     }
     None

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -337,11 +337,13 @@ impl<'a> Model<'a> {
                 child,
             } => match self.evaluate_node_with_reference(child, cell) {
                 CalcResult::Range { left, right } => CalcResult::Range { left, right },
-                _ => CalcResult::new_error(
-                    Error::ERROR,
-                    cell,
-                    format!("Error with Implicit Intersection in cell {cell:?}"),
-                ),
+                // The implicit intersection of a scalar is the scalar itself. The
+                // importer wraps any unknown-shaped function argument (e.g. a CHOOSE
+                // arm that is an IF(...) returning a value) in an automatic `@`; when
+                // the child evaluates to a value rather than a range, that value must
+                // flow through instead of erroring (previously: #ERROR! "Error with
+                // Implicit Intersection", which IFERROR then masked to 0).
+                other => other,
             },
             _ => self.evaluate_node_in_context(node, cell),
         }

--- a/base/src/test/test_fn_formulatext.rs
+++ b/base/src/test/test_fn_formulatext.rs
@@ -44,27 +44,6 @@ fn implicit_intersection_operator() {
     assert_eq!(model._get_text("B1"), *"#N/IMPL!");
 }
 
-// The implicit-intersection operator `@` applied to a single cell on ANOTHER
-// sheet must return that cell's value, not #VALUE!. Excel treats `@Sheet2!B3`
-// (and `@`-decorated OFFSET/INDIRECT that resolve to one cross-sheet cell) as
-// the cell itself. Regression: `implicit_intersection` used to reject any range
-// whose sheet differed from the calling cell's before checking the single-cell
-// case, so these silently became #VALUE! (and, wrapped in IFERROR, 0).
-#[test]
-fn implicit_intersection_operator_cross_sheet_single_cell() {
-    let mut model = new_empty_model();
-    model.new_sheet(); // Sheet2
-    model._set("Sheet2!B3", "42");
-    // direct cross-sheet single-cell reference
-    model._set("Sheet1!A1", "=@Sheet2!B3");
-    // via OFFSET(INDIRECT(..)) resolving to the same single cross-sheet cell
-    model._set("Sheet1!A2", "=@OFFSET(INDIRECT(\"Sheet2!B3\"),0,0)");
-    model.evaluate();
-
-    assert_eq!(model._get_text("Sheet1!A1"), *"42");
-    assert_eq!(model._get_text("Sheet1!A2"), *"42");
-}
-
 #[test]
 fn non_reference() {
     let mut model = new_empty_model();

--- a/base/src/test/test_fn_formulatext.rs
+++ b/base/src/test/test_fn_formulatext.rs
@@ -44,6 +44,27 @@ fn implicit_intersection_operator() {
     assert_eq!(model._get_text("B1"), *"#N/IMPL!");
 }
 
+// The implicit-intersection operator `@` applied to a single cell on ANOTHER
+// sheet must return that cell's value, not #VALUE!. Excel treats `@Sheet2!B3`
+// (and `@`-decorated OFFSET/INDIRECT that resolve to one cross-sheet cell) as
+// the cell itself. Regression: `implicit_intersection` used to reject any range
+// whose sheet differed from the calling cell's before checking the single-cell
+// case, so these silently became #VALUE! (and, wrapped in IFERROR, 0).
+#[test]
+fn implicit_intersection_operator_cross_sheet_single_cell() {
+    let mut model = new_empty_model();
+    model.new_sheet(); // Sheet2
+    model._set("Sheet2!B3", "42");
+    // direct cross-sheet single-cell reference
+    model._set("Sheet1!A1", "=@Sheet2!B3");
+    // via OFFSET(INDIRECT(..)) resolving to the same single cross-sheet cell
+    model._set("Sheet1!A2", "=@OFFSET(INDIRECT(\"Sheet2!B3\"),0,0)");
+    model.evaluate();
+
+    assert_eq!(model._get_text("Sheet1!A1"), *"42");
+    assert_eq!(model._get_text("Sheet1!A2"), *"42");
+}
+
 #[test]
 fn non_reference() {
     let mut model = new_empty_model();

--- a/base/src/test/test_implicit_intersection.rs
+++ b/base/src/test/test_implicit_intersection.rs
@@ -88,3 +88,117 @@ fn scalar_context_unwraps_1x1_array_from_offset_for_dependents() {
     assert_eq!(model._get_text("C1"), "31".to_string());
     assert_eq!(model._get_text("D1"), "30".to_string());
 }
+
+// --- Cross-sheet implicit intersection (`@`) ---
+//
+// The `@` operator applied to a reference resolving to a SINGLE cell on ANOTHER
+// sheet must dereference that cell (Excel: `=@Sheet2!D2` returns Sheet2!D2). A
+// 1x1 range always dereferences, regardless of the consuming cell's sheet.
+
+#[test]
+fn at_operator_on_cross_sheet_single_cell_dereferences() {
+    let mut model = new_empty_model();
+    model.new_sheet(); // Sheet2 at index 1
+    model._set("Sheet2!D2", "=42");
+    model._set("A1", "=@Sheet2!D2");
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"42");
+}
+
+#[test]
+fn at_operator_on_offset_to_other_sheet_dereferences() {
+    // OFFSET returns a reference; `@` in scalar context must dereference the
+    // resulting single cell even when it lives on another sheet.
+    let mut model = new_empty_model();
+    model.new_sheet(); // Sheet2 at index 1
+    model._set("Sheet2!C3", "=7");
+    // OFFSET(Sheet2!A1, 2, 2) -> Sheet2!C3
+    model._set("A1", "=@OFFSET(Sheet2!A1, 2, 2)");
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"7");
+}
+
+#[test]
+fn at_operator_on_offset_indirect_cross_sheet_editpnl_shape() {
+    // The exact editpnl leaf shape: IFERROR(@OFFSET(INDIRECT("Sheet2!"&ref),r,c)/1, 0)
+    // with the OFFSET target a single cell on Sheet2. Must compute, not fall to 0.
+    let mut model = new_empty_model();
+    model.new_sheet(); // Sheet2
+    model._set("Sheet2!B1", "=100"); // OFFSET(Sheet2!A1, 0, 1) -> Sheet2!B1
+    model._set("A1", "A1"); // the INDIRECT anchor string component
+    model._set(
+        "B1",
+        "=IFERROR(@OFFSET(INDIRECT(\"Sheet2!\"&A1), 0, 1)/1, -999)",
+    );
+    model.evaluate();
+
+    assert_eq!(model._get_text("B1"), *"100");
+}
+
+#[test]
+fn at_operator_on_same_sheet_single_cell_still_works() {
+    // Guard against a fix that breaks the same-sheet case.
+    let mut model = new_empty_model();
+    model._set("D2", "=42");
+    model._set("A1", "=@D2");
+    model.evaluate();
+
+    assert_eq!(model._get_text("A1"), *"42");
+}
+
+#[test]
+fn at_operator_row_aligned_intersection_across_sheets() {
+    // A column range on another sheet, row-aligned to the consuming cell, picks
+    // the cell on the range's own sheet at the consuming row (Excel:
+    // `=Sheet2!D1:D5` on C3 -> Sheet2!D3).
+    let mut model = new_empty_model();
+    model.new_sheet(); // Sheet2
+    model._set("Sheet2!D3", "=55");
+    model._set("C3", "=@Sheet2!D1:D5");
+    model.evaluate();
+
+    assert_eq!(model._get_text("C3"), *"55");
+}
+
+// --- Scalar @-child in REFERENCE context ---
+//
+// `fn_choose` (and other reference-context callers) evaluate the selected node
+// via `evaluate_node_with_reference`. When the importer auto-wraps a scalar-
+// signature CHOOSE arm (e.g. an `IF(...)` that returns a scalar) in `@`, that
+// `@`-node reaches `model.rs` `evaluate_node_with_reference`'s
+// `ImplicitIntersection` arm.
+
+#[test]
+fn choose_arm_at_wrapped_scalar_if_flows_through() {
+    // CHOOSE selects arm 1, an @-wrapped IF that returns a scalar. The scalar
+    // must flow through the reference-context intersection, not error to 0.
+    let mut model = new_empty_model();
+    model._set("A1", "10");
+    model._set("A2", "20");
+    // Arm 1 = @IF(TRUE, 5, AVERAGE(A1:A2)) -> scalar 5.
+    model._set(
+        "C1",
+        "=IFERROR(CHOOSE(1, @IF(TRUE, 5, AVERAGE(A1:A2)), 99), -1)",
+    );
+    model.evaluate();
+
+    assert_eq!(model._get_text("C1"), "5".to_string());
+}
+
+#[test]
+fn choose_arm_at_wrapped_scalar_cellref_flows_through() {
+    // The editpnl shape: CHOOSE arm = @IF(cond, single-cell, AVERAGE(range)).
+    // When the IF picks the single cell, the @-scalar must dereference, not error.
+    let mut model = new_empty_model();
+    model._set("A1", "10");
+    model._set("A2", "20");
+    model._set(
+        "C1",
+        "=IFERROR(CHOOSE(1, @IF(TRUE, A1, AVERAGE(A1:A2)), 99), -777)",
+    );
+    model.evaluate();
+
+    assert_eq!(model._get_text("C1"), "10".to_string());
+}


### PR DESCRIPTION
Fixes two related implicit-intersection (`@`) bugs where the operator either
returned `#VALUE!`/`#ERROR!` or silently produced `0` for cases Excel evaluates
to a plain value:

1. **Cross-sheet single-cell reference.** `implicit_intersection` only returned
   a result when the consuming cell shared a row/column with the range, and its
   single-cell (1×1) shortcut was gated on the consuming cell being on the same
   sheet. So `=@Sheet2!D5` — and any OFFSET/INDIRECT result that resolves to one
   cell on another sheet, used in scalar context — failed to dereference and
   evaluated to an error. A 1×1 range is unambiguous and, per Excel, always
   dereferences to that cell's value regardless of where the formula lives.

2. **Scalar flowing through an `@` wrapper.** The importer wraps unknown-shaped
   function arguments in an automatic implicit intersection (e.g. a `CHOOSE`
   arm that is an `IF(...)` returning a value). When that child evaluated to a
   scalar rather than a range, `evaluate_node_with_reference` raised
   `#ERROR!` ("Error with Implicit Intersection"). Downstream `IFERROR` then
   masked it to `0`, so workbooks computed silently-wrong numbers rather than
   erroring visibly. The implicit intersection of a scalar is the scalar itself,
   so the value should flow through.