### PR TITLE
fix(clipboard): fill a whole-multiple selection on paste, per-cell references

### DIFF
--- a/base/src/cut_paste.rs
+++ b/base/src/cut_paste.rs
@@ -60,6 +60,13 @@ fn cf_range_part_update_for_cut(part: &str, area: &Area, row_delta: i32, col_del
 
 /// Maps a single CF sqref range part to the target location, intersecting with the copied area.
 /// Returns `None` if the CF range part does not overlap the copy source.
+///
+/// `repeats` is `(row_repeats, column_repeats)` — how many times the copied rectangle is repeated
+/// down and to the right by a fill (`(1, 1)` for a plain paste). Repetitions whose mapped
+/// rectangles touch are emitted as **one** range, so the common "the rule covers the whole copied
+/// rectangle" case yields a single range spanning the filled block rather than one range per
+/// repetition.
+#[allow(clippy::too_many_arguments)]
 fn map_cf_range_part_to_target(
     part: &str,
     src_r1: i32,
@@ -68,6 +75,7 @@ fn map_cf_range_part_to_target(
     src_c2: i32,
     tgt_row: i32,
     tgt_col: i32,
+    repeats: (i32, i32),
 ) -> Option<String> {
     let upper = part.to_uppercase();
     let segs: Vec<&str> = upper.splitn(2, ':').collect();
@@ -93,23 +101,58 @@ fn map_cf_range_part_to_target(
         return None;
     }
 
-    // Map intersection to target coordinates
-    let new_r1 = tgt_row + (int_r1 - src_r1);
-    let new_c1 = tgt_col + (int_c1 - src_c1);
-    let new_r2 = tgt_row + (int_r2 - src_r1);
-    let new_c2 = tgt_col + (int_c2 - src_c1);
+    // Map the intersection to target coordinates, once per repetition of the copied rectangle.
+    // A repetition band collapses into a single span when the intersection covers the copied
+    // rectangle edge to edge along that axis (then consecutive repetitions are contiguous).
+    let (row_repeats, column_repeats) = repeats;
+    let source_height = src_r2 - src_r1 + 1;
+    let source_width = src_c2 - src_c1 + 1;
+    let spans = |offset1: i32, offset2: i32, source_size: i32, target_start: i32, count: i32| {
+        if offset1 == 0 && offset2 == source_size - 1 {
+            vec![(target_start, target_start + source_size * count - 1)]
+        } else {
+            (0..count)
+                .map(|repeat| {
+                    let base = target_start + repeat * source_size;
+                    (base + offset1, base + offset2)
+                })
+                .collect()
+        }
+    };
+    let row_spans = spans(
+        int_r1 - src_r1,
+        int_r2 - src_r1,
+        source_height,
+        tgt_row,
+        row_repeats,
+    );
+    let column_spans = spans(
+        int_c1 - src_c1,
+        int_c2 - src_c1,
+        source_width,
+        tgt_col,
+        column_repeats,
+    );
 
-    let c1 = utils::number_to_column(new_c1)?;
-    let c2 = utils::number_to_column(new_c2)?;
-    if new_r1 == new_r2 && new_c1 == new_c2 {
-        Some(format!("{c1}{new_r1}"))
-    } else {
-        Some(format!("{c1}{new_r1}:{c2}{new_r2}"))
+    let mut parts = Vec::with_capacity(row_spans.len() * column_spans.len());
+    for (new_r1, new_r2) in &row_spans {
+        for (new_c1, new_c2) in &column_spans {
+            let c1 = utils::number_to_column(*new_c1)?;
+            let c2 = utils::number_to_column(*new_c2)?;
+            if new_r1 == new_r2 && new_c1 == new_c2 {
+                parts.push(format!("{c1}{new_r1}"));
+            } else {
+                parts.push(format!("{c1}{new_r1}:{c2}{new_r2}"));
+            }
+        }
     }
+    Some(parts.join(" "))
 }
 
 /// Maps every part of a space-separated sqref string to the target location,
-/// dropping parts that fall entirely outside the copy source.
+/// dropping parts that fall entirely outside the copy source. `repeats` is the fill's
+/// `(row_repeats, column_repeats)` — see [`map_cf_range_part_to_target`].
+#[allow(clippy::too_many_arguments)]
 fn map_cf_sqref_to_target(
     sqref: &str,
     src_r1: i32,
@@ -118,11 +161,14 @@ fn map_cf_sqref_to_target(
     src_c2: i32,
     tgt_row: i32,
     tgt_col: i32,
+    repeats: (i32, i32),
 ) -> String {
     sqref
         .split_whitespace()
         .filter_map(|p| {
-            map_cf_range_part_to_target(p, src_r1, src_c1, src_r2, src_c2, tgt_row, tgt_col)
+            map_cf_range_part_to_target(
+                p, src_r1, src_c1, src_r2, src_c2, tgt_row, tgt_col, repeats,
+            )
         })
         .collect::<Vec<_>>()
         .join(" ")
@@ -457,6 +503,11 @@ impl<'a> Model<'a> {
     /// (`src_row1..src_row2`, `src_col1..src_col2`), computes the intersection
     /// and maps it to the target location starting at (`tgt_row`, `tgt_col`).
     ///
+    /// `repeats` is the fill's `(row_repeats, column_repeats)` — `(1, 1)` for a plain paste. A
+    /// rule that overlaps the copied rectangle is returned **once**, with a sqref covering every
+    /// repetition (merged into a single range wherever the repetitions are contiguous), so a fill
+    /// adds one CF entry per source rule rather than one per repetition.
+    ///
     /// Returns `(new_range_sqref, cf_rule)` for each overlapping CF entry.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn get_cf_rules_to_copy(
@@ -468,6 +519,7 @@ impl<'a> Model<'a> {
         src_col2: i32,
         tgt_row: i32,
         tgt_col: i32,
+        repeats: (i32, i32),
     ) -> Vec<(String, CfRule)> {
         let ws = match self.workbook.worksheets.get(source_sheet as usize) {
             Some(ws) => ws,
@@ -477,7 +529,7 @@ impl<'a> Model<'a> {
         let mut results = Vec::new();
         for cf in &ws.conditional_formatting {
             let new_range = map_cf_sqref_to_target(
-                &cf.range, src_row1, src_col1, src_row2, src_col2, tgt_row, tgt_col,
+                &cf.range, src_row1, src_col1, src_row2, src_col2, tgt_row, tgt_col, repeats,
             );
             if !new_range.is_empty() {
                 results.push((new_range, cf.cf_rule.clone()));

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -30,6 +30,7 @@ mod test_on_area_selection;
 mod test_on_expand_selected_range;
 mod test_on_paste_styles;
 mod test_paste_csv;
+mod test_paste_fill;
 mod test_recursive;
 mod test_rename_sheet;
 mod test_row_column;

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -28,6 +28,7 @@ mod test_on_area_selection;
 mod test_on_expand_selected_range;
 mod test_on_paste_styles;
 mod test_paste_csv;
+mod test_paste_fill;
 mod test_recursive;
 mod test_rename_sheet;
 mod test_row_column;

--- a/base/src/test/user_model/test_paste_fill.rs
+++ b/base/src/test/user_model/test_paste_fill.rs
@@ -1,0 +1,290 @@
+#![allow(clippy::unwrap_used)]
+
+//! Pasting a copy into a selection that is a whole multiple of it repeats ("fills") the copy
+//! across the selection, re-anchoring relative references in every repetition — Excel's behavior.
+
+use crate::cf_types::{CfRuleInput, Cfvo, ColorScaleThreshold};
+use crate::expressions::types::Area;
+use crate::test::user_model::util::new_empty_user_model;
+use crate::types::Color;
+use crate::UserModel;
+
+fn color_scale() -> CfRuleInput {
+    CfRuleInput::ColorScale {
+        thresholds: vec![
+            ColorScaleThreshold {
+                cfvo: Cfvo::Min,
+                color: Color::Rgb("#FF0000".to_string()),
+            },
+            ColorScaleThreshold {
+                cfvo: Cfvo::Max,
+                color: Color::Rgb("#00FF00".to_string()),
+            },
+        ],
+    }
+}
+
+/// Copies `range` (e.g. `(4, 2, 4, 2)` for B4) to the clipboard and pastes it over the
+/// `(first_row, first_column, last_row, last_column)` selection.
+fn copy_and_paste_over(
+    model: &mut UserModel,
+    source: (i32, i32, i32, i32),
+    target: (i32, i32, i32, i32),
+) {
+    let (source_first_row, source_first_column, source_last_row, source_last_column) = source;
+    model
+        .set_selected_cell(source_first_row, source_first_column)
+        .unwrap();
+    model
+        .set_selected_range(
+            source_first_row,
+            source_first_column,
+            source_last_row,
+            source_last_column,
+        )
+        .unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+
+    let (target_first_row, target_first_column, target_last_row, target_last_column) = target;
+    model
+        .set_selected_cell(target_first_row, target_first_column)
+        .unwrap();
+    model
+        .set_selected_range(
+            target_first_row,
+            target_first_column,
+            target_last_row,
+            target_last_column,
+        )
+        .unwrap();
+    model
+        .paste_from_clipboard(0, source, &clipboard.data, false)
+        .unwrap();
+}
+
+#[test]
+fn paste_of_a_single_cell_fills_the_selection_readjusting_references_per_cell() {
+    let mut model = new_empty_user_model();
+    // B3 = 1, B4 = =B3+1. Copy B4 and paste it over B5:B10.
+    model.set_user_input(0, 3, 2, "1").unwrap();
+    model.set_user_input(0, 4, 2, "=B3+1").unwrap();
+
+    copy_and_paste_over(&mut model, (4, 2, 4, 2), (5, 2, 10, 2));
+
+    // Every filled cell points at the cell above it, not at B4's source displacement.
+    for row in 5..=10 {
+        assert_eq!(
+            model.get_cell_content(0, row, 2).unwrap(),
+            format!("=B{}+1", row - 1),
+            "B{row} should reference the cell above it"
+        );
+        assert_eq!(
+            model.get_formatted_cell_value(0, row, 2).unwrap(),
+            (row - 2).to_string()
+        );
+    }
+}
+
+#[test]
+fn paste_fill_keeps_absolute_references_pinned() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "10").unwrap();
+    model.set_user_input(0, 3, 2, "=$A$1+A2").unwrap();
+
+    copy_and_paste_over(&mut model, (3, 2, 3, 2), (4, 2, 6, 2));
+
+    assert_eq!(model.get_cell_content(0, 4, 2).unwrap(), "=$A$1+A3");
+    assert_eq!(model.get_cell_content(0, 5, 2).unwrap(), "=$A$1+A4");
+    assert_eq!(model.get_cell_content(0, 6, 2).unwrap(), "=$A$1+A5");
+}
+
+#[test]
+fn paste_fill_repeats_a_block_in_both_axes() {
+    let mut model = new_empty_user_model();
+    // A 1x2 block in A1:B1 (a value and a formula pointing one row up).
+    model.set_user_input(0, 1, 1, "7").unwrap();
+    model.set_user_input(0, 1, 2, "=A1").unwrap();
+
+    // Fill C3:F4 — two repetitions right, two down.
+    copy_and_paste_over(&mut model, (1, 1, 1, 2), (3, 3, 4, 6));
+
+    for (row, column) in [(3, 3), (3, 5), (4, 3), (4, 5)] {
+        assert_eq!(model.get_cell_content(0, row, column).unwrap(), "7");
+        let reference = format!(
+            "={}{}",
+            crate::expressions::utils::number_to_column(column).unwrap(),
+            row
+        );
+        assert_eq!(
+            model.get_cell_content(0, row, column + 1).unwrap(),
+            reference,
+            "the formula copy must point at its own repetition's left cell"
+        );
+    }
+}
+
+#[test]
+fn paste_fill_repeats_values_and_styles() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "hello").unwrap();
+    let a1 = Area {
+        sheet: 0,
+        row: 1,
+        column: 1,
+        width: 1,
+        height: 1,
+    };
+    model.update_range_style(&a1, "font.b", "true").unwrap();
+
+    copy_and_paste_over(&mut model, (1, 1, 1, 1), (3, 1, 5, 2));
+
+    for row in 3..=5 {
+        for column in 1..=2 {
+            assert_eq!(
+                model.get_formatted_cell_value(0, row, column).unwrap(),
+                "hello"
+            );
+            assert!(model.get_cell_style(0, row, column).unwrap().font.b);
+        }
+    }
+}
+
+#[test]
+fn paste_fill_adds_one_conditional_formatting_rule_spanning_the_filled_block() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model
+        .add_conditional_formatting(0, "A1", color_scale())
+        .unwrap();
+
+    // Fill C3:D12 from A1 — 20 repetitions of the single copied cell.
+    copy_and_paste_over(&mut model, (1, 1, 1, 1), (3, 3, 12, 4));
+
+    let rules = model.get_conditional_formatting_list(0).unwrap();
+    assert_eq!(
+        rules.len(),
+        2,
+        "the fill adds ONE rule, not one per filled cell"
+    );
+    // The list is ordered by priority, highest first — the copied rule is the newest.
+    assert_eq!(
+        rules[0].range, "C3:D12",
+        "the copied rule spans the whole filled block"
+    );
+    assert_eq!(rules[1].range, "A1", "the source rule is untouched");
+
+    model.undo().unwrap();
+    assert_eq!(
+        model.get_conditional_formatting_list(0).unwrap().len(),
+        1,
+        "one undo removes the rule the fill added"
+    );
+}
+
+#[test]
+fn paste_fill_conditional_formatting_over_part_of_the_copy_maps_each_repetition() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model.set_user_input(0, 2, 1, "2").unwrap();
+    // The rule covers only the TOP cell of the 2-row copy, so the repetitions are not contiguous.
+    model
+        .add_conditional_formatting(0, "A1", color_scale())
+        .unwrap();
+
+    // Fill C1:C4 from A1:A2 — two repetitions down.
+    copy_and_paste_over(&mut model, (1, 1, 2, 1), (1, 3, 4, 3));
+
+    let rules = model.get_conditional_formatting_list(0).unwrap();
+    assert_eq!(rules.len(), 2, "still ONE added rule");
+    assert_eq!(
+        rules[0].range, "C1 C3",
+        "its sqref lists the mapped cell of each repetition"
+    );
+}
+
+#[test]
+fn paste_fill_selects_the_whole_filled_area() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+
+    copy_and_paste_over(&mut model, (1, 1, 1, 1), (3, 1, 6, 2));
+
+    assert_eq!(model.get_selected_view().range, [3, 1, 6, 2]);
+}
+
+#[test]
+fn paste_fill_is_a_single_undo_step() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 3, 2, "1").unwrap();
+    model.set_user_input(0, 4, 2, "=B3+1").unwrap();
+    model.set_user_input(0, 7, 2, "keep me").unwrap();
+
+    copy_and_paste_over(&mut model, (4, 2, 4, 2), (5, 2, 10, 2));
+    assert_eq!(model.get_cell_content(0, 10, 2).unwrap(), "=B9+1");
+
+    model.undo().unwrap();
+
+    assert_eq!(model.get_cell_content(0, 7, 2).unwrap(), "keep me");
+    for row in [5, 6, 8, 9, 10] {
+        assert_eq!(
+            model.get_cell_content(0, row, 2).unwrap(),
+            "",
+            "one undo must clear every filled cell"
+        );
+    }
+
+    model.redo().unwrap();
+    assert_eq!(model.get_cell_content(0, 5, 2).unwrap(), "=B4+1");
+    assert_eq!(model.get_cell_content(0, 10, 2).unwrap(), "=B9+1");
+}
+
+#[test]
+fn paste_into_a_selection_that_is_not_a_whole_multiple_pastes_once() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model.set_user_input(0, 2, 1, "2").unwrap();
+
+    // A 2-row copy into a 3-row selection is not a whole multiple: paste it once, at the
+    // selection's top-left corner.
+    copy_and_paste_over(&mut model, (1, 1, 2, 1), (4, 1, 6, 1));
+
+    assert_eq!(model.get_formatted_cell_value(0, 4, 1).unwrap(), "1");
+    assert_eq!(model.get_formatted_cell_value(0, 5, 1).unwrap(), "2");
+    assert_eq!(model.get_formatted_cell_value(0, 6, 1).unwrap(), "");
+}
+
+#[test]
+fn paste_into_a_smaller_selection_pastes_the_whole_copy() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model.set_user_input(0, 2, 1, "2").unwrap();
+    model.set_user_input(0, 3, 1, "3").unwrap();
+
+    // A single selected cell is the classic paste: the copy lands whole, from the anchor.
+    copy_and_paste_over(&mut model, (1, 1, 3, 1), (5, 1, 5, 1));
+
+    assert_eq!(model.get_formatted_cell_value(0, 5, 1).unwrap(), "1");
+    assert_eq!(model.get_formatted_cell_value(0, 6, 1).unwrap(), "2");
+    assert_eq!(model.get_formatted_cell_value(0, 7, 1).unwrap(), "3");
+}
+
+#[test]
+fn cut_into_a_larger_selection_moves_the_cells_once() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+
+    model.set_selected_cell(1, 1).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    model.set_selected_cell(3, 1).unwrap();
+    model.set_selected_range(3, 1, 6, 1).unwrap();
+    model
+        .paste_from_clipboard(0, (1, 1, 1, 1), &clipboard.data, true)
+        .unwrap();
+
+    // A cut is a move: exactly one cell moves, the rest of the selection is untouched.
+    assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "");
+    assert_eq!(model.get_formatted_cell_value(0, 3, 1).unwrap(), "1");
+    for row in 4..=6 {
+        assert_eq!(model.get_formatted_cell_value(0, row, 1).unwrap(), "");
+    }
+}

