### PR TITLE
update: dark mode adjustments in frozen panes, borders and named styles

### DIFF
--- a/webapp/IronCalc/src/components/BorderPicker/BorderPicker.tsx
+++ b/webapp/IronCalc/src/components/BorderPicker/BorderPicker.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../icons";
 import { IconButton } from "../Button/IconButton";
 import ColorPicker from "../ColorPicker/ColorPicker";
+import { themeColor } from "../ColorPicker/util";
 import "./border-picker.css";
 import LineStylePicker from "./LineStylePicker";
 
@@ -42,9 +43,6 @@ type Position = {
   top: number;
   left: number;
 };
-
-// --palette-common-black
-const DEFAULT_BORDER_COLOR = "#272525";
 
 const BORDER_BUTTONS = [
   {
@@ -123,7 +121,10 @@ export default function BorderPicker({
 
   const [position, setPosition] = useState<Position | null>(null);
   const [borderSelected, setBorderSelected] = useState<BorderType | null>(null);
-  const [borderColor, setBorderColor] = useState<Color>(DEFAULT_BORDER_COLOR);
+  const [defaultColor, setDefaultColor] = useState(() =>
+    themeColor("--palette-common-black", anchorEl.current),
+  );
+  const [borderColor, setBorderColor] = useState<Color>(defaultColor);
   const [borderStyle, setBorderStyle] = useState(BorderStyle.Thin);
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
   const [stylePickerOpen, setStylePickerOpen] = useState(false);
@@ -187,14 +188,16 @@ export default function BorderPicker({
 
   useEffect(() => {
     if (open) {
+      const color = themeColor("--palette-common-black", anchorEl.current);
+      setDefaultColor(color);
+      setBorderColor(color);
       return;
     }
     setBorderSelected(null);
-    setBorderColor(DEFAULT_BORDER_COLOR);
     setBorderStyle(BorderStyle.Thin);
     setColorPickerOpen(false);
     setStylePickerOpen(false);
-  }, [open]);
+  }, [open, anchorEl]);
 
   useEffect(() => {
     if (!open) {
@@ -314,7 +317,7 @@ export default function BorderPicker({
           </button>
           <ColorPicker
             color={borderColor}
-            defaultColor={DEFAULT_BORDER_COLOR}
+            defaultColor={defaultColor}
             title={t("color_picker.default")}
             onChange={(color) => {
               setBorderColor(color);

--- a/webapp/IronCalc/src/components/ColorPicker/util.ts
+++ b/webapp/IronCalc/src/components/ColorPicker/util.ts
@@ -3,6 +3,21 @@ import {
   hexWithTintToRgb,
   type IronCalcTheme,
 } from "@ironcalc/wasm";
+import { defaultThemeVariables } from "../../theme";
+import type { IronCalcThemeVariables } from "../../theme/themeVariables";
+
+// Styles are stored in the workbook, so theme defaults have to be resolved to a hex
+export function themeColor(
+  name: keyof IronCalcThemeVariables,
+  anchor?: Element | null,
+): string {
+  const root =
+    anchor?.closest(".ic-root") ?? document.querySelector(".ic-root");
+  const color = root
+    ? getComputedStyle(root).getPropertyValue(name).trim()
+    : "";
+  return color || defaultThemeVariables[name];
+}
 
 export function themeBaseColors(theme: IronCalcTheme): string[] {
   return [

--- a/webapp/IronCalc/src/components/ColorPicker/util.ts
+++ b/webapp/IronCalc/src/components/ColorPicker/util.ts
@@ -12,10 +12,14 @@ export function themeColor(
   anchor?: Element | null,
 ): string {
   const root =
-    anchor?.closest(".ic-root") ?? document.querySelector(".ic-root");
-  const color = root
-    ? getComputedStyle(root).getPropertyValue(name).trim()
-    : "";
+    anchor?.closest(".ic-root") ??
+    (typeof document !== "undefined"
+      ? document.querySelector(".ic-root")
+      : null);
+  const color =
+    root && typeof getComputedStyle !== "undefined"
+      ? getComputedStyle(root).getPropertyValue(name).trim()
+      : "";
   return color || defaultThemeVariables[name];
 }
 

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/EditNamedStyle.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/EditNamedStyle.tsx
@@ -240,7 +240,7 @@ const EditNamedStyle = ({
       style.border.left;
     return (firstSide?.style as BorderStyle) || BorderStyle.Thin;
   });
-  const [defaultColor] = useState(() => themeColor("--palette-common-black"));
+  const defaultColor = themeColor("--palette-common-black");
   const [borderColor, setBorderColor] = useState<Color>(() => {
     const firstSide =
       style.border.top ??

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/EditNamedStyle.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/EditNamedStyle.tsx
@@ -36,7 +36,7 @@ import { STYLE_OPTIONS as LINE_STYLE_OPTIONS } from "../../BorderPicker/LineStyl
 import { Button } from "../../Button/Button";
 import { IconButton } from "../../Button/IconButton";
 import ColorPicker from "../../ColorPicker/ColorPicker";
-import { resolveColorToHex } from "../../ColorPicker/util";
+import { resolveColorToHex, themeColor } from "../../ColorPicker/util";
 import { NumberFormats } from "../../FormatMenu/formatUtil";
 import { Input } from "../../Input/Input";
 import { Menu } from "../../Menu/Menu";
@@ -151,9 +151,6 @@ function initFormatStyle(model: Model, style: CellStyle): FormatStyle {
 
 const CUSTOM_VALUE = "__custom__";
 
-// --palette-common-black, same default as the toolbar's BorderPicker
-const DEFAULT_BORDER_COLOR = "#272525";
-
 const EditNamedStyle = ({
   model,
   name: initialName,
@@ -243,13 +240,14 @@ const EditNamedStyle = ({
       style.border.left;
     return (firstSide?.style as BorderStyle) || BorderStyle.Thin;
   });
+  const [defaultColor] = useState(() => themeColor("--palette-common-black"));
   const [borderColor, setBorderColor] = useState<Color>(() => {
     const firstSide =
       style.border.top ??
       style.border.right ??
       style.border.bottom ??
       style.border.left;
-    return firstSide?.color ?? DEFAULT_BORDER_COLOR;
+    return firstSide?.color ?? defaultColor;
   });
   const [fontColorOpen, setFontColorOpen] = useState(false);
   const [fillColorOpen, setFillColorOpen] = useState(false);
@@ -537,7 +535,7 @@ const EditNamedStyle = ({
                         resolveColorToHex(
                           formatStyle.fontColor,
                           currentTheme,
-                        ) || "#000000",
+                        ) || defaultColor,
                     }}
                     onClick={() => setFontColorOpen(true)}
                     aria-label={t("toolbar.font_color")}
@@ -545,7 +543,7 @@ const EditNamedStyle = ({
                 </div>
                 <ColorPicker
                   color={formatStyle.fontColor}
-                  defaultColor="#000000"
+                  defaultColor={defaultColor}
                   title={t("color_picker.default")}
                   onChange={(color) => {
                     setFormatStyle((current) => ({
@@ -812,7 +810,7 @@ const EditNamedStyle = ({
                       style={{
                         backgroundColor:
                           resolveColorToHex(borderColor, currentTheme) ||
-                          DEFAULT_BORDER_COLOR,
+                          defaultColor,
                       }}
                       onClick={() => setBorderColorOpen(true)}
                       aria-label={t("toolbar.borders.color")}
@@ -820,7 +818,7 @@ const EditNamedStyle = ({
                   </div>
                   <ColorPicker
                     color={borderColor}
-                    defaultColor={DEFAULT_BORDER_COLOR}
+                    defaultColor={defaultColor}
                     title={t("color_picker.default")}
                     onChange={(color) => {
                       setBorderColor(color);

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/named-styles.css
@@ -193,6 +193,7 @@
   line-height: 1;
   font-family: var(--typography-font-family);
   font-weight: 400;
+  color: var(--palette-common-black);
 }
 
 .ic-named-styles-manage-item-name {

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -1995,6 +1995,9 @@ export default class WorksheetCanvas {
     const frozenOffset = frozenSeparatorWidth / 2;
     // If there are frozen rows draw a separator
     if (frozenRows) {
+      // Grid line of the last frozen row, no cell below it draws it
+      context.fillStyle = this.theme.gridSeparatorColor;
+      context.fillRect(0, y - 1, this.width, 1);
       context.beginPath();
       context.lineWidth = frozenSeparatorWidth;
       context.strokeStyle = this.theme.gridSeparatorColor;
@@ -2007,6 +2010,9 @@ export default class WorksheetCanvas {
 
     // If there are frozen columns draw a separator
     if (frozenColumns) {
+      // Grid line of the last frozen column, no cell to its right draws it
+      context.fillStyle = this.theme.gridSeparatorColor;
+      context.fillRect(x - 1, 0, 1, this.height);
       context.beginPath();
       context.lineWidth = frozenSeparatorWidth;
       context.strokeStyle = this.theme.gridSeparatorColor;

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -1997,7 +1997,7 @@ export default class WorksheetCanvas {
     if (frozenRows) {
       // Grid line of the last frozen row, no cell below it draws it
       context.fillStyle = this.theme.gridSeparatorColor;
-      context.fillRect(0, y - 1, this.width, 1);
+      context.fillRect(0, Math.max(0, Math.round(y) - 1), this.width, 1);
       context.beginPath();
       context.lineWidth = frozenSeparatorWidth;
       context.strokeStyle = this.theme.gridSeparatorColor;
@@ -2010,9 +2010,9 @@ export default class WorksheetCanvas {
 
     // If there are frozen columns draw a separator
     if (frozenColumns) {
-      // Grid line of the last frozen column, no cell to its right draws it
+      // Grid line of the last frozen column, no cell to its right draws it.
       context.fillStyle = this.theme.gridSeparatorColor;
-      context.fillRect(x - 1, 0, 1, this.height);
+      context.fillRect(Math.max(0, Math.round(x) - 2), 0, 2, this.height);
       context.beginPath();
       context.lineWidth = frozenSeparatorWidth;
       context.strokeStyle = this.theme.gridSeparatorColor;

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -880,7 +880,7 @@ export default class WorksheetCanvas {
       );
       const borderLeftStyle = "thin";
       const leftStyle = leftExtended.style;
-      let borderLeftColor = null;
+      let borderLeftColor = this.theme.backgroundColor;
       if (style.fill.color) {
         borderLeftColor = this.model.resolveColor(style.fill.color);
       } else if (leftStyle.fill.color) {


### PR DESCRIPTION
This PR adds closes some undone tasks regarding dark mode support:

### 1. Frozen panes
We were still showing a white border on left and top of the frozen col/row separador. Turns out we were leaving that pixels empty, so we now draw a space on it and apply the right color depending on the theme.

before:
<img width="630" height="221" alt="image" src="https://github.com/user-attachments/assets/3f4e785a-ab00-43d9-88bf-c83218d09f23" />

after:
<img width="630" height="295" alt="image" src="https://github.com/user-attachments/assets/262b49e6-448a-4b9c-ad3e-ce8dce4a8cf8" />

### 2. Borders
We were still applying a dark color as default border color. This PR fixes that both in the normal border picker and in the border selector inside the Named Cell styles drawer. Also fixed the default font color in custom named styles.

before:
<img width="762" height="284" alt="image" src="https://github.com/user-attachments/assets/47550069-6684-4ecf-806e-449fa682cf05" />

after:
<img width="777" height="329" alt="image" src="https://github.com/user-attachments/assets/0c3d5827-ea6b-4f10-892b-4bbea33ca59d" />

### 3. Text overflow border
When cell content doesn't fit inside the cell and overflows, we hide the border between cells so the content doesn't appear cut off. As with the frozen panes we were showing and empty line, which was OK for the light mode but was too visible on the dark version.

before:
<img width="209" height="51" alt="image" src="https://github.com/user-attachments/assets/48da0598-429d-47b0-9aa2-05ed7078a6e0" />

after:
<img width="217" height="62" alt="image" src="https://github.com/user-attachments/assets/222f0a94-3042-48db-bc75-f438f756d906" />