### PR TITLE
PERF: only rescan spill anchors whose shape changed

### DIFF
--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::vec::Vec;
 
 use crate::expressions::parser::static_analysis::run_static_analysis_on_node;
@@ -200,6 +200,11 @@ pub struct Model<'a> {
     pub(crate) parser: Parser<'a>,
     /// The list of cells with formulas that are evaluated or being evaluated
     pub(crate) cells: HashMap<(u32, i32, i32), CellState>,
+    /// Dynamic-array anchors whose spill area changed shape during the current
+    /// evaluation pass (grew, shrank or was newly created). Only these can
+    /// invalidate values already read by earlier spill cells, so only they
+    /// need the reorder scan in `evaluate` phase 1.
+    pub(crate) changed_spill_shapes: HashSet<(u32, i32, i32)>,
     /// The locale of the model
     pub(crate) locale: &'a Locale,
     /// The language used
@@ -931,7 +936,7 @@ impl<'a> Model<'a> {
             let array_height = array.len() as i32;
 
             match original_range {
-                Some((true, _)) => {
+                Some((true, previous_dims)) => {
                     if row + array_height - 1 > LAST_ROW || column + array_width - 1 > LAST_COLUMN {
                         return self.set_cells_with_result(
                             cell_reference,
@@ -1003,6 +1008,12 @@ impl<'a> Model<'a> {
                             };
                             worksheet.update_cell(r, c, cell)?;
                         }
+                    }
+                    // A spill that keeps its previous dimensions rewrote only
+                    // cells it already owned; only a shape change can
+                    // invalidate positions other cells have read.
+                    if previous_dims != (array_width, array_height) {
+                        self.changed_spill_shapes.insert((sheet, row, column));
                     }
                     return Ok(());
                 }
@@ -1199,6 +1210,14 @@ impl<'a> Model<'a> {
                         },
                     )?;
                 }
+            }
+        }
+
+        // A dynamic anchor that produced a scalar collapses to a 1x1 spill
+        // area; if it previously spilled wider, its shape changed.
+        if let Some((true, previous_dims)) = original_range {
+            if previous_dims != (1, 1) {
+                self.changed_spill_shapes.insert((sheet, row, column));
             }
         }
 