--- a/base/src/test/user_model/test_paste_fill.rs
+++ b/base/src/test/user_model/test_paste_fill.rs
@@ -1,0 +1,387 @@
+#![allow(clippy::unwrap_used)]
+
+//! Pasting a copy into a selection that is a whole multiple of it repeats ("fills") the copy
+//! across the selection, re-anchoring relative references in every repetition — Excel's behavior.
+
+use crate::cf_types::{CfRuleInput, Cfvo, ColorScaleThreshold};
+use crate::expressions::types::Area;
+use crate::test::user_model::util::new_empty_user_model;
+use crate::types::{Color, Link};
+use crate::UserModel;
+
+fn external(target: &str) -> Link {
+    Link::External {
+        target: target.to_string(),
+        tooltip: None,
+    }
+}
+
+fn color_scale() -> CfRuleInput {
+    CfRuleInput::ColorScale {
+        thresholds: vec![
+            ColorScaleThreshold {
+                cfvo: Cfvo::Min,
+                color: Color::Rgb("#FF0000".to_string()),
+            },
+            ColorScaleThreshold {
+                cfvo: Cfvo::Max,
+                color: Color::Rgb("#00FF00".to_string()),
+            },
+        ],
+    }
+}
+
+/// Copies `range` (e.g. `(4, 2, 4, 2)` for B4) to the clipboard and pastes it over the
+/// `(first_row, first_column, last_row, last_column)` selection.
+fn copy_and_paste_over(
+    model: &mut UserModel,
+    source: (i32, i32, i32, i32),
+    target: (i32, i32, i32, i32),
+) {
+    let (source_first_row, source_first_column, source_last_row, source_last_column) = source;
+    model
+        .set_selected_cell(source_first_row, source_first_column)
+        .unwrap();
+    model
+        .set_selected_range(
+            source_first_row,
+            source_first_column,
+            source_last_row,
+            source_last_column,
+        )
+        .unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+
+    let (target_first_row, target_first_column, target_last_row, target_last_column) = target;
+    model
+        .set_selected_cell(target_first_row, target_first_column)
+        .unwrap();
+    model
+        .set_selected_range(
+            target_first_row,
+            target_first_column,
+            target_last_row,
+            target_last_column,
+        )
+        .unwrap();
+    model
+        .paste_from_clipboard(0, source, &clipboard.data, false)
+        .unwrap();
+}
+
+#[test]
+fn paste_of_a_single_cell_fills_the_selection_readjusting_references_per_cell() {
+    let mut model = new_empty_user_model();
+    // B3 = 1, B4 = =B3+1. Copy B4 and paste it over B5:B10.
+    model.set_user_input(0, 3, 2, "1").unwrap();
+    model.set_user_input(0, 4, 2, "=B3+1").unwrap();
+
+    copy_and_paste_over(&mut model, (4, 2, 4, 2), (5, 2, 10, 2));
+
+    // Every filled cell points at the cell above it, not at B4's source displacement.
+    for row in 5..=10 {
+        assert_eq!(
+            model.get_cell_content(0, row, 2).unwrap(),
+            format!("=B{}+1", row - 1),
+            "B{row} should reference the cell above it"
+        );
+        assert_eq!(
+            model.get_formatted_cell_value(0, row, 2).unwrap(),
+            (row - 2).to_string()
+        );
+    }
+}
+
+#[test]
+fn paste_fill_keeps_absolute_references_pinned() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "10").unwrap();
+    model.set_user_input(0, 3, 2, "=$A$1+A2").unwrap();
+
+    copy_and_paste_over(&mut model, (3, 2, 3, 2), (4, 2, 6, 2));
+
+    assert_eq!(model.get_cell_content(0, 4, 2).unwrap(), "=$A$1+A3");
+    assert_eq!(model.get_cell_content(0, 5, 2).unwrap(), "=$A$1+A4");
+    assert_eq!(model.get_cell_content(0, 6, 2).unwrap(), "=$A$1+A5");
+}
+
+#[test]
+fn paste_fill_repeats_a_block_in_both_axes() {
+    let mut model = new_empty_user_model();
+    // A 1x2 block in A1:B1 (a value and a formula pointing one row up).
+    model.set_user_input(0, 1, 1, "7").unwrap();
+    model.set_user_input(0, 1, 2, "=A1").unwrap();
+
+    // Fill C3:F4 — two repetitions right, two down.
+    copy_and_paste_over(&mut model, (1, 1, 1, 2), (3, 3, 4, 6));
+
+    for (row, column) in [(3, 3), (3, 5), (4, 3), (4, 5)] {
+        assert_eq!(model.get_cell_content(0, row, column).unwrap(), "7");
+        let reference = format!(
+            "={}{}",
+            crate::expressions::utils::number_to_column(column).unwrap(),
+            row
+        );
+        assert_eq!(
+            model.get_cell_content(0, row, column + 1).unwrap(),
+            reference,
+            "the formula copy must point at its own repetition's left cell"
+        );
+    }
+}
+
+#[test]
+fn paste_fill_repeats_values_and_styles() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "hello").unwrap();
+    let a1 = Area {
+        sheet: 0,
+        row: 1,
+        column: 1,
+        width: 1,
+        height: 1,
+    };
+    model.update_range_style(&a1, "font.b", "true").unwrap();
+
+    copy_and_paste_over(&mut model, (1, 1, 1, 1), (3, 1, 5, 2));
+
+    for row in 3..=5 {
+        for column in 1..=2 {
+            assert_eq!(
+                model.get_formatted_cell_value(0, row, column).unwrap(),
+                "hello"
+            );
+            assert!(model.get_cell_style(0, row, column).unwrap().font.b);
+        }
+    }
+}
+
+#[test]
+fn paste_fill_adds_one_conditional_formatting_rule_spanning_the_filled_block() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model
+        .add_conditional_formatting(0, "A1", color_scale())
+        .unwrap();
+
+    // Fill C3:D12 from A1 — 20 repetitions of the single copied cell.
+    copy_and_paste_over(&mut model, (1, 1, 1, 1), (3, 3, 12, 4));
+
+    let rules = model.get_conditional_formatting_list(0).unwrap();
+    assert_eq!(
+        rules.len(),
+        2,
+        "the fill adds ONE rule, not one per filled cell"
+    );
+    // The list is ordered by priority, highest first — the copied rule is the newest.
+    assert_eq!(
+        rules[0].range, "C3:D12",
+        "the copied rule spans the whole filled block"
+    );
+    assert_eq!(rules[1].range, "A1", "the source rule is untouched");
+
+    model.undo().unwrap();
+    assert_eq!(
+        model.get_conditional_formatting_list(0).unwrap().len(),
+        1,
+        "one undo removes the rule the fill added"
+    );
+}
+
+#[test]
+fn paste_fill_conditional_formatting_over_part_of_the_copy_maps_each_repetition() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model.set_user_input(0, 2, 1, "2").unwrap();
+    // The rule covers only the TOP cell of the 2-row copy, so the repetitions are not contiguous.
+    model
+        .add_conditional_formatting(0, "A1", color_scale())
+        .unwrap();
+
+    // Fill C1:C4 from A1:A2 — two repetitions down.
+    copy_and_paste_over(&mut model, (1, 1, 2, 1), (1, 3, 4, 3));
+
+    let rules = model.get_conditional_formatting_list(0).unwrap();
+    assert_eq!(rules.len(), 2, "still ONE added rule");
+    assert_eq!(
+        rules[0].range, "C1 C3",
+        "its sqref lists the mapped cell of each repetition"
+    );
+}
+
+#[test]
+fn paste_fill_selects_the_whole_filled_area() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+
+    copy_and_paste_over(&mut model, (1, 1, 1, 1), (3, 1, 6, 2));
+
+    assert_eq!(model.get_selected_view().range, [3, 1, 6, 2]);
+}
+
+#[test]
+fn paste_fill_is_a_single_undo_step() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 3, 2, "1").unwrap();
+    model.set_user_input(0, 4, 2, "=B3+1").unwrap();
+    model.set_user_input(0, 7, 2, "keep me").unwrap();
+
+    copy_and_paste_over(&mut model, (4, 2, 4, 2), (5, 2, 10, 2));
+    assert_eq!(model.get_cell_content(0, 10, 2).unwrap(), "=B9+1");
+
+    model.undo().unwrap();
+
+    assert_eq!(model.get_cell_content(0, 7, 2).unwrap(), "keep me");
+    for row in [5, 6, 8, 9, 10] {
+        assert_eq!(
+            model.get_cell_content(0, row, 2).unwrap(),
+            "",
+            "one undo must clear every filled cell"
+        );
+    }
+
+    model.redo().unwrap();
+    assert_eq!(model.get_cell_content(0, 5, 2).unwrap(), "=B4+1");
+    assert_eq!(model.get_cell_content(0, 10, 2).unwrap(), "=B9+1");
+}
+
+#[test]
+fn paste_into_a_selection_that_is_not_a_whole_multiple_pastes_once() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model.set_user_input(0, 2, 1, "2").unwrap();
+
+    // A 2-row copy into a 3-row selection is not a whole multiple: paste it once, at the
+    // selection's top-left corner.
+    copy_and_paste_over(&mut model, (1, 1, 2, 1), (4, 1, 6, 1));
+
+    assert_eq!(model.get_formatted_cell_value(0, 4, 1).unwrap(), "1");
+    assert_eq!(model.get_formatted_cell_value(0, 5, 1).unwrap(), "2");
+    assert_eq!(model.get_formatted_cell_value(0, 6, 1).unwrap(), "");
+}
+
+#[test]
+fn paste_into_a_smaller_selection_pastes_the_whole_copy() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model.set_user_input(0, 2, 1, "2").unwrap();
+    model.set_user_input(0, 3, 1, "3").unwrap();
+
+    // A single selected cell is the classic paste: the copy lands whole, from the anchor.
+    copy_and_paste_over(&mut model, (1, 1, 3, 1), (5, 1, 5, 1));
+
+    assert_eq!(model.get_formatted_cell_value(0, 5, 1).unwrap(), "1");
+    assert_eq!(model.get_formatted_cell_value(0, 6, 1).unwrap(), "2");
+    assert_eq!(model.get_formatted_cell_value(0, 7, 1).unwrap(), "3");
+}
+
+#[test]
+fn cut_into_a_larger_selection_moves_the_cells_once() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+
+    model.set_selected_cell(1, 1).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    model.set_selected_cell(3, 1).unwrap();
+    model.set_selected_range(3, 1, 6, 1).unwrap();
+    model
+        .paste_from_clipboard(0, (1, 1, 1, 1), &clipboard.data, true)
+        .unwrap();
+
+    // A cut is a move: exactly one cell moves, the rest of the selection is untouched.
+    assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "");
+    assert_eq!(model.get_formatted_cell_value(0, 3, 1).unwrap(), "1");
+    for row in 4..=6 {
+        assert_eq!(model.get_formatted_cell_value(0, row, 1).unwrap(), "");
+    }
+}
+
+// --- Links across a fill -----------------------------------------------------
+//
+// Link paste and value paste are separate passes over the copied cells. They must
+// cover exactly the same target cells, or a fill links only its first repetition
+// (and, worse, leaves the auto-links the value pass created in the rest).
+
+#[test]
+fn paste_fill_repeats_the_copied_link_in_every_repetition() {
+    let mut model = new_empty_user_model();
+    // B4 holds a label — not URL-shaped, so nothing auto-links it — with an
+    // explicit link. Every filled cell must get that link.
+    model.set_user_input(0, 4, 2, "Docs").unwrap();
+    model
+        .set_cell_link(0, 4, 2, external("https://example.com/docs"), None)
+        .unwrap();
+
+    copy_and_paste_over(&mut model, (4, 2, 4, 2), (5, 2, 8, 2));
+
+    for row in 5..=8 {
+        assert_eq!(model.get_formatted_cell_value(0, row, 2).unwrap(), "Docs");
+        assert_eq!(
+            model.get_cell_link(0, row, 2),
+            Ok(Some(external("https://example.com/docs"))),
+            "repetition at row {row} lost the copied link"
+        );
+    }
+
+    // The whole fill, links included, is one undo step.
+    model.undo().unwrap();
+    for row in 5..=8 {
+        assert_eq!(model.get_cell_link(0, row, 2), Ok(None));
+    }
+}
+
+#[test]
+fn paste_fill_repeats_the_absence_of_a_link_in_every_repetition() {
+    let mut model = new_empty_user_model();
+    // B4 holds a URL the user deliberately unlinked. Pasting it re-enters the text
+    // through `set_user_input`, which auto-links it — the link pass must undo that
+    // in every repetition, not just the first.
+    model
+        .set_user_input(0, 4, 2, "https://example.com/")
+        .unwrap();
+    model.delete_cell_link(0, 4, 2).unwrap();
+    assert_eq!(model.get_cell_link(0, 4, 2), Ok(None));
+
+    copy_and_paste_over(&mut model, (4, 2, 4, 2), (5, 2, 8, 2));
+
+    for row in 5..=8 {
+        assert_eq!(
+            model.get_formatted_cell_value(0, row, 2).unwrap(),
+            "https://example.com/"
+        );
+        assert_eq!(
+            model.get_cell_link(0, row, 2),
+            Ok(None),
+            "repetition at row {row} resurrected a link the user had removed"
+        );
+    }
+}
+
+#[test]
+fn paste_fill_repeats_links_of_a_block_in_both_axes() {
+    let mut model = new_empty_user_model();
+    // A1:B1 — only A1 carries a link. Fill C3:F4: two repetitions per axis.
+    model.set_user_input(0, 1, 1, "linked").unwrap();
+    model.set_user_input(0, 1, 2, "plain").unwrap();
+    model
+        .set_cell_link(0, 1, 1, external("https://example.com/"), None)
+        .unwrap();
+
+    copy_and_paste_over(&mut model, (1, 1, 1, 2), (3, 3, 4, 6));
+
+    for row in 3..=4 {
+        for column in [3, 5] {
+            assert_eq!(
+                model.get_cell_link(0, row, column),
+                Ok(Some(external("https://example.com/"))),
+                "({row}, {column}) should carry the link of the copied A1"
+            );
+            assert_eq!(
+                model.get_cell_link(0, row, column + 1),
+                Ok(None),
+                "({row}, {}) should carry no link, like the copied B1",
+                column + 1
+            );
+        }
+    }
+}

