### PR TITLE
feat: publish xlsx import export as a second wasm package

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -562,6 +562,12 @@ jobs:
           name: wasm-pkg
           path: bindings/wasm/pkg
           if-no-files-found: error
+      - name: Upload wasm-xlsx pkg artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: wasm-xlsx-pkg
+          path: bindings/wasm/pkg-xlsx
+          if-no-files-found: error
 
   build-test-workbook:
     name: Build and test @ironcalc/workbook
@@ -624,6 +630,43 @@ jobs:
       - name: Publish
         if: ${{ steps.wasm_check.outputs.skip != 'true' && env.RELEASE == 'true' }}
         working-directory: bindings/wasm/pkg
+        run: npm publish --access public
+
+  publish-wasm-xlsx:
+    name: Publish @ironcalc/wasm-xlsx
+    runs-on: ubuntu-latest
+    needs:
+      - build-test-wasm
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - name: Download wasm-xlsx pkg artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: wasm-xlsx-pkg
+          path: bindings/wasm/pkg-xlsx
+      - name: Read local version
+        id: wasm_xlsx_version
+        working-directory: .
+        run: echo "version=$(jq -r .version bindings/wasm/pkg-xlsx/package.json)" >> "$GITHUB_OUTPUT"
+      - name: Check published version
+        id: wasm_xlsx_check
+        run: |
+          REMOTE_VERSION="$(npm view @ironcalc/wasm-xlsx version || true)"
+          if [ "$REMOTE_VERSION" = "${{ steps.wasm_xlsx_version.outputs.version }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      # OIDC trusted publishing needs npm >= 11.5.1
+      - name: Update npm
+        run: npm install -g npm@latest
+      - name: Publish
+        if: ${{ steps.wasm_xlsx_check.outputs.skip != 'true' && env.RELEASE == 'true' }}
+        working-directory: bindings/wasm/pkg-xlsx
         run: npm publish --access public
 
   publish-workbook:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1091,9 +1092,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 name = "wasm"
 version = "0.8.4"
 dependencies = [
+ "ironcalc",
  "ironcalc_base",
  "serde",
  "serde-wasm-bindgen",
+ "time",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/bindings/wasm/.gitignore
+++ b/bindings/wasm/.gitignore
@@ -1,1 +1,2 @@
 target/*
+pkg-xlsx/

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -10,11 +10,20 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+default = []
+xlsx = ["dep:ironcalc", "dep:time"]
+
 [dependencies]
 # Uses `../ironcalc/base` when used locally, and uses
 # the indicated version from crates.io when published.
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
 ironcalc_base = { path = "../../base", version = "0.8" }
+ironcalc = { path = "../../xlsx", version = "0.8", optional = true }
+# zip's `time` feature needs the `time` crate's wasm-bindgen backend to read
+# the clock when writing xlsx archives. Feature-unifying it here keeps that
+# out of the xlsx crate itself.
+time = { version = "0.3", features = ["wasm-bindgen"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = "0.2.100"
 serde-wasm-bindgen = "0.4"

--- a/bindings/wasm/Makefile
+++ b/bindings/wasm/Makefile
@@ -1,3 +1,10 @@
+# Two wasm-pack builds from this crate:
+#   pkg/       — @ironcalc/wasm       (engine only, default)
+#   pkg-xlsx/  — @ironcalc/wasm-xlsx  (engine + xlsx import/export)
+#
+# The xlsx APIs are gated on `--features xlsx`, so the default bundle stays
+# the same size. Both builds go through wasm-pack (and therefore wasm-opt).
+
 # In some platforms, python is called python3
 PYTHON := $(shell command -v python 2>/dev/null || command -v python3 2>/dev/null)
 
@@ -8,12 +15,17 @@ endif
 
 all: deps
 	wasm-pack build --target web --scope ironcalc --release
+	wasm-pack build --target web --scope ironcalc --release --out-dir pkg-xlsx -- --features xlsx
 	cp README.pkg.md pkg/README.md
+	cp README.pkg-xlsx.md pkg-xlsx/README.md
 	pnpm exec tsc types.ts --target esnext --module esnext
-	$(PYTHON) fix_types.py
-	$(PYTHON) fix_package.py
+	$(PYTHON) fix_types.py pkg
+	$(PYTHON) fix_types.py pkg-xlsx
+	$(PYTHON) fix_package.py pkg
+	$(PYTHON) fix_package.py pkg-xlsx @ironcalc/wasm-xlsx
 	rm -f types.js
 	node --test tests/test_package.mjs
+	PKG_DIR=pkg-xlsx node --test tests/test_package.mjs
 
 # Installs the pinned JS tooling (typescript, typedoc) from pnpm-lock.yaml
 deps:
@@ -21,6 +33,7 @@ deps:
 
 tests:
 	wasm-pack build --target nodejs && node tests/test.mjs && node tests/test_cf.mjs
+	wasm-pack build --target nodejs --out-dir pkg-xlsx -- --features xlsx && node tests/test_xlsx.mjs
 
 lint:
 	cargo check
@@ -29,7 +42,7 @@ lint:
 
 clean:
 	cargo clean
-	rm -rf pkg
+	rm -rf pkg pkg-xlsx
 	rm -f types.js
 
 .PHONY: all deps lint clean tests

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -1,7 +1,13 @@
 # IronCalc Web bindings
 
 This crate is used to build the web bindings for IronCalc.
-Note that it does not contain the xlsx writer and reader, only the engine.
+
+Two packages are produced from the same crate:
+
+* `@ironcalc/wasm` — the calc engine only. This is the default `make` / `wasm-pack` build.
+* `@ironcalc/wasm-xlsx` — the same engine plus XLSX import (`Model.fromXlsx`) and export (`model.toXlsx`). Built with `--features xlsx`.
+
+The default package does not contain the xlsx writer and reader, so projects that do not import or export spreadsheets are not charged for that code.
 
 https://www.npmjs.com/package/@ironcalc/wasm?activeTab=readme
 
@@ -20,6 +26,8 @@ Dependencies:
 make
 ```
 
+That writes `@ironcalc/wasm` to `pkg/` and `@ironcalc/wasm-xlsx` to `pkg-xlsx/`.
+
 ## Testing
 
 Right now this is a manual process and only carries out a smoke test:
@@ -27,6 +35,12 @@ Right now this is a manual process and only carries out a smoke test:
 1. Build the package
 2. Run `python -m http.server`
 3. In your browser open <http://0.0.0.0:8000/test.html>
+
+Node tests (including XLSX round-trip on the larger build):
+
+```bash
+make tests
+```
 
 ## Publishing
 
@@ -36,5 +50,7 @@ Follow the commands:
 wasm-pack login
 make
 cd pkg
+npm publish --access=public
+cd ../pkg-xlsx
 npm publish --access=public
 ```

--- a/bindings/wasm/README.pkg-xlsx.md
+++ b/bindings/wasm/README.pkg-xlsx.md
@@ -1,0 +1,33 @@
+# IronCalc Web bindings with XLSX
+
+This package is the IronCalc engine plus XLSX import and export. If you only need the calc engine, use [`@ironcalc/wasm`](https://www.npmjs.com/package/@ironcalc/wasm) instead — that package stays smaller.
+
+This addresses the bundle size concern from [ironcalc/IronCalc#379](https://github.com/ironcalc/IronCalc/issues/379) and makes XLSX conversion available in the browser ([#1113](https://github.com/ironcalc/IronCalc/issues/1113)).
+
+## Usage
+
+In your project
+
+```
+npm install @ironcalc/wasm-xlsx
+```
+
+And then in your TypeScript
+
+```TypeScript
+import init, { Model } from "@ironcalc/wasm-xlsx";
+
+await init();
+
+async function convert() {
+    const xlsxBytes = new Uint8Array(await file.arrayBuffer());
+    const model = Model.fromXlsx(xlsxBytes, "Workbook1", "en", "UTC", "en");
+
+    model.setUserInput(0, 1, 1, "23");
+    model.setUserInput(0, 1, 2, "=A1*3+1");
+
+    const out = model.toXlsx();
+}
+
+convert();
+```

--- a/bindings/wasm/README.pkg.md
+++ b/bindings/wasm/README.pkg.md
@@ -1,6 +1,6 @@
 # IronCalc Web bindings
 
-This package contains web bindings for IronCalc. Note that it does not contain the xlsx writer and reader, only the engine.
+This package contains web bindings for IronCalc. Note that it does not contain the xlsx writer and reader, only the engine. For XLSX import and export, use [`@ironcalc/wasm-xlsx`](https://www.npmjs.com/package/@ironcalc/wasm-xlsx).
 
 
 ## Usage

--- a/bindings/wasm/fix_package.py
+++ b/bindings/wasm/fix_package.py
@@ -4,15 +4,24 @@
 # modules that are not in the tarball. See https://github.com/ironcalc/IronCalc/issues/1316
 # Upstream wasm-pack bug: https://github.com/wasm-bindgen/wasm-pack/issues/1206
 # This script can be removed once wasm-pack includes snippets in `files` itself.
+#
+# Usage: fix_package.py [pkg_dir] [package_name]
 import json
+import sys
 
-package_file = "pkg/package.json"
+pkg_dir = sys.argv[1] if len(sys.argv) > 1 else "pkg"
+package_name = sys.argv[2] if len(sys.argv) > 2 else None
+package_file = "{}/package.json".format(pkg_dir)
 
 with open(package_file) as f:
     package = json.load(f)
 
 if "snippets" not in package["files"]:
     package["files"].append("snippets")
+
+if package_name:
+    package["name"] = package_name
+    package["description"] = "IronCalc Web bindings with XLSX import and export"
 
 with open(package_file, "w") as f:
     json.dump(package, f, indent=2)

--- a/bindings/wasm/fix_types.py
+++ b/bindings/wasm/fix_types.py
@@ -1,3 +1,5 @@
+import sys
+
 header = r"""
 /* tslint:disable */
 /* eslint-disable */
@@ -27,14 +29,15 @@ def fix_types(text: str):
     return text
 
 if __name__ == "__main__":
-    types_file = "pkg/wasm.d.ts"
+    pkg_dir = sys.argv[1] if len(sys.argv) > 1 else "pkg"
+    types_file = "{}/wasm.d.ts".format(pkg_dir)
     with open(types_file) as f:
         text = f.read()
     text = fix_types(text)
     with open(types_file, "wb") as f:
         f.write(bytes(text, "utf8"))
 
-    js_file = "pkg/wasm.js"
+    js_file = "{}/wasm.js".format(pkg_dir)
     with open("types.js") as f:
         text_js = f.read()
     with open(js_file) as f:
@@ -42,4 +45,3 @@ if __name__ == "__main__":
 
     with open(js_file, "wb") as f:
         f.write(bytes("{}\n{}".format(text_js, text), "utf8"))
-    

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -143,6 +143,27 @@ impl Model {
         Ok(Model { model })
     }
 
+    /// Loads a workbook from the bytes of an xlsx file.
+    /// Only available in `@ironcalc/wasm-xlsx`.
+    #[cfg(feature = "xlsx")]
+    #[wasm_bindgen(js_name = "fromXlsx")]
+    pub fn from_xlsx(
+        bytes: &[u8],
+        name: &str,
+        locale: &str,
+        timezone: &str,
+        language_id: &str,
+    ) -> Result<Model, JsError> {
+        let workbook = ironcalc::import::load_from_xlsx_bytes(bytes, name, locale, timezone)
+            .map_err(|e| to_js_error(e.to_string()))?;
+        let language_id = leak_str(language_id);
+        let calc_model =
+            ironcalc_base::Model::from_workbook(workbook, language_id).map_err(to_js_error)?;
+        Ok(Model {
+            model: BaseModel::from_model(calc_model),
+        })
+    }
+
     pub fn undo(&mut self) -> Result<(), JsError> {
         self.model.undo().map_err(to_js_error)
     }
@@ -909,6 +930,17 @@ impl Model {
     #[wasm_bindgen(js_name = "toBytes")]
     pub fn to_bytes(&self) -> Vec<u8> {
         self.model.to_bytes()
+    }
+
+    /// Serializes the workbook to xlsx bytes.
+    /// Only available in `@ironcalc/wasm-xlsx`.
+    #[cfg(feature = "xlsx")]
+    #[wasm_bindgen(js_name = "toXlsx")]
+    pub fn to_xlsx(&self) -> Result<Vec<u8>, JsError> {
+        let writer = std::io::Cursor::new(Vec::new());
+        let writer = ironcalc::export::save_xlsx_to_writer(self.model.get_model(), writer)
+            .map_err(|e| to_js_error(e.to_string()))?;
+        Ok(writer.into_inner())
     }
 
     #[wasm_bindgen(js_name = "getName")]

--- a/bindings/wasm/tests/test_package.mjs
+++ b/bindings/wasm/tests/test_package.mjs
@@ -13,7 +13,11 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-const pkgDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'pkg');
+const pkgDir = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    process.env.PKG_DIR || 'pkg',
+);
 
 test('npm tarball contains every module imported by wasm.js', () => {
     const wasmJs = readFileSync(path.join(pkgDir, 'wasm.js'), 'utf8');

--- a/bindings/wasm/tests/test_xlsx.mjs
+++ b/bindings/wasm/tests/test_xlsx.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { Model } from '../pkg-xlsx/wasm.js';
+
+const exampleXlsx = readFileSync(
+    path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '..',
+        '..',
+        '..',
+        'xlsx',
+        'tests',
+        'example.xlsx',
+    ),
+);
+
+test('fromXlsx loads example.xlsx', () => {
+    const model = Model.fromXlsx(exampleXlsx, 'example', 'en', 'UTC', 'en');
+    const sheets = model.getWorksheetsProperties();
+    const names = sheets.map((sheet) => sheet.name);
+    assert.deepEqual(names, [
+        'Sheet1',
+        'Second',
+        'Sheet4',
+        'shared',
+        'Table',
+        'Sheet2',
+        'Created fourth',
+        'Frozen',
+        'Split',
+        'Hidden',
+    ]);
+});
+
+test('toXlsx round-trips a workbook', () => {
+    const model = Model.fromXlsx(exampleXlsx, 'example', 'en', 'UTC', 'en');
+    const bytes = model.toXlsx();
+    assert.ok(bytes.length > 0);
+
+    const roundtrip = Model.fromXlsx(bytes, 'example', 'en', 'UTC', 'en');
+    const names = roundtrip.getWorksheetsProperties().map((sheet) => sheet.name);
+    assert.deepEqual(names, model.getWorksheetsProperties().map((sheet) => sheet.name));
+});
+
+test('engine APIs still work on the xlsx build', () => {
+    const model = new Model('Workbook1', 'en', 'UTC', 'en');
+    model.setUserInput(0, 1, 1, '23');
+    model.setUserInput(0, 1, 2, '=A1*3+1');
+    assert.strictEqual(model.getFormattedCellValue(0, 1, 2), '70');
+
+    const bytes = model.toXlsx();
+    const loaded = Model.fromXlsx(bytes, 'Workbook1', 'en', 'UTC', 'en');
+    assert.strictEqual(loaded.getFormattedCellValue(0, 1, 2), '70');
+});


### PR DESCRIPTION
Publishes XLSX import and export as a second WebAssembly package, so the core `@ironcalc/wasm` bundle stays the same size for projects that do not use it. This addresses the bundle size concern from #379.

### What the packages provide

`@ironcalc/wasm` gives you the core engine (`wasm_bg.wasm`).

`@ironcalc/wasm-xlsx` gives you the same engine plus XLSX import and export (`Model.fromXlsx` / `model.toXlsx`).

Both are built from the wasm crate with wasm-pack. The xlsx APIs are behind a Cargo feature, so the default package does not grow. `@ironcalc/workbook` keeps depending on the smaller package.

This is relevant to #1113 (converting xlsx in the browser). Supersedes the separate-converter approach in #381.

### Usage

```TypeScript
import init, { Model } from "@ironcalc/wasm-xlsx";

await init();

const model = Model.fromXlsx(xlsxBytes, "Workbook1", "en", "UTC", "en");
const xlsxBytesOut = model.toXlsx();
```