### PR TITLE
feat(wasm): expose raw cell values via getCellValue

### DIFF
--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -17,6 +17,7 @@ mod test_dynamic_arrays;
 mod test_evaluation;
 mod test_fn_formulatext;
 mod test_general;
+mod test_get_cell_value;
 mod test_grid_lines;
 mod test_hidden_columns;
 mod test_keyboard_navigation;

--- a/base/src/test/user_model/test_get_cell_value.rs
+++ b/base/src/test/user_model/test_get_cell_value.rs
@@ -1,0 +1,31 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::cell::CellValue;
+use crate::test::user_model::util::new_empty_user_model;
+
+#[test]
+fn get_cell_value_returns_raw_typed_values() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "=1/3").unwrap();
+    model.set_user_input(0, 2, 1, "hello").unwrap();
+    model.set_user_input(0, 3, 1, "=TRUE()").unwrap();
+    model.evaluate();
+
+    // full-precision f64, not the 15-digit display rounding
+    assert_eq!(
+        model.get_cell_value(0, 1, 1).unwrap(),
+        CellValue::Number(1.0 / 3.0)
+    );
+    assert_eq!(
+        model.get_cell_value(0, 2, 1).unwrap(),
+        CellValue::String("hello".to_string())
+    );
+    assert_eq!(
+        model.get_cell_value(0, 3, 1).unwrap(),
+        CellValue::Boolean(true)
+    );
+    // empty cell
+    assert_eq!(model.get_cell_value(0, 4, 1).unwrap(), CellValue::None);
+    // wrong sheet is an error
+    assert!(model.get_cell_value(1, 1, 1).is_err());
+}

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, fmt::Debug};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    cell::CellValue,
     cf_types::ExtendedStyle,
     constants::{LAST_COLUMN, LAST_ROW},
     expressions::{
@@ -580,6 +581,15 @@ impl<'a> UserModel<'a> {
         column: i32,
     ) -> Result<String, String> {
         self.model.get_formatted_cell_value(sheet, row, column)
+    }
+
+    /// Returns the raw (unformatted) value of a cell
+    ///
+    /// See also:
+    /// * [Model::get_cell_value_by_index]
+    #[inline]
+    pub fn get_cell_value(&self, sheet: u32, row: i32, column: i32) -> Result<CellValue, String> {
+        self.model.get_cell_value_by_index(sheet, row, column)
     }
 
     /// Returns the type of the cell

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::{
 };
 
 use ironcalc_base::{
+    cell::CellValue,
     cf_types::CfRuleInput,
     colors,
     expressions::{
@@ -502,6 +503,26 @@ impl Model {
         self.model
             .get_formatted_cell_value(sheet, row, column)
             .map_err(to_js_error)
+    }
+
+    /// Returns the raw value of a cell as a native JS value
+    /// (null, string, number or boolean). Unlike `getFormattedCellValue`,
+    /// the number is the full-precision f64, not the display rounding.
+    #[wasm_bindgen(
+        js_name = "getCellValue",
+        unchecked_return_type = "string | number | boolean | null"
+    )]
+    pub fn get_cell_value(&self, sheet: u32, row: i32, column: i32) -> Result<JsValue, JsError> {
+        let value = self
+            .model
+            .get_cell_value(sheet, row, column)
+            .map_err(to_js_error)?;
+        Ok(match value {
+            CellValue::None => JsValue::NULL,
+            CellValue::String(s) => JsValue::from_str(&s),
+            CellValue::Number(f) => JsValue::from_f64(f),
+            CellValue::Boolean(b) => JsValue::from_bool(b),
+        })
     }
 
     #[wasm_bindgen(js_name = "getFrozenRowsCount")]


### PR DESCRIPTION
The wasm `Model` currently exposes `getFormattedCellValue` (the display string, which rounds numbers at 15 significant digits, matching spreadsheet display convention) and `getCellContent` (the input text/formula) - but no way to read a cell's **raw evaluated value**. The nodejs binding already has this as `Model.getCellValue` / `getCellValueByRef`, backed by `Model::get_cell_value_by_index`. Browser embedders doing numeric work (charting, exporting, differential testing against reference values) currently can't get the full-precision `f64` without going through the formatted string - e.g. `25498.569618488982` reads back as `"25498.569618489"`.

This PR:

- adds `UserModel::get_cell_value(sheet, row, column) -> Result<CellValue, String>` in `base/src/user_model/common.rs`, an `#[inline]` delegation to `Model::get_cell_value_by_index`, in the same style as the neighbouring `get_formatted_cell_value` / `get_cell_type`;
- exposes it from `bindings/wasm/src/lib.rs` as `getCellValue(sheet, row, column): string | number | boolean | null` (via `unchecked_return_type`), converting `CellValue` to `JsValue` the same way the nodejs binding maps it to `Either3` - `None -> null`;
- adds `base/src/test/user_model/test_get_cell_value.rs` covering number (full-precision `1/3`), string, boolean, empty cell (`CellValue::None`), and the wrong-sheet error path.

Verified locally: `cargo check` and `cargo clippy` clean on `ironcalc_base` and `bindings/wasm`; `cargo test -p ironcalc_base get_cell_value` passes. I didn't run a wasm32-target build locally - the change is target-independent delegation plus `JsValue` construction, but happy to iterate if CI disagrees.

Naming follows the nodejs binding (`getCellValue`); if you'd rather mirror the base name (`getCellValueByIndex`), happy to rename.