--- a/base/src/user_model/clipboard.rs
+++ b/base/src/user_model/clipboard.rs
@@ -91,6 +91,17 @@ impl<'a> UserModel<'a> {
     }
 
     /// Paste text that we copied
+    ///
+    /// If this is a copy (not a cut) and the selected area is a whole multiple of the copied
+    /// rectangle and strictly larger than it, the copy is *repeated* to fill the whole selection,
+    /// like Excel does. Every repetition re-anchors its relative references to its own position
+    /// (copying `=B3+1` from `B4` into `B5:B10` gives `=B4+1`, `=B5+1`, … `=B9+1`), and the whole
+    /// fill is still a single undo step. Any other selection pastes the copy once at the
+    /// selection's top-left corner.
+    ///
+    /// A fill writes (and records an undo diff for) every cell of the selection, so a caller that
+    /// lets the user select a whole column or the whole sheet should bound the selection before
+    /// pasting into it.
     pub fn paste_from_clipboard(
         &mut self,
         source_sheet: u32,
@@ -103,95 +114,112 @@ impl<'a> UserModel<'a> {
         let (source_first_row, source_first_column, source_last_row, source_last_column) =
             source_range;
         let sheet = view.sheet;
-        let [selected_row, selected_column, _, _] = view.range;
+        let [selected_row, selected_column, selected_last_row, selected_last_column] = view.range;
         let mut max_row = selected_row;
         let mut max_column = selected_column;
+        let source_width = source_last_column - source_first_column + 1;
+        let source_height = source_last_row - source_first_row + 1;
+        // A cut is a move, so it is always pasted exactly once.
+        let (row_repeats, column_repeats) = if is_cut {
+            (1, 1)
+        } else {
+            fill_repeats(
+                source_height,
+                source_width,
+                selected_last_row - selected_row + 1,
+                selected_last_column - selected_column + 1,
+            )
+        };
         let area = &Area {
             sheet,
             row: source_first_row,
             column: source_first_column,
-            width: source_last_column - source_first_column + 1,
-            height: source_last_row - source_first_row + 1,
+            width: source_width,
+            height: source_height,
         };
         let target_area = &Area {
             sheet,
             row: selected_row,
             column: selected_column,
-            width: source_last_column - source_first_column + 1,
-            height: source_last_row - source_first_row + 1,
+            width: source_width * column_repeats,
+            height: source_height * row_repeats,
         };
 
         let mut seen_cells = HashSet::new();
         // Compute all changes
         let mut changes = Vec::new();
-        for (source_row, data_row) in clipboard {
-            let delta_row = source_row - source_first_row;
-            let target_row = selected_row + delta_row;
-            max_row = max_row.max(target_row);
-            for (source_column, value) in data_row {
-                let delta_column = source_column - source_first_column;
-                let target_column = selected_column + delta_column;
-                max_column = max_column.max(target_column);
+        for (row_offset, column_offset) in
+            fill_offsets(row_repeats, column_repeats, source_height, source_width)
+        {
+            for (source_row, data_row) in clipboard {
+                let delta_row = source_row - source_first_row;
+                let target_row = selected_row + delta_row + row_offset;
+                max_row = max_row.max(target_row);
+                for (source_column, value) in data_row {
+                    let delta_column = source_column - source_first_column;
+                    let target_column = selected_column + delta_column + column_offset;
+                    max_column = max_column.max(target_column);
 
-                if value.is_spill {
-                    // Spill cells carry no formula/value, but their style should still be copied.
+                    if value.is_spill {
+                        // Spill cells carry no formula/value, but their style should still be copied.
+                        let old_style =
+                            self.model
+                                .get_cell_style_or_none(sheet, target_row, target_column)?;
+                        changes.push((
+                            target_row,
+                            target_column,
+                            None,
+                            old_style,
+                            None,
+                            value.style.clone(),
+                        ));
+                        seen_cells.insert((target_row, target_column));
+                        continue;
+                    }
+
+                    // We are copying the value in
+                    // (source_row, source_column) to (target_row , target_column)
+                    // References in formulas are displaced
+
+                    // remain in the copied area
+                    let source = &CellReferenceIndex {
+                        sheet,
+                        column: *source_column,
+                        row: *source_row,
+                    };
+                    let target = &CellReferenceIndex {
+                        sheet,
+                        column: target_column,
+                        row: target_row,
+                    };
+                    let new_value = if is_cut {
+                        self.model
+                            .move_cell_value_to_area(&value.text, source, target, area)?
+                    } else {
+                        self.model
+                            .extend_copied_value(&value.text, source, target)?
+                    };
+
+                    let old_value = self
+                        .model
+                        .workbook
+                        .worksheet(sheet)?
+                        .cell(target_row, target_column)
+                        .cloned();
+
                     let old_style =
                         self.model
                             .get_cell_style_or_none(sheet, target_row, target_column)?;
                     changes.push((
                         target_row,
                         target_column,
-                        None,
-                        old_style,
-                        None,
+                        old_value.clone(),
+                        old_style.clone(),
+                        Some(new_value.clone()),
                         value.style.clone(),
                     ));
                     seen_cells.insert((target_row, target_column));
-                    continue;
                 }
-
-                // We are copying the value in
-                // (source_row, source_column) to (target_row , target_column)
-                // References in formulas are displaced
-
-                // remain in the copied area
-                let source = &CellReferenceIndex {
-                    sheet,
-                    column: *source_column,
-                    row: *source_row,
-                };
-                let target = &CellReferenceIndex {
-                    sheet,
-                    column: target_column,
-                    row: target_row,
-                };
-                let new_value = if is_cut {
-                    self.model
-                        .move_cell_value_to_area(&value.text, source, target, area)?
-                } else {
-                    self.model
-                        .extend_copied_value(&value.text, source, target)?
-                };
-
-                let old_value = self
-                    .model
-                    .workbook
-                    .worksheet(sheet)?
-                    .cell(target_row, target_column)
-                    .cloned();
-
-                let old_style =
-                    self.model
-                        .get_cell_style_or_none(sheet, target_row, target_column)?;
-                changes.push((
-                    target_row,
-                    target_column,
-                    old_value.clone(),
-                    old_style.clone(),
-                    Some(new_value.clone()),
-                    value.style.clone(),
-                ));
-                seen_cells.insert((target_row, target_column));
             }
         }
         // clear the whole area (this resets array formulas)
@@ -374,7 +402,9 @@ impl<'a> UserModel<'a> {
                 });
             }
         } else {
-            // Copy-paste: duplicate CF rules from the source area to the target.
+            // Copy-paste: duplicate CF rules from the source area to the target. A fill adds ONE
+            // entry per source rule, its sqref covering every repetition (`get_cf_rules_to_copy`
+            // merges them), so the added rules never scale with the number of filled cells.
             let cf_copies = self.model.get_cf_rules_to_copy(
                 source_sheet,
                 source_first_row,
@@ -383,18 +413,21 @@ impl<'a> UserModel<'a> {
                 source_last_column,
                 selected_row,
                 selected_column,
+                (row_repeats, column_repeats),
             );
+            // The next free priority, read once and then counted up — re-scanning the (growing)
+            // rule list per added rule would be quadratic.
+            let mut priority = self
+                .model
+                .workbook
+                .worksheet(sheet)?
+                .conditional_formatting
+                .iter()
+                .map(|cf| cf.priority)
+                .max()
+                .map(|m| m + 1)
+                .unwrap_or(1);
             for (new_range, new_rule) in cf_copies {
-                let priority = self
-                    .model
-                    .workbook
-                    .worksheet(sheet)?
-                    .conditional_formatting
-                    .iter()
-                    .map(|cf| cf.priority)
-                    .max()
-                    .map(|m| m + 1)
-                    .unwrap_or(1);
                 self.model
                     .workbook
                     .worksheet_mut(sheet)?
@@ -410,6 +443,7 @@ impl<'a> UserModel<'a> {
                     rule: Box::new(new_rule),
                     priority,
                 });
+                priority += 1;
             }
         }
         self.push_diff_list(diff_list);
@@ -490,4 +524,44 @@ impl<'a> UserModel<'a> {
         self.evaluate_if_not_paused();
         Ok(())
     }
+}
+
+/// How many times a copied rectangle repeats down and to the right to fill the selected target
+/// rectangle, as `(row_repeats, column_repeats)`.
+///
+/// A copy fills the selection only when the selection is a whole multiple of it in *both* axes
+/// and strictly larger in at least one of them (Excel's rule). Every other selection — including
+/// a partial multiple like a 2-row copy into a 3-row selection — pastes the copy once.
+fn fill_repeats(
+    source_height: i32,
+    source_width: i32,
+    target_height: i32,
+    target_width: i32,
+) -> (i32, i32) {
+    if source_width < 1 || source_height < 1 || target_width < 1 || target_height < 1 {
+        return (1, 1);
+    }
+    let fills = target_width % source_width == 0
+        && target_height % source_height == 0
+        && (target_width > source_width || target_height > source_height);
+    if fills {
+        (target_height / source_height, target_width / source_width)
+    } else {
+        (1, 1)
+    }
+}
+
+/// The `(row_offset, column_offset)` of every repetition of a `source_height`×`source_width`
+/// rectangle in a fill of `row_repeats`×`column_repeats` repetitions, relative to the target's
+/// top-left corner. Always yields at least `(0, 0)` — the plain single paste.
+fn fill_offsets(
+    row_repeats: i32,
+    column_repeats: i32,
+    source_height: i32,
+    source_width: i32,
+) -> impl Iterator<Item = (i32, i32)> {
+    (0..row_repeats).flat_map(move |repeat_row| {
+        (0..column_repeats)
+            .map(move |repeat_column| (repeat_row * source_height, repeat_column * source_width))
+    })
 }

--- a/base/src/user_model/clipboard.rs
+++ b/base/src/user_model/clipboard.rs
@@ -97,6 +97,17 @@ impl<'a> UserModel<'a> {
     }
 
     /// Paste text that we copied
+    ///
+    /// If this is a copy (not a cut) and the selected area is a whole multiple of the copied
+    /// rectangle and strictly larger than it, the copy is *repeated* to fill the whole selection,
+    /// like Excel does. Every repetition re-anchors its relative references to its own position
+    /// (copying `=B3+1` from `B4` into `B5:B10` gives `=B4+1`, `=B5+1`, … `=B9+1`), and the whole
+    /// fill is still a single undo step. Any other selection pastes the copy once at the
+    /// selection's top-left corner.
+    ///
+    /// A fill writes (and records an undo diff for) every cell of the selection, so a caller that
+    /// lets the user select a whole column or the whole sheet should bound the selection before
+    /// pasting into it.
     pub fn paste_from_clipboard(
         &mut self,
         source_sheet: u32,
@@ -109,95 +120,117 @@ impl<'a> UserModel<'a> {
         let (source_first_row, source_first_column, source_last_row, source_last_column) =
             source_range;
         let sheet = view.sheet;
-        let [selected_row, selected_column, _, _] = view.range;
+        let [selected_row, selected_column, selected_last_row, selected_last_column] = view.range;
         let mut max_row = selected_row;
         let mut max_column = selected_column;
+        let source_width = source_last_column - source_first_column + 1;
+        let source_height = source_last_row - source_first_row + 1;
+        // A cut is a move, so it is always pasted exactly once.
+        let (row_repeats, column_repeats) = if is_cut {
+            (1, 1)
+        } else {
+            fill_repeats(
+                source_height,
+                source_width,
+                selected_last_row - selected_row + 1,
+                selected_last_column - selected_column + 1,
+            )
+        };
         let area = &Area {
             sheet,
             row: source_first_row,
             column: source_first_column,
-            width: source_last_column - source_first_column + 1,
-            height: source_last_row - source_first_row + 1,
+            width: source_width,
+            height: source_height,
         };
         let target_area = &Area {
             sheet,
             row: selected_row,
             column: selected_column,
-            width: source_last_column - source_first_column + 1,
-            height: source_last_row - source_first_row + 1,
+            width: source_width * column_repeats,
+            height: source_height * row_repeats,
         };
 
         let mut seen_cells = HashSet::new();
         // Compute all changes
         let mut changes = Vec::new();
-        for (source_row, data_row) in clipboard {
-            let delta_row = source_row - source_first_row;
-            let target_row = selected_row + delta_row;
-            max_row = max_row.max(target_row);
-            for (source_column, value) in data_row {
-                let delta_column = source_column - source_first_column;
-                let target_column = selected_column + delta_column;
-                max_column = max_column.max(target_column);
+        // The link each target cell must end up with, collected in this same
+        // iteration so it can never cover a different set of cells than the
+        // values do. It is applied after the values are written (see below).
+        let mut link_changes = Vec::new();
+        for (row_offset, column_offset) in
+            fill_offsets(row_repeats, column_repeats, source_height, source_width)
+        {
+            for (source_row, data_row) in clipboard {
+                let delta_row = source_row - source_first_row;
+                let target_row = selected_row + delta_row + row_offset;
+                max_row = max_row.max(target_row);
+                for (source_column, value) in data_row {
+                    let delta_column = source_column - source_first_column;
+                    let target_column = selected_column + delta_column + column_offset;
+                    max_column = max_column.max(target_column);
+                    link_changes.push((target_row, target_column, value.link.clone()));
 
-                if value.is_spill {
-                    // Spill cells carry no formula/value, but their style should still be copied.
+                    if value.is_spill {
+                        // Spill cells carry no formula/value, but their style should still be copied.
+                        let old_style =
+                            self.model
+                                .get_cell_style_or_none(sheet, target_row, target_column)?;
+                        changes.push((
+                            target_row,
+                            target_column,
+                            None,
+                            old_style,
+                            None,
+                            value.style.clone(),
+                        ));
+                        seen_cells.insert((target_row, target_column));
+                        continue;
+                    }
+
+                    // We are copying the value in
+                    // (source_row, source_column) to (target_row , target_column)
+                    // References in formulas are displaced
+
+                    // remain in the copied area
+                    let source = &CellReferenceIndex {
+                        sheet,
+                        column: *source_column,
+                        row: *source_row,
+                    };
+                    let target = &CellReferenceIndex {
+                        sheet,
+                        column: target_column,
+                        row: target_row,
+                    };
+                    let new_value = if is_cut {
+                        self.model
+                            .move_cell_value_to_area(&value.text, source, target, area)?
+                    } else {
+                        self.model
+                            .extend_copied_value(&value.text, source, target)?
+                    };
+
+                    let old_value = self
+                        .model
+                        .workbook
+                        .worksheet(sheet)?
+                        .cell(target_row, target_column)
+                        .cloned();
+
                     let old_style =
                         self.model
                             .get_cell_style_or_none(sheet, target_row, target_column)?;
                     changes.push((
                         target_row,
                         target_column,
-                        None,
-                        old_style,
-                        None,
+                        old_value.clone(),
+                        old_style.clone(),
+                        Some(new_value.clone()),
                         value.style.clone(),
                     ));
                     seen_cells.insert((target_row, target_column));
-                    continue;
                 }
-
-                // We are copying the value in
-                // (source_row, source_column) to (target_row , target_column)
-                // References in formulas are displaced
-
-                // remain in the copied area
-                let source = &CellReferenceIndex {
-                    sheet,
-                    column: *source_column,
-                    row: *source_row,
-                };
-                let target = &CellReferenceIndex {
-                    sheet,
-                    column: target_column,
-                    row: target_row,
-                };
-                let new_value = if is_cut {
-                    self.model
-                        .move_cell_value_to_area(&value.text, source, target, area)?
-                } else {
-                    self.model
-                        .extend_copied_value(&value.text, source, target)?
-                };
-
-                let old_value = self
-                    .model
-                    .workbook
-                    .worksheet(sheet)?
-                    .cell(target_row, target_column)
-                    .cloned();
-
-                let old_style =
-                    self.model
-                        .get_cell_style_or_none(sheet, target_row, target_column)?;
-                changes.push((
-                    target_row,
-                    target_column,
-                    old_value.clone(),
-                    old_style.clone(),
-                    Some(new_value.clone()),
-                    value.style.clone(),
-                ));
-                seen_cells.insert((target_row, target_column));
             }
         }
         // Clearing the target area also removes its links: capture them for undo
@@ -229,32 +262,30 @@ impl<'a> UserModel<'a> {
             });
         }
         // Paste the links of the copied cells. This runs after the values are
-        // set so that it also overrides any link auto-created by an URL value.
-        for (source_row, data_row) in clipboard {
-            let target_row = selected_row + (source_row - source_first_row);
-            for (source_column, value) in data_row {
-                let target_column = selected_column + (source_column - source_first_column);
-                let old_link = self.model.get_cell_link(sheet, target_row, target_column)?;
-                if old_link == value.link {
-                    continue;
-                }
-                match &value.link {
-                    Some(link) => {
-                        self.model
-                            .set_cell_link(sheet, target_row, target_column, link.clone())?
-                    }
-                    None => self
-                        .model
-                        .delete_cell_link(sheet, target_row, target_column)?,
-                }
-                diff_list.push(Diff::SetCellLink {
-                    sheet,
-                    row: target_row,
-                    column: target_column,
-                    old_value: Box::new(old_link),
-                    new_value: Box::new(value.link.clone()),
-                });
+        // set so that it also overrides any link auto-created by an URL value —
+        // including in every repetition of a fill, where the source cell's
+        // absence of a link must also be reproduced.
+        for (target_row, target_column, link) in link_changes {
+            let old_link = self.model.get_cell_link(sheet, target_row, target_column)?;
+            if old_link == link {
+                continue;
             }
+            match &link {
+                Some(link) => {
+                    self.model
+                        .set_cell_link(sheet, target_row, target_column, link.clone())?
+                }
+                None => self
+                    .model
+                    .delete_cell_link(sheet, target_row, target_column)?,
+            }
+            diff_list.push(Diff::SetCellLink {
+                sheet,
+                row: target_row,
+                column: target_column,
+                old_value: Box::new(old_link),
+                new_value: Box::new(link),
+            });
         }
         if is_cut {
             for row in source_first_row..=source_last_row {
@@ -423,7 +454,9 @@ impl<'a> UserModel<'a> {
                 });
             }
         } else {
-            // Copy-paste: duplicate CF rules from the source area to the target.
+            // Copy-paste: duplicate CF rules from the source area to the target. A fill adds ONE
+            // entry per source rule, its sqref covering every repetition (`get_cf_rules_to_copy`
+            // merges them), so the added rules never scale with the number of filled cells.
             let cf_copies = self.model.get_cf_rules_to_copy(
                 source_sheet,
                 source_first_row,
@@ -432,18 +465,21 @@ impl<'a> UserModel<'a> {
                 source_last_column,
                 selected_row,
                 selected_column,
+                (row_repeats, column_repeats),
             );
+            // The next free priority, read once and then counted up — re-scanning the (growing)
+            // rule list per added rule would be quadratic.
+            let mut priority = self
+                .model
+                .workbook
+                .worksheet(sheet)?
+                .conditional_formatting
+                .iter()
+                .map(|cf| cf.priority)
+                .max()
+                .map(|m| m + 1)
+                .unwrap_or(1);
             for (new_range, new_rule) in cf_copies {
-                let priority = self
-                    .model
-                    .workbook
-                    .worksheet(sheet)?
-                    .conditional_formatting
-                    .iter()
-                    .map(|cf| cf.priority)
-                    .max()
-                    .map(|m| m + 1)
-                    .unwrap_or(1);
                 self.model
                     .workbook
                     .worksheet_mut(sheet)?
@@ -459,6 +495,7 @@ impl<'a> UserModel<'a> {
                     rule: Box::new(new_rule),
                     priority,
                 });
+                priority += 1;
             }
         }
         self.push_diff_list(diff_list);
@@ -546,4 +583,44 @@ impl<'a> UserModel<'a> {
         self.evaluate_if_not_paused();
         Ok(())
     }
+}
+
+/// How many times a copied rectangle repeats down and to the right to fill the selected target
+/// rectangle, as `(row_repeats, column_repeats)`.
+///
+/// A copy fills the selection only when the selection is a whole multiple of it in *both* axes
+/// and strictly larger in at least one of them (Excel's rule). Every other selection — including
+/// a partial multiple like a 2-row copy into a 3-row selection — pastes the copy once.
+fn fill_repeats(
+    source_height: i32,
+    source_width: i32,
+    target_height: i32,
+    target_width: i32,
+) -> (i32, i32) {
+    if source_width < 1 || source_height < 1 || target_width < 1 || target_height < 1 {
+        return (1, 1);
+    }
+    let fills = target_width % source_width == 0
+        && target_height % source_height == 0
+        && (target_width > source_width || target_height > source_height);
+    if fills {
+        (target_height / source_height, target_width / source_width)
+    } else {
+        (1, 1)
+    }
+}
+
+/// The `(row_offset, column_offset)` of every repetition of a `source_height`×`source_width`
+/// rectangle in a fill of `row_repeats`×`column_repeats` repetitions, relative to the target's
+/// top-left corner. Always yields at least `(0, 0)` — the plain single paste.
+fn fill_offsets(
+    row_repeats: i32,
+    column_repeats: i32,
+    source_height: i32,
+    source_width: i32,
+) -> impl Iterator<Item = (i32, i32)> {
+    (0..row_repeats).flat_map(move |repeat_row| {
+        (0..column_repeats)
+            .map(move |repeat_column| (repeat_row * source_height, repeat_column * source_width))
+    })
 }


### PR DESCRIPTION
Use case: when pasting formulas into multiple cells: first cell works (it shifts non $ references), but if you paste to many cells, the second and later don’t shift. 

Example: Formula in cell B4 =B3+1, copy it (single cell copy). Paste into range B5-B10: B5 correctly gets =B4+1 but  B6-B10 incorrectly get =B4+1

## Change

`paste_from_clipboard` only ever pasted the copied rectangle once, at the top-left of the selected view, ignoring the rest of the selection. Excel instead *repeats* the copy across a selection that is a whole multiple of it, re-anchoring relative references in every repetition: copying `=B3+1` from B4 over B5:B10 gives `=B4+1`, `=B5+1`, ..., `=B9+1`.

Repeat the copy across such a selection, running each repetition through `extend_copied_value` from the *original* source cell so its references are displaced by its own offset. Values and styles are written per repetition, the whole fill clears its target area first, and it all stays a single diff list (one undo step).

Conditional formatting is copied ONCE per source rule, not once per repetition: `get_cf_rules_to_copy` now takes the fill's repeat counts and maps each overlapping rule to a single sqref covering every repetition, merged into one range wherever the repetitions are contiguous (the usual case — a rule spanning the copied rectangle becomes one range over the whole filled block, as in Excel).

Only a copy fills: a cut is a move, so it is still pasted exactly once. A selection that is not a whole multiple of the copy (or is not larger than it) also pastes once, at the selection's top-left corner.