@@ -1710,6 +1729,7 @@ impl<'a> Model<'a> {
             parsed_defined_names: HashMap::new(),
             parser,
             cells,
+            changed_spill_shapes: HashSet::new(),
             language,
             locale,
             tz,
@@ -3045,6 +3065,7 @@ impl<'a> Model<'a> {
         while retry && restart_count < max_restarts {
             retry = false;
             self.cells.clear();
+            self.changed_spill_shapes.clear();
             self.support.clear();
             // dynamic links (HYPERLINK) are rebuilt on every evaluation
             self.links.clear();
@@ -3055,6 +3076,20 @@ impl<'a> Model<'a> {
             for i in 0..self.spill_cells.len() {
                 let spill_cell = self.spill_cells[i];
                 self.evaluate_cell(spill_cell);
+
+                // A spill that kept its previous shape only rewrote cells it
+                // already owned. Earlier spill cells that read one of those
+                // cells forced this anchor's evaluation on demand (see the
+                // `Cell::SpillCell` branch of `evaluate_cell`), so they saw
+                // fresh values and no reorder can be needed. Only a shape
+                // change can invalidate positions read as something else.
+                if !self.changed_spill_shapes.contains(&(
+                    spill_cell.sheet,
+                    spill_cell.row,
+                    spill_cell.column,
+                )) {
+                    continue;
+                }
 
                 // Find every cell position written by this spill (anchor + spill cells).
                 let spill_area = self.get_spill_area(spill_cell);

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -685,6 +685,7 @@ impl<'a> Model<'a> {
             parsed_defined_names: HashMap::new(),
             parser,
             cells,
+            changed_spill_shapes: std::collections::HashSet::new(),
             locale,
             language,
             tz,

--- a/base/src/test/dynamic_evaluation/mod.rs
+++ b/base/src/test/dynamic_evaluation/mod.rs
@@ -1,3 +1,4 @@
 mod test_evaluation_order;
 mod test_randarray;
+mod test_reorder_skip;
 mod test_wrong_order;

--- a/base/src/test/dynamic_evaluation/test_reorder_skip.rs
+++ b/base/src/test/dynamic_evaluation/test_reorder_skip.rs
@@ -1,0 +1,109 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+// A second evaluation of a model whose spill areas are already materialized
+// (the imported-workbook shape) must not flag any spill as changed: every
+// anchor keeps its dimensions, so the reorder scan is skipped entirely.
+#[test]
+fn second_evaluation_flags_no_shape_changes() {
+    let mut model = new_empty_model();
+
+    model._set("A1", "=B2+D2");
+    model._set("B1", "=D1:D2");
+    model._set("D1", "=E1:E2");
+    model._set("E1", "10");
+    model._set("E2", "20");
+
+    model.evaluate();
+    // The spill areas now exist with their final dimensions, like a workbook
+    // imported from xlsx. Re-evaluating must produce the same values.
+    model.evaluate();
+
+    assert_eq!(model._get_text("D1"), "10");
+    assert_eq!(model._get_text("D2"), "20");
+    assert_eq!(model._get_text("B1"), "10");
+    assert_eq!(model._get_text("B2"), "20");
+    assert_eq!(model._get_text("A1"), "40");
+    // No spill changed shape in the steady-state pass.
+    assert!(model.changed_spill_shapes.is_empty());
+}
+
+// Genuine reorder case: anchor B1 depends on anchor C1's spill area and is
+// listed first in natural order. On the first evaluation both spills change
+// shape (from 1x1), so the changed-shape path must still run the reorder scan
+// and converge to correct values.
+#[test]
+fn dependent_anchor_listed_first_still_reorders() {
+    let mut model = new_empty_model();
+
+    model._set("B1", "=C1:C3");
+    model._set("C1", "=SEQUENCE(3)");
+
+    model.evaluate();
+
+    assert_eq!(model._get_text("B1"), "1");
+    assert_eq!(model._get_text("B2"), "2");
+    assert_eq!(model._get_text("B3"), "3");
+    assert_eq!(model._get_text("C1"), "1");
+    assert_eq!(model._get_text("C2"), "2");
+    assert_eq!(model._get_text("C3"), "3");
+}
+
+// Shape grow and shrink across evaluations: the anchor is flagged as changed
+// on the passes where its dimensions move, and dependents stay correct.
+#[test]
+fn shape_grow_and_shrink() {
+    let mut model = new_empty_model();
+
+    model._set("B1", "=C1:C4");
+    model._set("C1", "=SEQUENCE(E1)");
+    model._set("E1", "2");
+
+    model.evaluate();
+    assert_eq!(model._get_text("C1"), "1");
+    assert_eq!(model._get_text("C2"), "2");
+    assert_eq!(model._get_text("C3"), "");
+    assert_eq!(model._get_text("B2"), "2");
+
+    // grow 2x1 -> 3x1
+    model._set("E1", "3");
+    model.evaluate();
+    assert_eq!(model._get_text("C3"), "3");
+    assert_eq!(model._get_text("B3"), "3");
+
+    // shrink 3x1 -> 1x1
+    model._set("E1", "1");
+    model.evaluate();
+    assert_eq!(model._get_text("C1"), "1");
+    assert_eq!(model._get_text("C2"), "");
+    assert_eq!(model._get_text("C3"), "");
+    assert_eq!(model._get_text("B1"), "1");
+    assert_eq!(model._get_text("B2"), "0");
+
+    // steady state after the shrink: nothing changes shape any more
+    model.evaluate();
+    assert!(model.changed_spill_shapes.is_empty());
+}
+
+// A dynamic anchor that collapses from a spilled area to a scalar result
+// (here via a #SPILL!-style shrink to an error/scalar) is flagged as changed
+// on that pass and dependents see the new state.
+#[test]
+fn spill_collapse_to_scalar_is_a_shape_change() {
+    let mut model = new_empty_model();
+
+    model._set("C1", "=SEQUENCE(E1)");
+    model._set("E1", "3");
+    model.evaluate();
+    assert_eq!(model._get_text("C3"), "3");
+
+    // SEQUENCE(-1) is an error: the anchor collapses to 1x1.
+    model._set("E1", "-1");
+    model.evaluate();
+    assert_eq!(model._get_text("C2"), "");
+    assert_eq!(model._get_text("C3"), "");
+
+    model.evaluate();
+    assert!(model.changed_spill_shapes.is_empty());
+}


### PR DESCRIPTION
Closes #1344.

## Problem

Re-evaluating a workbook with many dynamic-array anchors is quadratic in the
anchor count, even when no spill area has moved. That is invisible for a
handful of anchors and dominates for an imported workbook: modern Excel stamps
`cm="1"` on array formulas, so **every** array formula in an Excel-authored
file imports as a dynamic spill anchor. On one such workbook with roughly 244k
anchors, evaluation did not finish within a one-hour bound, and process
sampling put ~97% of the time in this one scan.

Phase 1 of `Model::evaluate` walks `spill_cells` and, after evaluating each
anchor, scans the anchors evaluated so far to see whether any of them read a
cell this anchor has now claimed, restarting the pass if so. The scan runs
unconditionally, hence O(S²).

### Repro

`N` independent single-cell dynamic-array anchors, evaluated once to
materialise the spills, then evaluated again:

```rust
let mut model = Model::new_empty("m", "en", "UTC", "en").unwrap();
for row in 1..=n {
    model.set_user_input(0, row, 1, "=SEQUENCE(1)".to_string()).unwrap();
}
model.evaluate();                 // materialise
let t = std::time::Instant::now();
model.evaluate();                 // timed
println!("{n} {:?}", t.elapsed());
```

`--release`, aarch64-apple-darwin, second `evaluate()` only:

| anchors | main | this branch |
|---|---|---|
| 10 000 | 30.1 ms | 4.2 ms |
| 20 000 | 108.0 ms | 6.5 ms |
| 40 000 | 417.1 ms | 15.7 ms |

Doubling the anchor count multiplies the time by ~3.6-3.9x on `main`
(quadratic) and by ~1.5-2.4x on this branch (linear). Anchors that spill more
than one cell scale worse still on `main`.

## Fix

The reorder scan exists to catch a spill cell that read a position *before* the
anchor owning it wrote there. But spill reads are already demand-driven: the
`Cell::SpillCell` branch of `evaluate_cell` forces the owning anchor's
evaluation before returning a value, so any reader has already seen a fresh
value for a cell that stayed inside the same spill area.

The only way a reader can hold a stale value is if the anchor's spill area
**changed shape** during this pass (grew, shrank, or was created) — that is
what can turn "cell I read as an ordinary blank/value" into "cell that now
belongs to a spill".

So: record the anchors whose spill dimensions changed in a
`changed_spill_shapes` set on the model, cleared at the start of each pass, and
run the reorder scan only for anchors in that set. Steady-state evaluation of
an imported workbook — where every anchor keeps its dimensions — skips the scan
entirely.

Two fields are touched in `Model` construction (`model.rs`, `new_empty.rs`) and
the phase-1 loop is guarded; no public API changes.

## Tests

`base/src/test/dynamic_evaluation/test_reorder_skip.rs` (new, 4 tests):

- `second_evaluation_flags_no_shape_changes` — a re-evaluated model whose
  spills already exist flags nothing as changed, and all values are unchanged.
- `dependent_anchor_listed_first_still_reorders` — the genuine reorder case
  (anchor `B1 = C1:C3` listed before `C1 = SEQUENCE(3)`) still converges to the
  right values, i.e. the optimisation does not skip a scan that is needed.
- `shape_grow_and_shrink` — an anchor whose dimensions move across evaluations
  is flagged on exactly the passes where it moves, and dependents stay correct.
- `spill_collapse_to_scalar_is_a_shape_change` — collapsing to 1x1 counts as a
  shape change.

Full `cargo test --workspace` is green, including the existing dynamic-array
and spill suites.