### PR TITLE
XLOOKUP: support computed (array-constant) lookup and return arrays

### DIFF
--- a/base/src/functions/xlookup.rs
+++ b/base/src/functions/xlookup.rs
@@ -31,6 +31,45 @@ enum MatchMode {
     WildcardMatch = 2,
 }
 
+/// Which of the two array arguments of XLOOKUP is being evaluated. Excel
+/// reports a different error for each: a `lookup_array` that is not a range
+/// simply finds nothing (`#N/A`), while a `return_array` that is not a range,
+/// or that does not line up with the `lookup_array`, is an invalid argument
+/// (`#VALUE!`).
+#[derive(PartialEq, Clone, Copy)]
+enum VectorArgument {
+    LookupArray,
+    ReturnArray,
+}
+
+impl VectorArgument {
+    fn not_a_vector_error(self, cell: CellReferenceIndex) -> CalcResult {
+        match self {
+            VectorArgument::LookupArray => CalcResult::Error {
+                error: Error::ERROR,
+                origin: cell,
+                message: "Second argument must be a vector".to_string(),
+            },
+            VectorArgument::ReturnArray => CalcResult::Error {
+                error: Error::VALUE,
+                origin: cell,
+                message: "Arrays must be of the same size".to_string(),
+            },
+        }
+    }
+
+    fn not_a_range_error(self, cell: CellReferenceIndex) -> CalcResult {
+        CalcResult::Error {
+            error: match self {
+                VectorArgument::LookupArray => Error::NA,
+                VectorArgument::ReturnArray => Error::VALUE,
+            },
+            origin: cell,
+            message: "Range expected".to_string(),
+        }
+    }
+}
+
 // lookup_value in array, match_mode search_mode
 fn linear_search(
     lookup_value: &CalcResult,
@@ -219,11 +258,11 @@ impl<'a> Model<'a> {
         // Materialise lookup_array (args[1]) and return_array (args[2]) into flat
         // vectors so a range reference or an in-formula array constant (e.g.
         // `A1:A2&"|"&B1:B2`) is handled the same way. See issue #1338.
-        let lookup_array = match self.xlookup_vector(&args[1], cell) {
+        let lookup_array = match self.xlookup_vector(&args[1], cell, VectorArgument::LookupArray) {
             Ok(v) => v,
             Err(e) => return e,
         };
-        let return_array = match self.xlookup_vector(&args[2], cell) {
+        let return_array = match self.xlookup_vector(&args[2], cell, VectorArgument::ReturnArray) {
             Ok(v) => v,
             Err(e) => return e,
         };
@@ -287,6 +326,7 @@ impl<'a> Model<'a> {
         &mut self,
         node: &Node,
         cell: CellReferenceIndex,
+        argument: VectorArgument,
     ) -> Result<Vec<CalcResult>, CalcResult> {
         match self.evaluate_node_in_context(node, cell) {
             CalcResult::Range { left, right } => {
@@ -295,11 +335,7 @@ impl<'a> Model<'a> {
                 } else if left.column == right.column {
                     true
                 } else {
-                    return Err(CalcResult::Error {
-                        error: Error::ERROR,
-                        origin: cell,
-                        message: "Second argument must be a vector".to_string(),
-                    });
+                    return Err(argument.not_a_vector_error(cell));
                 };
                 let mut row2 = right.row;
                 let mut column2 = right.column;
@@ -340,11 +376,7 @@ impl<'a> Model<'a> {
                 let is_row_vec = n_rows == 1;
                 let is_col_vec = n_cols == 1;
                 if n_rows == 0 || n_cols == 0 || (!is_row_vec && !is_col_vec) {
-                    return Err(CalcResult::Error {
-                        error: Error::ERROR,
-                        origin: cell,
-                        message: "Second argument must be a vector".to_string(),
-                    });
+                    return Err(argument.not_a_vector_error(cell));
                 }
                 Ok(rows
                     .iter()
@@ -353,11 +385,7 @@ impl<'a> Model<'a> {
                     .collect())
             }
             error @ CalcResult::Error { .. } => Err(error),
-            _ => Err(CalcResult::Error {
-                error: Error::NA,
-                origin: cell,
-                message: "Range expected".to_string(),
-            }),
+            _ => Err(argument.not_a_range_error(cell)),
         }
     }
 }

--- a/base/src/functions/xlookup.rs
+++ b/base/src/functions/xlookup.rs
@@ -1,7 +1,10 @@
 use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::expressions::types::CellReferenceIndex;
 use crate::{
-    calc_result::CalcResult, expressions::parser::Node, expressions::token::Error, model::Model,
+    calc_result::CalcResult,
+    expressions::parser::{ArrayNode, Node},
+    expressions::token::Error,
+    model::Model,
 };
 
 use super::{
@@ -12,7 +15,7 @@ use super::{
     util::{compare_values, from_wildcard_to_regex, result_matches_regex},
 };
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone, Copy)]
 enum SearchMode {
     StartAtFirstItem = 1,
     StartAtLastItem = -1,
@@ -20,7 +23,7 @@ enum SearchMode {
     BinarySearchAscending = 2,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone, Copy)]
 enum MatchMode {
     ExactMatchSmaller = -1,
     ExactMatch = 0,
@@ -213,178 +216,162 @@ impl<'a> Model<'a> {
             // default
             SearchMode::StartAtFirstItem
         };
-        // lookup_array
-        match self.evaluate_node_in_context(&args[1], cell) {
-            CalcResult::Range { left, right } => {
-                let is_row_vector;
-                if left.row == right.row {
-                    is_row_vector = false;
-                } else if left.column == right.column {
-                    is_row_vector = true;
-                } else {
-                    // second argument must be a vector
-                    return CalcResult::Error {
-                        error: Error::ERROR,
-                        origin: cell,
-                        message: "Second argument must be a vector".to_string(),
-                    };
+        // Materialise lookup_array (args[1]) and return_array (args[2]) into flat
+        // vectors so a range reference or an in-formula array constant (e.g.
+        // `A1:A2&"|"&B1:B2`) is handled the same way. See issue #1338.
+        let lookup_array = match self.xlookup_vector(&args[1], cell) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let return_array = match self.xlookup_vector(&args[2], cell) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        if lookup_array.len() != return_array.len() {
+            return CalcResult::Error {
+                error: Error::VALUE,
+                origin: cell,
+                message: "Arrays must be of the same size".to_string(),
+            };
+        }
+        match search_mode {
+            SearchMode::StartAtFirstItem | SearchMode::StartAtLastItem => {
+                match linear_search(&lookup_value, &lookup_array, search_mode, match_mode) {
+                    Some(index) => return_array[index].clone(),
+                    None => if_not_found,
                 }
-                // return array
-                match self.evaluate_node_in_context(&args[2], cell) {
-                    CalcResult::Range {
-                        left: result_left,
-                        right: result_right,
-                    } => {
-                        if result_right.row - result_left.row != right.row - left.row
-                            || result_right.column - result_left.column
-                                != right.column - left.column
+            }
+            SearchMode::BinarySearchAscending | SearchMode::BinarySearchDescending => {
+                let index = if match_mode == MatchMode::ExactMatchLarger {
+                    if search_mode == SearchMode::BinarySearchAscending {
+                        binary_search_or_greater(&lookup_value, &lookup_array)
+                    } else {
+                        binary_search_descending_or_greater(&lookup_value, &lookup_array)
+                    }
+                } else if search_mode == SearchMode::BinarySearchAscending {
+                    binary_search_or_smaller(&lookup_value, &lookup_array)
+                } else {
+                    binary_search_descending_or_smaller(&lookup_value, &lookup_array)
+                };
+                match index {
+                    None => if_not_found,
+                    Some(l) => {
+                        let l = l as usize;
+                        if match_mode == MatchMode::ExactMatch {
+                            if compare_values(&lookup_array[l], &lookup_value) == 0 {
+                                return_array[l].clone()
+                            } else {
+                                if_not_found
+                            }
+                        } else if match_mode == MatchMode::ExactMatchSmaller
+                            || match_mode == MatchMode::ExactMatchLarger
                         {
-                            return CalcResult::Error {
+                            return_array[l].clone()
+                        } else {
+                            CalcResult::Error {
                                 error: Error::VALUE,
                                 origin: cell,
-                                message: "Arrays must be of the same size".to_string(),
-                            };
-                        }
-                        let mut row2 = right.row;
-                        let row1 = left.row;
-                        let mut column2 = right.column;
-                        let column1 = left.column;
-
-                        if row1 == 1 && row2 == LAST_ROW {
-                            row2 = match self.workbook.worksheet(left.sheet) {
-                                Ok(s) => s.dimension().max_row,
-                                Err(_) => {
-                                    return CalcResult::new_error(
-                                        Error::ERROR,
-                                        cell,
-                                        format!("Invalid worksheet index: '{}'", left.sheet),
-                                    );
-                                }
-                            };
-                        }
-                        if column1 == 1 && column2 == LAST_COLUMN {
-                            column2 = match self.workbook.worksheet(left.sheet) {
-                                Ok(s) => s.dimension().max_column,
-                                Err(_) => {
-                                    return CalcResult::new_error(
-                                        Error::ERROR,
-                                        cell,
-                                        format!("Invalid worksheet index: '{}'", left.sheet),
-                                    );
-                                }
-                            };
-                        }
-                        let left = CellReferenceIndex {
-                            sheet: left.sheet,
-                            column: column1,
-                            row: row1,
-                        };
-                        let right = CellReferenceIndex {
-                            sheet: left.sheet,
-                            column: column2,
-                            row: row2,
-                        };
-                        match search_mode {
-                            SearchMode::StartAtFirstItem | SearchMode::StartAtLastItem => {
-                                let array = &self.prepare_array(&left, &right, is_row_vector);
-                                match linear_search(&lookup_value, array, search_mode, match_mode) {
-                                    Some(index) => {
-                                        let row_index =
-                                            if is_row_vector { index as i32 } else { 0 };
-                                        let column_index =
-                                            if is_row_vector { 0 } else { index as i32 };
-                                        self.evaluate_cell(CellReferenceIndex {
-                                            sheet: result_left.sheet,
-                                            row: result_left.row + row_index,
-                                            column: result_left.column + column_index,
-                                        })
-                                    }
-                                    None => if_not_found,
-                                }
-                            }
-                            SearchMode::BinarySearchAscending
-                            | SearchMode::BinarySearchDescending => {
-                                let index = if match_mode == MatchMode::ExactMatchLarger {
-                                    if search_mode == SearchMode::BinarySearchAscending {
-                                        binary_search_or_greater(
-                                            &lookup_value,
-                                            &self.prepare_array(&left, &right, is_row_vector),
-                                        )
-                                    } else {
-                                        binary_search_descending_or_greater(
-                                            &lookup_value,
-                                            &self.prepare_array(&left, &right, is_row_vector),
-                                        )
-                                    }
-                                } else if search_mode == SearchMode::BinarySearchAscending {
-                                    binary_search_or_smaller(
-                                        &lookup_value,
-                                        &self.prepare_array(&left, &right, is_row_vector),
-                                    )
-                                } else {
-                                    binary_search_descending_or_smaller(
-                                        &lookup_value,
-                                        &self.prepare_array(&left, &right, is_row_vector),
-                                    )
-                                };
-                                match index {
-                                    None => if_not_found,
-                                    Some(l) => {
-                                        let row =
-                                            result_left.row + if is_row_vector { l } else { 0 };
-                                        let column =
-                                            result_left.column + if is_row_vector { 0 } else { l };
-                                        if match_mode == MatchMode::ExactMatch {
-                                            let value = self.evaluate_cell(CellReferenceIndex {
-                                                sheet: left.sheet,
-                                                row: left.row + if is_row_vector { l } else { 0 },
-                                                column: left.column
-                                                    + if is_row_vector { 0 } else { l },
-                                            });
-                                            if compare_values(&value, &lookup_value) == 0 {
-                                                self.evaluate_cell(CellReferenceIndex {
-                                                    sheet: result_left.sheet,
-                                                    row,
-                                                    column,
-                                                })
-                                            } else {
-                                                if_not_found
-                                            }
-                                        } else if match_mode == MatchMode::ExactMatchSmaller
-                                            || match_mode == MatchMode::ExactMatchLarger
-                                        {
-                                            self.evaluate_cell(CellReferenceIndex {
-                                                sheet: result_left.sheet,
-                                                row,
-                                                column,
-                                            })
-                                        } else {
-                                            CalcResult::Error {
-                                                error: Error::VALUE,
-                                                origin: cell,
-                                                message: "Cannot use wildcard in binary search"
-                                                    .to_string(),
-                                            }
-                                        }
-                                    }
-                                }
+                                message: "Cannot use wildcard in binary search".to_string(),
                             }
                         }
                     }
-                    error @ CalcResult::Error { .. } => error,
-                    _ => CalcResult::Error {
-                        error: Error::VALUE,
-                        origin: cell,
-                        message: "Range expected".to_string(),
-                    },
                 }
             }
-            error @ CalcResult::Error { .. } => error,
-            _ => CalcResult::Error {
+        }
+    }
+
+    /// Evaluates `node` and materialises it into a flat vector of values for the
+    /// XLOOKUP family. The argument must be a single-row or single-column range
+    /// reference, or an in-formula array constant of the same shape (issue #1338).
+    fn xlookup_vector(
+        &mut self,
+        node: &Node,
+        cell: CellReferenceIndex,
+    ) -> Result<Vec<CalcResult>, CalcResult> {
+        match self.evaluate_node_in_context(node, cell) {
+            CalcResult::Range { left, right } => {
+                let is_row_vector = if left.row == right.row {
+                    false
+                } else if left.column == right.column {
+                    true
+                } else {
+                    return Err(CalcResult::Error {
+                        error: Error::ERROR,
+                        origin: cell,
+                        message: "Second argument must be a vector".to_string(),
+                    });
+                };
+                let mut row2 = right.row;
+                let mut column2 = right.column;
+                if left.row == 1 && row2 == LAST_ROW {
+                    row2 = match self.workbook.worksheet(left.sheet) {
+                        Ok(s) => s.dimension().max_row,
+                        Err(_) => {
+                            return Err(CalcResult::new_error(
+                                Error::ERROR,
+                                cell,
+                                format!("Invalid worksheet index: '{}'", left.sheet),
+                            ))
+                        }
+                    };
+                }
+                if left.column == 1 && column2 == LAST_COLUMN {
+                    column2 = match self.workbook.worksheet(left.sheet) {
+                        Ok(s) => s.dimension().max_column,
+                        Err(_) => {
+                            return Err(CalcResult::new_error(
+                                Error::ERROR,
+                                cell,
+                                format!("Invalid worksheet index: '{}'", left.sheet),
+                            ))
+                        }
+                    };
+                }
+                let right = CellReferenceIndex {
+                    sheet: left.sheet,
+                    row: row2,
+                    column: column2,
+                };
+                Ok(self.prepare_array(&left, &right, is_row_vector))
+            }
+            CalcResult::Array(rows) => {
+                let n_rows = rows.len();
+                let n_cols = rows.first().map(|r| r.len()).unwrap_or(0);
+                let is_row_vec = n_rows == 1;
+                let is_col_vec = n_cols == 1;
+                if n_rows == 0 || n_cols == 0 || (!is_row_vec && !is_col_vec) {
+                    return Err(CalcResult::Error {
+                        error: Error::ERROR,
+                        origin: cell,
+                        message: "Second argument must be a vector".to_string(),
+                    });
+                }
+                Ok(rows
+                    .iter()
+                    .flatten()
+                    .map(|array_node| array_node_to_calc_result(array_node, cell))
+                    .collect())
+            }
+            error @ CalcResult::Error { .. } => Err(error),
+            _ => Err(CalcResult::Error {
                 error: Error::NA,
                 origin: cell,
                 message: "Range expected".to_string(),
-            },
+            }),
         }
+    }
+}
+
+fn array_node_to_calc_result(node: &ArrayNode, cell: CellReferenceIndex) -> CalcResult {
+    match node {
+        ArrayNode::Number(n) => CalcResult::Number(*n),
+        ArrayNode::Boolean(b) => CalcResult::Boolean(*b),
+        ArrayNode::String(s) => CalcResult::String(s.clone()),
+        ArrayNode::Error(e) => CalcResult::Error {
+            error: e.clone(),
+            origin: cell,
+            message: "".to_string(),
+        },
+        ArrayNode::Empty => CalcResult::EmptyCell,
     }
 }

--- a/base/src/test/lookup_and_reference/mod.rs
+++ b/base/src/test/lookup_and_reference/mod.rs
@@ -9,4 +9,5 @@ mod test_fn_match;
 mod test_fn_trimrange;
 mod test_fn_vlookup;
 mod test_fn_wrapcols_wraprows;
+mod test_fn_xlookup;
 mod test_fn_xmatch;

--- a/base/src/test/lookup_and_reference/test_fn_xlookup.rs
+++ b/base/src/test/lookup_and_reference/test_fn_xlookup.rs
@@ -74,3 +74,69 @@ fn test_xlookup_approximate_and_binary() {
     assert_eq!(model._get_text("D1"), "twenty");
     assert_eq!(model._get_text("D2"), "thirty");
 }
+
+// A bad argument is #VALUE!, a lookup that finds nothing is #N/A. See the
+// `Errors` sheet of xlsx/tests/calc_tests/LOOKUP_AND_REFERENCE/XLOOKUP.xlsx.
+
+#[test]
+fn test_xlookup_scalar_return_array_is_value_error() {
+    let mut model = new_empty_model();
+    model._set("A1", "apple");
+    model._set("A2", "banana");
+    model._set("D1", "=XLOOKUP(\"banana\",A1:A2,TRUE)");
+    model._set("D2", "=XLOOKUP(\"banana\",A1:A2,3)");
+    // Not found, so the scalar return_array is never read: still #VALUE!.
+    model._set("D3", "=XLOOKUP(\"missing\",A1:A2,3)");
+    model.evaluate();
+    assert_eq!(model._get_text("D1"), "#VALUE!");
+    assert_eq!(model._get_text("D2"), "#VALUE!");
+    assert_eq!(model._get_text("D3"), "#VALUE!");
+}
+
+#[test]
+fn test_xlookup_scalar_lookup_array_is_na() {
+    let mut model = new_empty_model();
+    model._set("B1", "one");
+    model._set("B2", "two");
+    model._set("D1", "=XLOOKUP(\"banana\",3,B1:B2)");
+    model.evaluate();
+    assert_eq!(model._get_text("D1"), "#N/A");
+}
+
+#[test]
+fn test_xlookup_arrays_of_different_sizes_is_value_error() {
+    let mut model = new_empty_model();
+    model._set("A1", "1");
+    model._set("A2", "2");
+    model._set("A3", "3");
+    model._set("A4", "4");
+    model._set("B1", "a");
+    model._set("B2", "b");
+    model._set("B3", "c");
+    model._set("C1", "x");
+    // Column vectors of length 4 and 3.
+    model._set("D1", "=XLOOKUP(1,A1:A4,B1:B3)");
+    // A two dimensional return_array does not line up with a vector.
+    model._set("D2", "=XLOOKUP(1,A1:A3,B1:C3)");
+    // Same for an array constant.
+    model._set("D3", "=XLOOKUP(1,A1:A3,{10;20})");
+    model.evaluate();
+    assert_eq!(model._get_text("D1"), "#VALUE!");
+    assert_eq!(model._get_text("D2"), "#VALUE!");
+    assert_eq!(model._get_text("D3"), "#VALUE!");
+}
+
+#[test]
+fn test_xlookup_not_found_is_still_na() {
+    // The #VALUE! cases above must not swallow a plain "no match" result.
+    let mut model = new_empty_model();
+    model._set("A1", "apple");
+    model._set("A2", "banana");
+    model._set("B1", "1");
+    model._set("B2", "2");
+    model._set("D1", "=XLOOKUP(\"cherry\",A1:A2,B1:B2)");
+    model._set("D2", "=XLOOKUP(\"cherry\",A1:A2,{10;20})");
+    model.evaluate();
+    assert_eq!(model._get_text("D1"), "#N/A");
+    assert_eq!(model._get_text("D2"), "#N/A");
+}

--- a/base/src/test/lookup_and_reference/test_fn_xlookup.rs
+++ b/base/src/test/lookup_and_reference/test_fn_xlookup.rs
@@ -1,0 +1,76 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+fn setup() -> crate::model::Model<'static> {
+    let mut model = new_empty_model();
+    model._set("A1", "a");
+    model._set("A2", "b");
+    model._set("B1", "x");
+    model._set("B2", "y");
+    model._set("C1", "first");
+    model._set("C2", "second");
+    model
+}
+
+#[test]
+fn test_xlookup_range_basic() {
+    let mut model = new_empty_model();
+    model._set("A1", "apple");
+    model._set("A2", "banana");
+    model._set("A3", "cherry");
+    model._set("B1", "1");
+    model._set("B2", "2");
+    model._set("B3", "3");
+    model._set("D1", "=XLOOKUP(\"banana\",A1:A3,B1:B3)");
+    model._set("D2", "=XLOOKUP(\"missing\",A1:A3,B1:B3)");
+    model._set("D3", "=XLOOKUP(\"missing\",A1:A3,B1:B3,\"nope\")");
+    model.evaluate();
+    assert_eq!(model._get_text("D1"), "2");
+    assert_eq!(model._get_text("D2"), "#N/A");
+    assert_eq!(model._get_text("D3"), "nope");
+}
+
+#[test]
+fn test_xlookup_computed_lookup_array() {
+    // A computed lookup_array must be searchable, not just a range reference (#1338).
+    let mut model = setup();
+    model._set("E1", "=XLOOKUP(\"b|y\",A1:A2&\"|\"&B1:B2,C1:C2)");
+    model._set(
+        "E2",
+        "=XLOOKUP(\"z|z\",A1:A2&\"|\"&B1:B2,C1:C2,\"fallback\")",
+    );
+    model.evaluate();
+    assert_eq!(model._get_text("E1"), "second");
+    assert_eq!(model._get_text("E2"), "fallback");
+}
+
+#[test]
+fn test_xlookup_computed_return_array() {
+    // A computed return_array (array constant) must also be indexable (#1338).
+    let mut model = new_empty_model();
+    model._set("A1", "apple");
+    model._set("A2", "banana");
+    model._set("A3", "cherry");
+    model._set("D1", "=XLOOKUP(\"banana\",A1:A3,{10;20;30})");
+    model.evaluate();
+    assert_eq!(model._get_text("D1"), "20");
+}
+
+#[test]
+fn test_xlookup_approximate_and_binary() {
+    let mut model = new_empty_model();
+    model._set("A1", "10");
+    model._set("A2", "20");
+    model._set("A3", "30");
+    model._set("B1", "ten");
+    model._set("B2", "twenty");
+    model._set("B3", "thirty");
+    // exact-or-next-smaller (match_mode -1): 25 -> 20 -> "twenty"
+    model._set("D1", "=XLOOKUP(25,A1:A3,B1:B3,,-1)");
+    // binary search ascending (search_mode 2), exact
+    model._set("D2", "=XLOOKUP(30,A1:A3,B1:B3,,0,2)");
+    model.evaluate();
+    assert_eq!(model._get_text("D1"), "twenty");
+    assert_eq!(model._get_text("D2"), "thirty");
+}


### PR DESCRIPTION
### Summary

Fixes #1338. `XLOOKUP` returns `#N/A` when `lookup_array` is a computed array (and `#VALUE!` when `return_array` is one), because it only handled arguments that evaluate to a range reference.

### Root cause

`fn_xlookup` matched `lookup_array` (args[1]) and `return_array` (args[2]) only against `CalcResult::Range`. A computed array such as `A1:A2&"|"&B1:B2` evaluates to `CalcResult::Array`, so it fell through to the catch-all arm and returned `#N/A` directly — which also bypassed `if_not_found`. A computed `return_array` hit the inner catch-all and returned `#VALUE!`.

```
=XLOOKUP("b|y", A1:A2&"|"&B1:B2, C1:C2)   → #N/A   (should find the match)
=XMATCH("b|y", A1:A2&"|"&B1:B2)           → 2      (sibling already works)
```

### Fix

Materialise both `lookup_array` and `return_array` into a flat `Vec<CalcResult>` (`xlookup_vector`), handling a range reference (via `prepare_array`, with the existing entire-column/row clamping and single-row/column validation) and an in-formula array constant (via `array_node_to_calc_result`) the same way `XMATCH` already does. The search then runs on the lookup vector and the result is taken by index from the return vector.

This unifies the previously range-only path (net fewer lines) and leaves range/range behaviour unchanged.

### Tests

`XLOOKUP` had no tests, so this adds `test_fn_xlookup.rs` covering:
- range/range exact match, not-found (`#N/A`), and `if_not_found`;
- computed `lookup_array` (the reported case), including `if_not_found`;
- computed `return_array` (`{10;20;30}`);
- approximate match (`match_mode=-1`) and binary search (`search_mode=2`).

### Verification (local, in Docker)

- `cargo test -p ironcalc_base` — 2283 + 23 tests pass, 0 failures (the four new tests included; no regressions).
- `cargo clippy -p ironcalc_base --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

---

Disclosure: this fix was prepared with AI assistance (Claude). I reviewed it, mirrored the established `XMATCH` approach, and verified the red-green tests and full suite myself.
