### PR TITLE
update: dark mode support

### DIFF
--- a/webapp/IronCalc/.storybook/preview.tsx
+++ b/webapp/IronCalc/.storybook/preview.tsx
@@ -3,7 +3,11 @@ import { useEffect, useRef, useState } from "react";
 import { I18nextProvider } from "react-i18next";
 import i18n from "../src/i18n";
 import type { PartialIronCalcThemeVariables } from "../src/theme";
-import { defaultThemeVariables, setThemeVariables } from "../src/theme/theme";
+import {
+  darkThemeVariables,
+  defaultThemeVariables,
+  setThemeVariables,
+} from "../src/theme/theme";
 import "../src/theme/theme.css";
 import "../src/index.css";
 
@@ -34,6 +38,7 @@ const crazyThemeVariables: PartialIronCalcThemeVariables = {
 
 const themes = {
   default: defaultThemeVariables,
+  dark: darkThemeVariables,
   crazy: crazyThemeVariables,
 };
 
@@ -88,6 +93,7 @@ const preview: Preview = {
         icon: "paintbrush",
         items: [
           { value: "default", title: "Default" },
+          { value: "dark", title: "Dark" },
           { value: "crazy", title: "Crazy" },
         ],
       },

--- a/webapp/IronCalc/.storybook/preview.tsx
+++ b/webapp/IronCalc/.storybook/preview.tsx
@@ -2,7 +2,6 @@ import type { Preview } from "@storybook/react";
 import { useEffect, useRef, useState } from "react";
 import { I18nextProvider } from "react-i18next";
 import i18n from "../src/i18n";
-import type { PartialIronCalcThemeVariables } from "../src/theme";
 import {
   darkThemeVariables,
   defaultThemeVariables,
@@ -11,35 +10,9 @@ import {
 import "../src/theme/theme.css";
 import "../src/index.css";
 
-const crazyThemeVariables: PartialIronCalcThemeVariables = {
-  "--palette-common-black": "#2f1616",
-  "--palette-common-white": "#ecc9c9",
-
-  "--palette-primary-main": "#F2994A",
-  "--palette-primary-light": "#EFAA6D",
-  "--palette-primary-dark": "#D68742",
-  "--palette-primary-contrast-text": "#dccece",
-
-  "--palette-secondary-main": "#2F80ED",
-  "--palette-secondary-light": "#4E92EC",
-  "--palette-secondary-dark": "#2B6EC8",
-  "--palette-secondary-contrast-text": "#272525",
-
-  "--palette-error-main": "#EB5757",
-  "--palette-error-light": "#E77A7A",
-  "--palette-error-dark": "#CB4C4C",
-  "--palette-error-contrast-text": "#272525",
-
-  "--palette-warning-main": "#F2C94C",
-  "--palette-warning-light": "#EED384",
-  "--palette-warning-dark": "#D6B244",
-  "--palette-warning-contrast-text": "#e3e9cf",
-};
-
 const themes = {
   default: defaultThemeVariables,
   dark: darkThemeVariables,
-  crazy: crazyThemeVariables,
 };
 
 function PreviewProviders({
@@ -94,7 +67,6 @@ const preview: Preview = {
         items: [
           { value: "default", title: "Default" },
           { value: "dark", title: "Dark" },
-          { value: "crazy", title: "Crazy" },
         ],
       },
     },

--- a/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/AdvancedColorPicker.tsx
+++ b/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/AdvancedColorPicker.tsx
@@ -200,12 +200,7 @@ const AdvancedColorPicker = ({
               ]
                 .filter(Boolean)
                 .join(" ")}
-              style={{
-                backgroundColor: selectedColor,
-                borderColor: isWhiteSwatch
-                  ? "var(--palette-grey-300)"
-                  : selectedColor,
-              }}
+              style={{ backgroundColor: selectedColor }}
               aria-hidden="true"
             />
           </div>

--- a/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/advanced-color-picker.css
+++ b/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/advanced-color-picker.css
@@ -1,5 +1,5 @@
 .ic-advanced-color-picker {
-  background: var(--palette-common-white);
+  background: transparent;
   width: 240px;
   max-width: 100%;
   padding: 0;
@@ -93,6 +93,7 @@
   min-width: 0;
   border: none;
   background: transparent;
+  color: var(--palette-common-black);
   outline: none;
   padding-right: 10px;
   border-radius: 5px;
@@ -123,11 +124,10 @@
 
 .ic-advanced-color-picker-panel {
   position: fixed;
+  border: 1px solid var(--palette-surface-elevated-border);
   border-radius: 12px;
   padding: 0;
   overflow: hidden;
-  background: var(--palette-common-white);
-  box-shadow:
-    0px 8px 24px rgba(0, 0, 0, 0.18),
-    0px 2px 8px rgba(0, 0, 0, 0.1);
+  background: var(--palette-surface-elevated);
+  box-shadow: var(--shadow-md);
 }

--- a/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/advanced-color-picker.css
+++ b/webapp/IronCalc/src/components/AdvancedColorPicker.tsx/advanced-color-picker.css
@@ -59,7 +59,8 @@
 .ic-advanced-color-picker-hex-label {
   margin: auto 0;
   display: inline-flex;
-  font-size: 12px;
+  font-size: var(--typography-font-size);
+  color: var(--palette-grey-900);
   font-family: var(--typography-font-family);
 }
 
@@ -83,7 +84,7 @@
 
 .ic-advanced-color-picker-hash-label {
   margin: auto 0 auto 10px;
-  font-size: 12px;
+  font-size: var(--typography-font-size);
   color: var(--palette-grey-900);
   font-family: var(--typography-font-family);
 }
@@ -98,7 +99,7 @@
   padding-right: 10px;
   border-radius: 5px;
   font-family: var(--typography-font-family);
-  font-size: 12px;
+  font-size: var(--typography-font-size);
   text-transform: uppercase;
   text-align: right;
 }
@@ -108,7 +109,8 @@
   min-width: 28px;
   height: 28px;
   border-radius: 5px;
-  border: 1px solid;
+  border: 1px solid
+    color-mix(in srgb, var(--palette-common-black) 8%, transparent);
 }
 
 .ic-advanced-color-picker-swatch--white {

--- a/webapp/IronCalc/src/components/BorderPicker/border-picker.css
+++ b/webapp/IronCalc/src/components/BorderPicker/border-picker.css
@@ -3,9 +3,10 @@
   z-index: 1300;
   display: flex;
   flex-direction: column;
-  background: var(--palette-common-white);
+  background: var(--palette-surface-elevated);
+  border: 1px solid var(--palette-surface-elevated-border);
   border-radius: 8px;
-  box-shadow: 1px 2px 8px rgba(139, 143, 173, 0.5);
+  box-shadow: var(--shadow-md);
   font-family: var(--typography-font-family);
   font-size: var(--typography-font-size);
 }
@@ -53,7 +54,7 @@
 
 .ic-border-picker__menu .ic-border-picker__button:hover,
 .ic-border-picker__menu .ic-border-picker__button.selected {
-  background: var(--palette-grey-100);
+  background: var(--palette-grey-200);
 }
 
 .ic-border-picker__menu .ic-border-picker__button {

--- a/webapp/IronCalc/src/components/BorderPicker/line-style-picker.css
+++ b/webapp/IronCalc/src/components/BorderPicker/line-style-picker.css
@@ -7,9 +7,10 @@
   align-items: stretch;
   min-width: 92px;
   padding: 4px;
-  background: var(--palette-common-white);
+  background: var(--palette-surface-elevated);
+  border: 1px solid var(--palette-surface-elevated-border);
   border-radius: 8px;
-  box-shadow: 1px 2px 8px rgba(139, 143, 173, 0.5);
+  box-shadow: var(--shadow-md);
 }
 
 .ic-line-preview {

--- a/webapp/IronCalc/src/components/ColorPicker/color-picker.css
+++ b/webapp/IronCalc/src/components/ColorPicker/color-picker.css
@@ -1,14 +1,13 @@
 .ic-color-picker {
   position: fixed;
   z-index: 1300;
-  max-width: 220px;
+  max-width: 222px;
   min-width: 180px;
   margin: 0;
+  border: 1px solid var(--palette-surface-elevated-border);
   border-radius: 8px;
-  background: var(--palette-common-white);
-  box-shadow:
-    0 2px 8px rgb(0 0 0 / 0.12),
-    0 8px 24px rgb(0 0 0 / 0.12);
+  background: var(--palette-surface-elevated);
+  box-shadow: var(--shadow-md);
   font-family: var(--typography-font-family);
   font-size: var(--typography-font-size);
   box-sizing: border-box;
@@ -62,7 +61,7 @@
 
 .ic-color-picker__menu-item:hover {
   cursor: pointer;
-  background: var(--palette-grey-100);
+  background: var(--palette-grey-200);
 }
 
 .ic-color-picker__menu-item-square {

--- a/webapp/IronCalc/src/components/ColorPicker/color-picker.css
+++ b/webapp/IronCalc/src/components/ColorPicker/color-picker.css
@@ -156,6 +156,7 @@
   border: none;
   border-radius: 4px;
   background: none;
+  color: var(--palette-common-black);
   font: inherit;
 }
 

--- a/webapp/IronCalc/src/components/Editor/Editor.tsx
+++ b/webapp/IronCalc/src/components/Editor/Editor.tsx
@@ -72,7 +72,7 @@ const commonCSS: CSSProperties = {
   lineHeight: "22px",
 };
 
-const caretColor = "rgb(242, 153, 74)";
+const caretColor = "var(--palette-primary-main)";
 
 interface EditorOptions {
   originalText: string;

--- a/webapp/IronCalc/src/components/Editor/editor.css
+++ b/webapp/IronCalc/src/components/Editor/editor.css
@@ -3,9 +3,10 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: #fff;
+  background: var(--palette-common-white);
+  color: var(--palette-sheet-default-text-color);
   font-family: var(--palette-sheet-default-cell-font-family);
-  font-size: 12px;
+  font-size: var(--typography-font-size);
 }
 
 .ic-editor-container--hidden {

--- a/webapp/IronCalc/src/components/FormulaBar/formula-bar-menu.css
+++ b/webapp/IronCalc/src/components/FormulaBar/formula-bar-menu.css
@@ -25,12 +25,10 @@
   z-index: 1000;
   max-width: min(400px, calc(100vw - 16px));
   padding: 4px 0;
-  border: 1px solid var(--palette-grey-200);
+  border: 1px solid var(--palette-surface-elevated-border);
   border-radius: 8px;
-  background: var(--palette-common-white);
-  box-shadow:
-    0px 4px 10px rgba(0, 0, 0, 0.12),
-    0px 2px 4px rgba(0, 0, 0, 0.08);
+  background: var(--palette-surface-elevated);
+  box-shadow: var(--shadow-md);
   min-width: 0;
   width: max-content;
 }
@@ -59,7 +57,7 @@
 }
 
 .ic-formula-bar-menu-item:hover:not(:disabled) {
-  background: var(--palette-grey-50);
+  background: var(--palette-grey-200);
 }
 
 .ic-formula-bar-menu-item:focus-visible {

--- a/webapp/IronCalc/src/components/IconPicker/icon-picker.css
+++ b/webapp/IronCalc/src/components/IconPicker/icon-picker.css
@@ -16,10 +16,10 @@
 
 .ic-icon-picker-panel {
   position: fixed;
-  background: var(--palette-common-white);
-  border: 1px solid var(--palette-grey-300);
+  background: var(--palette-surface-elevated);
+  border: 1px solid var(--palette-surface-elevated-border);
   border-radius: 6px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-md);
   padding: 6px;
   display: grid;
   grid-template-columns: repeat(6, 1fr);
@@ -39,10 +39,10 @@
 }
 
 .ic-icon-picker-item:hover {
-  background: var(--palette-grey-100);
+  background: var(--palette-grey-200);
 }
 
 .ic-icon-picker-item--selected {
-  background: var(--palette-grey-50);
+  background: var(--palette-grey-100);
   outline-offset: -1px;
 }

--- a/webapp/IronCalc/src/components/Input/input.css
+++ b/webapp/IronCalc/src/components/Input/input.css
@@ -26,9 +26,9 @@
   display: flex;
   align-items: center;
   box-sizing: border-box;
-  border: 1px solid var(--palette-grey-300);
+  border: 1px solid var(--palette-input-border);
   border-radius: 6px;
-  background-color: var(--palette-common-white);
+  background-color: var(--palette-input-background);
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease;
@@ -69,7 +69,7 @@
 
 .ic-input-control.is-disabled {
   background-color: var(--palette-grey-200);
-  border-color: var(--palette-grey-300);
+  border-color: var(--palette-input-border);
   cursor: not-allowed;
 }
 

--- a/webapp/IronCalc/src/components/Menu/menu.css
+++ b/webapp/IronCalc/src/components/Menu/menu.css
@@ -7,8 +7,9 @@
 .ic-menu {
   box-sizing: border-box;
   min-width: 160px;
+  border: 1px solid var(--palette-surface-elevated-border);
   border-radius: 8px;
-  background: var(--palette-common-white);
+  background: var(--palette-surface-elevated);
   padding: 4px;
   box-shadow: var(--shadow-md);
 }
@@ -43,7 +44,7 @@
 
 .ic-menu-item:hover:not([disabled]),
 .ic-menu-item:focus-visible:not([disabled]) {
-  background: var(--palette-grey-50);
+  background: var(--palette-grey-200);
 }
 
 .ic-menu-item[disabled] {

--- a/webapp/IronCalc/src/components/Modal/modal-dialog.css
+++ b/webapp/IronCalc/src/components/Modal/modal-dialog.css
@@ -29,6 +29,7 @@
   justify-content: space-between;
   height: 44px;
   padding: 0 12px;
+  color: var(--palette-common-black);
 }
 
 .ic-modal-dialog-header h2 {

--- a/webapp/IronCalc/src/components/Modal/modal-dialog.css
+++ b/webapp/IronCalc/src/components/Modal/modal-dialog.css
@@ -12,8 +12,9 @@
   max-width: calc(100% - 40px);
   display: flex;
   flex-direction: column;
+  border: 1px solid var(--palette-surface-elevated-border);
   border-radius: 8px;
-  background: var(--palette-common-white);
+  background: var(--palette-surface-elevated);
   box-shadow: var(--shadow-sm);
   font-family: var(--typography-font-family);
 }

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/DataBarsRule.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/DataBarsRule.tsx
@@ -78,16 +78,8 @@ export const DataBarMiniChart = ({
     : color;
   return (
     <div className="ic-db-mini-chart">
-      {BAR_WIDTHS.map((w, i) => (
-        <div
-          key={w}
-          style={{
-            flex: 1,
-            display: "flex",
-            alignItems: "center",
-            borderTop: i > 0 ? "1px solid #e0e0e0" : undefined,
-          }}
-        >
+      {BAR_WIDTHS.map((w) => (
+        <div key={w} className="ic-db-bar-segment">
           <div
             style={{
               width: `${w * 100}%`,

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
@@ -10,6 +10,7 @@
   align-items: center;
   justify-content: flex-end;
   padding: 0 8px;
+  color: var(--palette-common-black);
   border-bottom: 1px solid var(--palette-grey-300);
 }
 
@@ -240,6 +241,7 @@
   justify-content: space-between;
   padding: 0 8px;
   gap: 8px;
+  color: var(--palette-common-black);
   border-bottom: 1px solid var(--palette-grey-300);
 }
 

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
@@ -87,6 +87,7 @@
   border: none;
   border-radius: 0;
   width: 100%;
+  background-color: var(--palette-common-white);
 }
 
 .ic-cf-filter {

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/conditional-formatting.css
@@ -248,7 +248,7 @@
 
 .ic-cf-edit-header-title {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--typography-font-size);
   font-weight: 500;
 }
 

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/edit-rule.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/edit-rule.css
@@ -205,7 +205,7 @@
 }
 
 .ic-db-swatch-row + .ic-db-swatch-row {
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--palette-grey-200);
 }
 
 .ic-db-swatch-bar {
@@ -219,6 +219,16 @@
   flex-direction: column;
   border-radius: 3px;
   overflow: hidden;
+}
+
+.ic-db-bar-segment {
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.ic-db-bar-segment + .ic-db-bar-segment {
+  border-top: 1px solid var(--palette-grey-200);
 }
 
 .ic-is-presets {

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/named-ranges.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/named-ranges.css
@@ -158,6 +158,7 @@
   align-items: center;
   justify-content: flex-end;
   padding: 0 8px;
+  color: var(--palette-common-black);
   border-bottom: 1px solid var(--palette-grey-300);
 }
 
@@ -173,6 +174,7 @@
   justify-content: space-between;
   padding: 0 8px;
   gap: 8px;
+  color: var(--palette-common-black);
   border-bottom: 1px solid var(--palette-grey-300);
 }
 

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/named-ranges.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/named-ranges.css
@@ -56,6 +56,7 @@
   border: none;
   border-radius: 0;
   width: 100%;
+  background-color: var(--palette-common-white);
 }
 
 .ic-named-ranges-search-container {

--- a/webapp/IronCalc/src/components/RightDrawer/NamedRanges/named-ranges.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedRanges/named-ranges.css
@@ -181,7 +181,7 @@
 
 .ic-named-ranges-edit-header-title {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--typography-font-size);
   font-weight: 500;
 }
 

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
@@ -18,6 +18,7 @@
 .ic-named-styles-header-title {
   width: 100%;
   font-size: var(--typography-font-size);
+  color: var(--palette-common-black);
 }
 
 .ic-named-styles-content {
@@ -33,6 +34,7 @@
   justify-content: space-between;
   padding: 0 8px;
   gap: 8px;
+  color: var(--palette-common-white);
   border-bottom: 1px solid var(--palette-grey-300);
 }
 

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
@@ -34,13 +34,13 @@
   justify-content: space-between;
   padding: 0 8px;
   gap: 8px;
-  color: var(--palette-common-white);
+  color: var(--palette-common-black);
   border-bottom: 1px solid var(--palette-grey-300);
 }
 
 .ic-named-styles-edit-header-title {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--typography-font-size);
   font-weight: 500;
 }
 

--- a/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/regional-settings.css
+++ b/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/regional-settings.css
@@ -12,6 +12,7 @@
   align-items: center;
   justify-content: flex-end;
   padding: 0 8px;
+  color: var(--palette-common-black);
   border-bottom: 1px solid var(--palette-grey-300);
 }
 

--- a/webapp/IronCalc/src/components/RightDrawer/Themes/themes.css
+++ b/webapp/IronCalc/src/components/RightDrawer/Themes/themes.css
@@ -11,6 +11,7 @@
   align-items: center;
   justify-content: flex-end;
   padding: 0 8px;
+  color: var(--palette-common-black);
   border-bottom: 1px solid var(--palette-grey-300);
   flex-shrink: 0;
 }
@@ -40,6 +41,7 @@
   flex: 1;
   font-size: var(--typography-font-size);
   font-weight: 500;
+  color: var(--palette-common-black);
 }
 
 .ic-themes-list-item {

--- a/webapp/IronCalc/src/components/Select/dropdown-menu.css
+++ b/webapp/IronCalc/src/components/Select/dropdown-menu.css
@@ -3,6 +3,7 @@
   position: fixed;
   font-family: var(--typography-font-family);
   font-size: var(--typography-font-size);
+  background-color: var(--palette-common-white);
 }
 
 .ic-dropdown-menu {
@@ -11,7 +12,7 @@
   max-height: 240px;
   overflow-y: auto;
   border-radius: 8px;
-  background: var(--palette-common-white);
+  background-color: var(--palette-common-white);
   padding: 4px;
   box-shadow:
     0 2px 6px rgba(0, 0, 0, 0.12),

--- a/webapp/IronCalc/src/components/Select/dropdown-menu.css
+++ b/webapp/IronCalc/src/components/Select/dropdown-menu.css
@@ -3,7 +3,6 @@
   position: fixed;
   font-family: var(--typography-font-family);
   font-size: var(--typography-font-size);
-  background-color: var(--palette-common-white);
 }
 
 .ic-dropdown-menu {
@@ -11,12 +10,11 @@
   width: 100%;
   max-height: 240px;
   overflow-y: auto;
+  border: 1px solid var(--palette-surface-elevated-border);
   border-radius: 8px;
-  background-color: var(--palette-common-white);
+  background-color: var(--palette-surface-elevated);
   padding: 4px;
-  box-shadow:
-    0 2px 6px rgba(0, 0, 0, 0.12),
-    0 8px 24px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-md);
 }
 
 /* Options */
@@ -41,7 +39,7 @@
 .ic-dropdown-menu-option:hover,
 .ic-dropdown-menu-option:focus-visible,
 .ic-dropdown-menu-option.is-active {
-  background: var(--palette-grey-50);
+  background: var(--palette-grey-200);
 }
 
 .ic-dropdown-menu-option-check {

--- a/webapp/IronCalc/src/components/Select/select.css
+++ b/webapp/IronCalc/src/components/Select/select.css
@@ -61,9 +61,9 @@
   display: flex;
   width: 100%;
   align-items: center;
-  border: 1px solid var(--palette-grey-300);
+  border: 1px solid var(--palette-input-border);
   border-radius: 6px;
-  background: var(--palette-common-white);
+  background: var(--palette-input-background);
   color: var(--palette-common-black);
   font: inherit;
   text-align: left;
@@ -125,7 +125,7 @@
 /* Disabled state */
 .ic-select-control.disabled .ic-select-trigger,
 .ic-select-trigger:disabled {
-  border-color: var(--palette-grey-300);
+  border-color: var(--palette-input-border);
   background: var(--palette-grey-200);
   color: var(--palette-grey-400);
   cursor: not-allowed;

--- a/webapp/IronCalc/src/components/SheetTabBar/sheet-tab.css
+++ b/webapp/IronCalc/src/components/SheetTabBar/sheet-tab.css
@@ -8,6 +8,7 @@
   cursor: pointer;
   border-bottom: 3px solid transparent;
   font-weight: 400;
+  color: var(--palette-common-black);
 }
 
 .ic-sheet-tab--selected {

--- a/webapp/IronCalc/src/components/SheetTabBar/sheet-tab.css
+++ b/webapp/IronCalc/src/components/SheetTabBar/sheet-tab.css
@@ -17,7 +17,7 @@
 }
 
 .ic-sheet-tab:hover {
-  background-color: rgb(245 245 245 / 50%);
+  background-color: var(--palette-grey-200);
 }
 
 .ic-sheet-tab-name {
@@ -47,7 +47,7 @@
 }
 
 .ic-sheet-tab-menu-button:hover {
-  background-color: var(--palette-grey-200);
+  background-color: var(--palette-grey-300);
 }
 
 .ic-sheet-tab-menu-button:active,

--- a/webapp/IronCalc/src/components/Textarea/textarea.css
+++ b/webapp/IronCalc/src/components/Textarea/textarea.css
@@ -25,9 +25,9 @@
   position: relative;
   display: flex;
   box-sizing: border-box;
-  border: 1px solid var(--palette-grey-300);
+  border: 1px solid var(--palette-input-border);
   border-radius: 6px;
-  background-color: var(--palette-common-white);
+  background-color: var(--palette-input-background);
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease;
@@ -59,7 +59,7 @@
 
 .ic-textarea-control.is-disabled {
   background-color: var(--palette-grey-200);
-  border-color: var(--palette-grey-300);
+  border-color: var(--palette-input-border);
   cursor: not-allowed;
 }
 

--- a/webapp/IronCalc/src/components/ThemeMenu/theme-menu.css
+++ b/webapp/IronCalc/src/components/ThemeMenu/theme-menu.css
@@ -8,9 +8,13 @@
   width: 12px;
   height: 12px;
   border-radius: 4px;
-  border: 1px solid var(--palette-common-white);
+  border: 1px solid var(--palette-surface-elevated);
 }
 
 .ic-theme-menu-swatch + .ic-theme-menu-swatch {
   margin-left: -4px;
+}
+
+.ic-menu-item:hover .ic-theme-menu-swatch {
+  border: 1px solid var(--palette-grey-200);
 }

--- a/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
+++ b/webapp/IronCalc/src/components/Toolbar/Toolbar.tsx
@@ -426,7 +426,7 @@ function Toolbar(properties: ToolbarProperties) {
                     style={{
                       backgroundColor:
                         resolveColorToHex(properties.fontColor, currentTheme) ||
-                        "#000000",
+                        "var(--palette-sheet-default-text-color)",
                     }}
                   />
                 </>
@@ -449,7 +449,7 @@ function Toolbar(properties: ToolbarProperties) {
                     style={{
                       backgroundColor:
                         resolveColorToHex(properties.fillColor, currentTheme) ||
-                        "#FFFFFF",
+                        "var(--palette-common-white)",
                     }}
                   />
                 </>

--- a/webapp/IronCalc/src/components/Toolbar/toolbar.css
+++ b/webapp/IronCalc/src/components/Toolbar/toolbar.css
@@ -6,7 +6,6 @@
   background: var(--palette-common-white);
   height: var(--toolbar-height);
   border-bottom: 1px solid var(--palette-grey-300);
-  border-radius: 4px 4px 0 0;
 }
 
 /* Toolbar container */
@@ -47,6 +46,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
+  color: var(--palette-common-black);
   font-family: var(--typography-font-family);
   font-size: var(--typography-font-size);
   border: 1px solid var(--palette-grey-300);

--- a/webapp/IronCalc/src/components/Toolbar/toolbar.css
+++ b/webapp/IronCalc/src/components/Toolbar/toolbar.css
@@ -81,6 +81,7 @@
   align-items: center;
   justify-content: center;
   background-color: var(--palette-common-white);
+  color: var(--palette-common-black);
   border: none;
   cursor: pointer;
 }

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -84,7 +84,7 @@ const Workbook = (props: {
     ({ name, color, sheet_id, state }: WorksheetProperties) => {
       return {
         name,
-        color: model.resolveColor(color) || "#FFF",
+        color: model.resolveColor(color) || "var(--palette-common-white)",
         sheetId: sheet_id,
         state,
       };

--- a/webapp/IronCalc/src/components/Worksheet/worksheet.css
+++ b/webapp/IronCalc/src/components/Worksheet/worksheet.css
@@ -5,7 +5,7 @@
   background: var(--palette-sheet-outline-color);
   cursor: crosshair;
   border-radius: 1px;
-  border: 1px solid white;
+  border: 1px solid var(--palette-common-white);
 }
 
 /* The handle auto-fills (drags) cell content, so it is an edit affordance. */

--- a/webapp/IronCalc/src/components/WorksheetCanvas/util.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/util.ts
@@ -79,6 +79,10 @@ export function readThemeFromCSS(root: Element): Theme {
     primaryMain: readCSSVar("--palette-primary-main", style),
     headerTextColor: readCSSVar("--palette-sheet-header-text-color", style),
     headerBackground: readCSSVar("--palette-sheet-header-background", style),
+    headerCornerBackground: readCSSVar(
+      "--palette-sheet-header-corner-background",
+      style,
+    ),
     headerSelectedBackground: readCSSVar(
       "--palette-sheet-header-selected-background",
       style,
@@ -105,6 +109,7 @@ export interface Theme {
   primaryMain: string;
   headerTextColor: string;
   headerBackground: string;
+  headerCornerBackground: string;
   headerSelectedBackground: string;
   headerBorderColor: string;
   outlineColor: string;

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -1191,16 +1191,16 @@ export default class WorksheetCanvas {
       }
       const selected = row >= rowStart && row <= rowEnd;
       context.fillStyle = this.theme.headerBorderColor;
-      context.fillRect(0.5, topLeftCornerY, headerColumnWidth - 1, rowHeight);
+      context.fillRect(0, topLeftCornerY, headerColumnWidth, rowHeight);
       context.fillStyle = selected
         ? isFullRowSelected
           ? this.theme.primaryMain
           : this.theme.headerSelectedBackground
         : this.theme.headerBackground;
       context.fillRect(
-        0.5,
+        0,
         topLeftCornerY + 0.5,
-        headerColumnWidth - 1,
+        headerColumnWidth,
         rowHeight - 1,
       );
       if (selected) {

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -2061,6 +2061,9 @@ export default class WorksheetCanvas {
     this.renderRowHeaders(frozenRows, topLeftCell, bottomRightCell);
 
     // square in the top left corner
+    // (extends 0.5px right and down to meet the headers, which start at +0.5)
+    context.fillStyle = this.theme.headerCornerBackground;
+    context.fillRect(0, 0, headerColumnWidth + 0.5, headerRowHeight + 0.5);
     context.beginPath();
     context.strokeStyle = this.theme.gridSeparatorColor;
     context.moveTo(0, 0.5);

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -1191,16 +1191,16 @@ export default class WorksheetCanvas {
       }
       const selected = row >= rowStart && row <= rowEnd;
       context.fillStyle = this.theme.headerBorderColor;
-      context.fillRect(0, topLeftCornerY, headerColumnWidth, rowHeight);
+      context.fillRect(0.5, topLeftCornerY, headerColumnWidth - 1, rowHeight);
       context.fillStyle = selected
         ? isFullRowSelected
           ? this.theme.primaryMain
           : this.theme.headerSelectedBackground
         : this.theme.headerBackground;
       context.fillRect(
-        0,
+        0.5,
         topLeftCornerY + 0.5,
-        headerColumnWidth,
+        headerColumnWidth - 1,
         rowHeight - 1,
       );
       if (selected) {

--- a/webapp/IronCalc/src/theme/index.ts
+++ b/webapp/IronCalc/src/theme/index.ts
@@ -1,4 +1,5 @@
 export {
+  darkThemeVariables,
   defaultThemeVariables,
   setThemeVariables,
   unsetThemeVariables,

--- a/webapp/IronCalc/src/theme/theme.css
+++ b/webapp/IronCalc/src/theme/theme.css
@@ -59,6 +59,10 @@
   --palette-grey-a400: #bdbdbd;
   --palette-grey-a700: #616161;
 
+  /* elevated surfaces (menus, modals) */
+  --palette-surface-elevated: #fff;
+  --palette-surface-elevated-border: transparent;
+
   /* shadows */
   --shadow-sm: 0px 1px 3px 0px rgb(39 37 37 / 10%);
   --shadow-md: 0 2px 6px rgb(0 0 0 / 12%), 0 8px 24px rgb(0 0 0 / 12%);

--- a/webapp/IronCalc/src/theme/theme.css
+++ b/webapp/IronCalc/src/theme/theme.css
@@ -63,6 +63,10 @@
   --palette-surface-elevated: #fff;
   --palette-surface-elevated-border: transparent;
 
+  /* inputs (selects, text fields) */
+  --palette-input-background: #fff;
+  --palette-input-border: #e0e0e0;
+
   /* shadows */
   --shadow-sm: 0px 1px 3px 0px rgb(39 37 37 / 10%);
   --shadow-md: 0 2px 6px rgb(0 0 0 / 12%), 0 8px 24px rgb(0 0 0 / 12%);

--- a/webapp/IronCalc/src/theme/theme.ts
+++ b/webapp/IronCalc/src/theme/theme.ts
@@ -55,6 +55,9 @@ export const defaultThemeVariables: IronCalcThemeVariables = {
   "--palette-grey-a400": "#bdbdbd",
   "--palette-grey-a700": "#616161",
 
+  "--palette-surface-elevated": "#FFF",
+  "--palette-surface-elevated-border": "transparent",
+
   "--palette-sheet-header-corner-background": "#FFF",
   "--palette-sheet-header-text-color": "#333",
   "--palette-sheet-header-background": "#FFF",
@@ -126,6 +129,9 @@ export const darkThemeVariables: IronCalcThemeVariables = {
   "--palette-grey-a200": "#363636",
   "--palette-grey-a400": "#5E5E5E",
   "--palette-grey-a700": "#B5B5B5",
+
+  "--palette-surface-elevated": "#2A2A2A",
+  "--palette-surface-elevated-border": "#3A3A3A",
 
   "--palette-sheet-header-corner-background": "#242424",
   "--palette-sheet-header-text-color": "#D0D0D0",

--- a/webapp/IronCalc/src/theme/theme.ts
+++ b/webapp/IronCalc/src/theme/theme.ts
@@ -58,6 +58,9 @@ export const defaultThemeVariables: IronCalcThemeVariables = {
   "--palette-surface-elevated": "#FFF",
   "--palette-surface-elevated-border": "transparent",
 
+  "--palette-input-background": "#FFF",
+  "--palette-input-border": "#E0E0E0",
+
   "--palette-sheet-header-corner-background": "#FFF",
   "--palette-sheet-header-text-color": "#333",
   "--palette-sheet-header-background": "#FFF",
@@ -132,6 +135,9 @@ export const darkThemeVariables: IronCalcThemeVariables = {
 
   "--palette-surface-elevated": "#2A2A2A",
   "--palette-surface-elevated-border": "#3A3A3A",
+
+  "--palette-input-background": "#2A2A2A",
+  "--palette-input-border": "#3A3A3A",
 
   "--palette-sheet-header-corner-background": "#242424",
   "--palette-sheet-header-text-color": "#D0D0D0",

--- a/webapp/IronCalc/src/theme/theme.ts
+++ b/webapp/IronCalc/src/theme/theme.ts
@@ -75,6 +75,78 @@ export const defaultThemeVariables: IronCalcThemeVariables = {
     'bold 12px Inter, "Adjusted Arial Fallback", sans-serif',
 };
 
+export const darkThemeVariables: IronCalcThemeVariables = {
+  "--typography-font-family": "Inter",
+  "--typography-font-size": "12px",
+
+  "--palette-common-black": "#E8E6E3",
+  "--palette-common-white": "#1E1E1E",
+
+  "--palette-primary-main": "#F2994A",
+  "--palette-primary-light": "#F5AD6E",
+  "--palette-primary-dark": "#D68742",
+  "--palette-primary-contrast-text": "#1E1E1E",
+
+  "--palette-secondary-main": "#4E92EC",
+  "--palette-secondary-light": "#6EA6F0",
+  "--palette-secondary-dark": "#2B6EC8",
+  "--palette-secondary-contrast-text": "#FFF",
+
+  "--palette-error-main": "#EF6B6B",
+  "--palette-error-light": "#F08A8A",
+  "--palette-error-dark": "#CB4C4C",
+  "--palette-error-contrast-text": "#1E1E1E",
+
+  "--palette-warning-main": "#F2C94C",
+  "--palette-warning-light": "#F5D879",
+  "--palette-warning-dark": "#D6B244",
+  "--palette-warning-contrast-text": "#1E1E1E",
+
+  "--palette-info-main": "#ABABAB",
+  "--palette-info-light": "#C2C2C2",
+  "--palette-info-dark": "#757575",
+  "--palette-info-contrast-text": "#1E1E1E",
+
+  "--palette-success-main": "#3DBE76",
+  "--palette-success-light": "#5FCB8E",
+  "--palette-success-dark": "#239152",
+  "--palette-success-contrast-text": "#1E1E1E",
+
+  "--palette-grey-50": "#2A2A2A",
+  "--palette-grey-100": "#2F2F2F",
+  "--palette-grey-200": "#363636",
+  "--palette-grey-300": "#444444",
+  "--palette-grey-400": "#5E5E5E",
+  "--palette-grey-500": "#7A7A7A",
+  "--palette-grey-600": "#9E9E9E",
+  "--palette-grey-700": "#B5B5B5",
+  "--palette-grey-800": "#CFCFCF",
+  "--palette-grey-900": "#EDEDED",
+  "--palette-grey-a100": "#2F2F2F",
+  "--palette-grey-a200": "#363636",
+  "--palette-grey-a400": "#5E5E5E",
+  "--palette-grey-a700": "#B5B5B5",
+
+  "--palette-sheet-header-corner-background": "#242424",
+  "--palette-sheet-header-text-color": "#D0D0D0",
+  "--palette-sheet-header-background": "#242424",
+  "--palette-sheet-header-global-selector-color": "#2C2F3A",
+  "--palette-sheet-header-selected-background": "#333333",
+  "--palette-sheet-header-full-selected-background": "#39405A",
+  "--palette-sheet-header-selected-color": "#F0F0F0",
+  "--palette-sheet-header-border-color": "#3A3A3A",
+  "--palette-sheet-grid-color": "#3A3A3A",
+  "--palette-sheet-grid-separator-color": "#3A3A3A",
+  "--palette-sheet-default-text-color": "#E4E4E4",
+  "--palette-sheet-outline-color": "#F2994A",
+  "--palette-sheet-outline-editing-color": "#4A331C",
+  "--palette-sheet-outline-background-color": "#F2994A26",
+  "--palette-sheet-default-cell-font-family":
+    'Inter, "Adjusted Arial Fallback", sans-serif',
+  "--palette-sheet-header-font":
+    'bold 12px Inter, "Adjusted Arial Fallback", sans-serif',
+};
+
 export function setThemeVariables(
   variables: PartialIronCalcThemeVariables,
   target: HTMLElement = document.documentElement,

--- a/webapp/IronCalc/src/theme/themeVariables.ts
+++ b/webapp/IronCalc/src/theme/themeVariables.ts
@@ -50,6 +50,9 @@ export interface IronCalcThemeVariables {
   "--palette-grey-a400": string;
   "--palette-grey-a700": string;
 
+  "--palette-surface-elevated": string;
+  "--palette-surface-elevated-border": string;
+
   "--palette-sheet-header-corner-background": string;
   "--palette-sheet-header-text-color": string;
   "--palette-sheet-header-background": string;

--- a/webapp/IronCalc/src/theme/themeVariables.ts
+++ b/webapp/IronCalc/src/theme/themeVariables.ts
@@ -53,6 +53,9 @@ export interface IronCalcThemeVariables {
   "--palette-surface-elevated": string;
   "--palette-surface-elevated-border": string;
 
+  "--palette-input-background": string;
+  "--palette-input-border": string;
+
   "--palette-sheet-header-corner-background": string;
   "--palette-sheet-header-text-color": string;
   "--palette-sheet-header-background": string;

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
@@ -40,6 +40,7 @@
   height: 52px;
   flex-shrink: 0;
   padding: 0 12px;
+  color: var(--palette-common-black);
   border-bottom: 1px solid var(--palette-grey-300);
 }
 

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
@@ -40,7 +40,6 @@
   height: 52px;
   flex-shrink: 0;
   padding: 0 12px;
-  color: var(--palette-common-black);
   border-bottom: 1px solid var(--palette-grey-300);
 }
 


### PR DESCRIPTION
This PR dark mode to IronCalc! Although there's still a few more things to do, we've started with the next changes:

- The most significant is the cleanup of multiple components that were using hardcoded colors or wrong variables. Most of the files changed are affected by this.
- Added some new color variables like `--palette-surface-elevated` or `--palette-surface-elevated-border`, to handle these that elements are visible on dark mode but not on light
- Minor fixes in the Conditional Formatting thumbnails so they are mode-sensitive
- Added a 'Dark' option to the mode toggle in Storybook
- Added an item in `utils.ts` for the grid corner
  - This brought some adjustments in `worksheetCanvas.ts`
 
Also, see here some screenshots:

<img width="1286" height="828" alt="image" src="https://github.com/user-attachments/assets/45758ec8-8f00-4bad-aec8-62c4d026fbcc" />
<img width="1283" height="824" alt="image" src="https://github.com/user-attachments/assets/7ff67199-d6e0-47b0-bb19-f37550ed7966" />
<img width="654" height="389" alt="image" src="https://github.com/user-attachments/assets/557be3fd-b2d1-4700-81c9-0fff9c25d7de" />


---

Pending tasks, will come in future PRs:

- How to handle font and background color in Themes
- Named Cell styles
- Conditional Formatting
- Frozen rows and columns
- Borders
- Cells where content overflows