### PR TITLE
FIX: number format date/time tokens must be case-insensitive

### DIFF
--- a/base/src/formatter/lexer.rs
+++ b/base/src/formatter/lexer.rs
@@ -434,11 +434,15 @@ impl Lexer {
                         Token::ILLEGAL
                     }
                 }
-                'd' => {
+                'd' | 'D' => {
                     let mut d = 1;
-                    while let Some('d') = self.peek_char() {
-                        d += 1;
-                        self.read_next_char();
+                    while let Some(c) = self.peek_char() {
+                        if c.eq_ignore_ascii_case(&'d') {
+                            d += 1;
+                            self.read_next_char();
+                        } else {
+                            break;
+                        }
                     }
                     match d {
                         1 => Token::Day,
@@ -447,11 +451,15 @@ impl Lexer {
                         _ => Token::DayName,
                     }
                 }
-                'm' => {
+                'm' | 'M' => {
                     let mut m = 1;
-                    while let Some('m') = self.peek_char() {
-                        m += 1;
-                        self.read_next_char();
+                    while let Some(c) = self.peek_char() {
+                        if c.eq_ignore_ascii_case(&'m') {
+                            m += 1;
+                            self.read_next_char();
+                        } else {
+                            break;
+                        }
                     }
                     match m {
                         1 => Token::Month,       // (or minute)
@@ -462,11 +470,15 @@ impl Lexer {
                         _ => Token::MonthName,
                     }
                 }
-                'y' => {
+                'y' | 'Y' => {
                     let mut y = 1;
-                    while let Some('y') = self.peek_char() {
-                        y += 1;
-                        self.read_next_char();
+                    while let Some(c) = self.peek_char() {
+                        if c.eq_ignore_ascii_case(&'y') {
+                            y += 1;
+                            self.read_next_char();
+                        } else {
+                            break;
+                        }
                     }
                     if y == 1 || y == 2 {
                         Token::YearShort
@@ -493,11 +505,15 @@ impl Lexer {
                         Token::ILLEGAL
                     }
                 }
-                's' => {
+                's' | 'S' => {
                     let mut s = 1;
-                    while let Some('s') = self.peek_char() {
-                        s += 1;
-                        self.read_next_char();
+                    while let Some(c) = self.peek_char() {
+                        if c.eq_ignore_ascii_case(&'s') {
+                            s += 1;
+                            self.read_next_char();
+                        } else {
+                            break;
+                        }
                     }
                     if s == 1 {
                         Token::Second

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -113,6 +113,7 @@ mod test_fn_scan;
 mod test_fn_tocol_torow;
 mod test_fn_transpose;
 mod test_fn_type;
+mod test_format_case;
 mod test_frozen_rows_and_columns;
 mod test_geomean;
 mod test_get_cell_content;

--- a/base/src/test/test_format_case.rs
+++ b/base/src/test/test_format_case.rs
@@ -14,6 +14,11 @@ fn test_text_uppercase_date_tokens() {
     model._set("A5", r#"=TEXT(45000,"MMM")"#);
     model._set("A6", r#"=TEXT(45000,"D")"#);
     model._set("A7", r#"=TEXT(45000,"MMM-YY")"#);
+    model._set("B3", r#"=TEXT(45000,"mm/dd/yyyy")"#);
+    model._set("B4", r#"=TEXT(45000,"yyyy")"#);
+    model._set("B5", r#"=TEXT(45000,"mmm")"#);
+    model._set("B6", r#"=TEXT(45000,"d")"#);
+    model._set("B7", r#"=TEXT(45000,"mmm-yy")"#);
     model.evaluate();
     let lower = model._get_text("A1");
     assert_eq!(model._get_text("A2"), lower);
@@ -22,6 +27,12 @@ fn test_text_uppercase_date_tokens() {
     assert_eq!(model._get_text("A5"), "Mar");
     assert_eq!(model._get_text("A6"), "15");
     assert_eq!(model._get_text("A7"), "Mar-23");
+    // Each upper-case format must match its lower-case counterpart.
+    assert_eq!(model._get_text("B3"), model._get_text("A3"));
+    assert_eq!(model._get_text("B4"), model._get_text("A4"));
+    assert_eq!(model._get_text("B5"), model._get_text("A5"));
+    assert_eq!(model._get_text("B6"), model._get_text("A6"));
+    assert_eq!(model._get_text("B7"), model._get_text("A7"));
 }
 
 #[test]

--- a/base/src/test/test_format_case.rs
+++ b/base/src/test/test_format_case.rs
@@ -1,0 +1,38 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+// Excel date-format tokens are case-insensitive: M/D/YYYY behaves like
+// m/d/yyyy, including the month-vs-minute disambiguation.
+#[test]
+fn test_text_uppercase_date_tokens() {
+    let mut model = new_empty_model();
+    model._set("A1", r#"=TEXT(45000,"m/d/yyyy")"#);
+    model._set("A2", r#"=TEXT(45000,"M/D/YYYY")"#);
+    model._set("A3", r#"=TEXT(45000,"MM/DD/YYYY")"#);
+    model._set("A4", r#"=TEXT(45000,"YYYY")"#);
+    model._set("A5", r#"=TEXT(45000,"MMM")"#);
+    model._set("A6", r#"=TEXT(45000,"D")"#);
+    model._set("A7", r#"=TEXT(45000,"MMM-YY")"#);
+    model.evaluate();
+    let lower = model._get_text("A1");
+    assert_eq!(model._get_text("A2"), lower);
+    assert!(!model._get_text("A3").starts_with('#'));
+    assert_eq!(model._get_text("A4"), "2023");
+    assert_eq!(model._get_text("A5"), "Mar");
+    assert_eq!(model._get_text("A6"), "15");
+    assert_eq!(model._get_text("A7"), "Mar-23");
+}
+
+#[test]
+fn test_text_uppercase_minutes_disambiguation() {
+    let mut model = new_empty_model();
+    model._set("A1", r#"=TEXT(45000.526,"hh:mm:ss")"#);
+    model._set("A2", r#"=TEXT(45000.526,"hh:MM:SS")"#);
+    model._set("A3", r#"=TEXT(45000.526,"MM/DD/YYYY hh:MM:SS")"#);
+    model.evaluate();
+    let lower = model._get_text("A1");
+    assert_eq!(model._get_text("A2"), lower);
+    let combined = model._get_text("A3");
+    assert!(combined.ends_with(&lower), "got {combined}");
+}


### PR DESCRIPTION
## Problem

A number format code written in upper case renders as `#VALUE!`. Excel treats
format codes as case-insensitive, and upper-case forms are common in files
written both by Excel and by third-party writers. The format lexer matches the
date/time token heads as the literal lower-case characters `'d'`, `'m'`, `'y'`,
`'s'` and consumes repeats the same way, so anything it cannot tokenise falls
through to `#VALUE!`.

### Repro

| formula | Excel | IronCalc `main` |
|---|---|---|
| `=TEXT(45000, "m/d/yyyy")` (control) | `3/15/2023` | `3/15/2023` |
| `=TEXT(45000, "M/D/YYYY")` | `3/15/2023` | `#VALUE!` |
| `=TEXT(45000, "DD-MMM-YY")` | `15-Mar-23` | `#VALUE!` |
| `=TEXT(0.5, "H:MM AM/PM")` | `12:00 PM` | `#VALUE!` |

The same applies to a cell's `numFmt` string, not just `TEXT`.

Every expected value was read back from desktop Excel (Microsoft 365).

## Fix

Match the four token heads as `'d' | 'D'`, `'m' | 'M'`, `'y' | 'Y'`,
`'s' | 'S'`, and continue the repeat loop with `eq_ignore_ascii_case` so a
mixed-case run such as `Mmm` is consumed as one three-character token rather
than as `M` followed by `mm`.

The month-versus-minute disambiguation is untouched: it depends on the
neighbouring tokens, not on case, and Excel behaves the same way.

## Tests

`base/src/test/test_format_case.rs` (new):

- `test_text_uppercase_date_tokens` — `"M/D/YYYY"` matches `"m/d/yyyy"`, and
  `"MM/DD/YYYY"`, `"YYYY"`, `"MMM"`, `"D"`, `"MMM-YY"` all produce the expected
  strings rather than an error.
- `test_text_uppercase_minutes_disambiguation` — `"hh:MM:SS"` matches
  `"hh:mm:ss"`, and `"MM/DD/YYYY hh:MM:SS"` still reads the leading `MM` as
  month and the trailing `MM` as minutes, so the fix does not disturb the
  existing rule.

Both fail on `main` and pass with this change.