### PR TITLE
update: links styling and pointer

### DIFF
--- a/webapp/IronCalc/src/components/Worksheet/LinkTooltip.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/LinkTooltip.tsx
@@ -74,7 +74,7 @@ const LinkTooltip = (props: {
     >
       <div className="ic-worksheet-link-tooltip-row">
         <span className="ic-worksheet-link-tooltip-icon">
-          <Globe size={12} />
+          <Globe />
         </span>
         <button
           type="button"
@@ -91,6 +91,7 @@ const LinkTooltip = (props: {
             type="button"
             className="ic-worksheet-link-tooltip-button"
             title={t("link_tooltip.copy")}
+            aria-label={t("link_tooltip.copy")}
             onClick={() => {
               const text =
                 link.type === "External" ? link.target : link.location;
@@ -99,7 +100,7 @@ const LinkTooltip = (props: {
               });
             }}
           >
-            <Copy size={12} />
+            <Copy />
           </button>
           {/* Dynamic links (created by formulas like HYPERLINK) cannot be edited
             or deleted: only the formula itself can change them. */}
@@ -108,12 +109,13 @@ const LinkTooltip = (props: {
               type="button"
               className="ic-worksheet-link-tooltip-button"
               title={t("link_tooltip.edit")}
+              aria-label={t("link_tooltip.edit")}
               onClick={() => {
                 onHide();
                 onEdit(cell.row, cell.column);
               }}
             >
-              <PencilLine size={12} />
+              <PencilLine />
             </button>
           )}
           {onDelete && !link.dynamic && (
@@ -121,12 +123,13 @@ const LinkTooltip = (props: {
               type="button"
               className="ic-worksheet-link-tooltip-button"
               title={t("link_tooltip.break")}
+              aria-label={t("link_tooltip.break")}
               onClick={() => {
                 onHide();
                 onDelete(cell.row, cell.column);
               }}
             >
-              <Link2Off size={12} />
+              <Link2Off />
             </button>
           )}
         </div>

--- a/webapp/IronCalc/src/components/Worksheet/LinkTooltip.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/LinkTooltip.tsx
@@ -1,5 +1,5 @@
 import type { CellLink } from "@ironcalc/wasm";
-import { Copy, Link, Link2Off, PencilLine } from "lucide-react";
+import { Copy, Globe, Link2Off, PencilLine } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { LinkHoverCell } from "../WorksheetCanvas/cellLinks";
@@ -74,7 +74,7 @@ const LinkTooltip = (props: {
     >
       <div className="ic-worksheet-link-tooltip-row">
         <span className="ic-worksheet-link-tooltip-icon">
-          <Link size={12} />
+          <Globe size={12} />
         </span>
         <button
           type="button"
@@ -86,47 +86,50 @@ const LinkTooltip = (props: {
         >
           {linkLabel(link)}
         </button>
-        <button
-          type="button"
-          className="ic-worksheet-link-tooltip-button"
-          title={t("link_tooltip.copy")}
-          onClick={() => {
-            const text = link.type === "External" ? link.target : link.location;
-            navigator.clipboard?.writeText(text).catch(() => {
-              // clipboard access denied or unavailable: nothing to do
-            });
-          }}
-        >
-          <Copy size={12} />
-        </button>
-        {/* Dynamic links (created by formulas like HYPERLINK) cannot be edited
-          or deleted: only the formula itself can change them. */}
-        {onEdit && !link.dynamic && (
+        <div className="ic-worksheet-link-tooltip-actions">
           <button
             type="button"
             className="ic-worksheet-link-tooltip-button"
-            title={t("link_tooltip.edit")}
+            title={t("link_tooltip.copy")}
             onClick={() => {
-              onHide();
-              onEdit(cell.row, cell.column);
+              const text =
+                link.type === "External" ? link.target : link.location;
+              navigator.clipboard?.writeText(text).catch(() => {
+                // clipboard access denied or unavailable: nothing to do
+              });
             }}
           >
-            <PencilLine size={12} />
+            <Copy size={12} />
           </button>
-        )}
-        {onDelete && !link.dynamic && (
-          <button
-            type="button"
-            className="ic-worksheet-link-tooltip-button"
-            title={t("link_tooltip.break")}
-            onClick={() => {
-              onHide();
-              onDelete(cell.row, cell.column);
-            }}
-          >
-            <Link2Off size={12} />
-          </button>
-        )}
+          {/* Dynamic links (created by formulas like HYPERLINK) cannot be edited
+            or deleted: only the formula itself can change them. */}
+          {onEdit && !link.dynamic && (
+            <button
+              type="button"
+              className="ic-worksheet-link-tooltip-button"
+              title={t("link_tooltip.edit")}
+              onClick={() => {
+                onHide();
+                onEdit(cell.row, cell.column);
+              }}
+            >
+              <PencilLine size={12} />
+            </button>
+          )}
+          {onDelete && !link.dynamic && (
+            <button
+              type="button"
+              className="ic-worksheet-link-tooltip-button"
+              title={t("link_tooltip.break")}
+              onClick={() => {
+                onHide();
+                onDelete(cell.row, cell.column);
+              }}
+            >
+              <Link2Off size={12} />
+            </button>
+          )}
+        </div>
       </div>
       {link.tooltip ? (
         <div className="ic-worksheet-link-tooltip-text">{link.tooltip}</div>

--- a/webapp/IronCalc/src/components/Worksheet/worksheet.css
+++ b/webapp/IronCalc/src/components/Worksheet/worksheet.css
@@ -158,7 +158,7 @@
   border-radius: 4px;
   background-color: color-mix(
     in srgb,
-    var(--palette-grey-900) 90%,
+    var(--palette-grey-900) 94%,
     transparent
   );
   color: var(--palette-common-white);
@@ -167,6 +167,11 @@
   white-space: nowrap;
   box-shadow: var(--shadow-md);
   z-index: 20;
+}
+
+.ic-worksheet-link-tooltip svg {
+  width: 1em;
+  height: 1em;
 }
 
 .ic-worksheet-link-tooltip-row {

--- a/webapp/IronCalc/src/components/Worksheet/worksheet.css
+++ b/webapp/IronCalc/src/components/Worksheet/worksheet.css
@@ -154,14 +154,18 @@
   flex-direction: column;
   align-items: stretch;
   gap: 2px;
-  padding: 4px 8px;
+  padding: 2px 2px 2px 6px;
   border-radius: 4px;
-  background-color: #333333;
-  color: #ffffff;
-  font-size: 12px;
-  font-family: var(--palette-sheet-default-cell-font-family);
+  background-color: color-mix(
+    in srgb,
+    var(--palette-grey-900) 90%,
+    transparent
+  );
+  color: var(--palette-common-white);
+  font-size: var(--typography-font-size);
+  font-family: var(--typography-font-family);
   white-space: nowrap;
-  box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow-md);
   z-index: 20;
 }
 
@@ -173,7 +177,7 @@
 
 /* The optional descriptive text of the link, below the label and actions */
 .ic-worksheet-link-tooltip-text {
-  color: #b0b0b0;
+  color: var(--palette-grey-400);
   max-width: 240px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -182,7 +186,7 @@
 .ic-worksheet-link-tooltip-icon {
   display: flex;
   align-items: center;
-  color: #b0b0b0;
+  color: var(--palette-grey-400);
 }
 
 .ic-worksheet-link-tooltip-label {
@@ -203,21 +207,27 @@
   text-decoration: underline;
 }
 
+.ic-worksheet-link-tooltip-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
 .ic-worksheet-link-tooltip-button {
   display: flex;
   align-items: center;
   background: none;
   border: none;
-  padding: 2px;
+  padding: 4px;
   margin: 0;
-  color: #b0b0b0;
+  color: var(--palette-grey-400);
   cursor: pointer;
   border-radius: 2px;
 }
 
 .ic-worksheet-link-tooltip-button:hover {
-  color: #ffffff;
-  background-color: #4d4d4d;
+  color: var(--palette-common-white);
+  background-color: var(--palette-grey-800);
 }
 
 /* Editor wrapper */

--- a/webapp/IronCalc/src/components/Worksheet/worksheet.css
+++ b/webapp/IronCalc/src/components/Worksheet/worksheet.css
@@ -186,6 +186,7 @@
   max-width: 240px;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0px 4px 2px 0px;
 }
 
 .ic-worksheet-link-tooltip-icon {
@@ -216,6 +217,7 @@
   display: flex;
   align-items: center;
   gap: 2px;
+  margin-left: auto;
 }
 
 .ic-worksheet-link-tooltip-button {

--- a/webapp/IronCalc/src/components/WorksheetCanvas/cellLinks.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/cellLinks.ts
@@ -27,7 +27,7 @@ export interface CellLinksOptions {
 }
 
 // Handles the cell links of the selected sheet: hit-testing the rendered
-// cells on pointer moves (cursor + hover reporting) and following a link.
+// cells on pointer moves (hover reporting) and following a link.
 // The tooltip itself is rendered by React (see Worksheet/LinkTooltip.tsx).
 export class CellLinks {
   private worksheet: WorksheetCanvas;
@@ -76,16 +76,9 @@ export class CellLinks {
         event.clientX - rect.left,
         event.clientY - rect.top,
       );
-      if (cell) {
-        canvas.style.cursor = "pointer";
-        this.options.onLinkHover?.(cell);
-      } else {
-        canvas.style.cursor = "";
-        this.options.onLinkHover?.(null);
-      }
+      this.options.onLinkHover?.(cell);
     };
     container.onpointerleave = () => {
-      canvas.style.cursor = "";
       this.options.onLinkHover?.(null);
     };
     // Ctrl+click (Cmd+click on Mac) on a link cell follows the link. Only the


### PR DESCRIPTION
This PR brings a few cosmetic changes to the link tooltips:

- Use of variables, so we can properly switch to dark mode
- Some cosmetic changes: buttons inside the tooltip are larger, paddings smaller, use of a more suitable `Globe` icon...
- Changed the grouping in the tooltip buttons so I can use a different gap in there
- Remove pointer when hovering cells. The reason is that a pointer cursor is a promise that a plain click acts on the thing under it, and here it selects the cell like anywhere else on the grid, so there's no need to have it
  - That said, we should show a pointer when `cmd` or `ctrl` keys are pressed, as that actually makes the hyperlink work. That will come in a future PR