### PR TITLE
update: in links, show pointer on hover when cmd/ctrl is pressed

### DIFF
--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -442,7 +442,7 @@ const Workbook = (props: {
         "ic-worksheet-sheet-container",
       )[0];
       if (el) {
-        (el as HTMLElement).style.cursor = "auto";
+        (el as HTMLElement).style.cursor = "";
       }
       setRedrawId((id) => id + 1);
     },

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -334,7 +334,7 @@ const Worksheet = forwardRef(
         }
         workbookState.setCopyStyles(null);
         if (worksheetElement.current) {
-          worksheetElement.current.style.cursor = "auto";
+          worksheetElement.current.style.cursor = "";
         }
         refresh();
       },

--- a/webapp/IronCalc/src/components/Worksheet/worksheet.css
+++ b/webapp/IronCalc/src/components/Worksheet/worksheet.css
@@ -28,6 +28,10 @@
   height: 100%;
 }
 
+.ic-worksheet-sheet-container.ic-worksheet-link-cursor {
+  cursor: pointer;
+}
+
 /* Column resize handle */
 .ic-worksheet-sheet-container .column-resize-handle {
   position: absolute;

--- a/webapp/IronCalc/src/components/WorksheetCanvas/cellLinks.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/cellLinks.ts
@@ -26,7 +26,18 @@ export interface CellLinksOptions {
   tooltipCell: LinkHoverCell | null;
 }
 
-// Pointer cursor while Ctrl/Cmd+click would follow a link
+// Cmd on Mac, Ctrl elsewhere (on Mac Ctrl+click is a right click)
+const isMac =
+  typeof navigator !== "undefined" && navigator.userAgent.includes("Mac");
+
+function hasLinkModifier(event: {
+  ctrlKey: boolean;
+  metaKey: boolean;
+}): boolean {
+  return isMac ? event.metaKey : event.ctrlKey;
+}
+
+// Pointer cursor while the modifier+click would follow a link
 const LINK_CURSOR_CLASS = "ic-worksheet-link-cursor";
 let linkContainer: HTMLElement | null = null;
 let linkHovered = false;
@@ -40,14 +51,14 @@ function updateLinkCursor(): void {
   );
 }
 
-// The container is never focused so Ctrl/Cmd is tracked on the window
+// The container is never focused so the modifier is tracked on the window
 function trackModifierKey(): void {
   if (modifierTracked || typeof window === "undefined") {
     return;
   }
   modifierTracked = true;
   const onKey = (event: KeyboardEvent): void => {
-    modifierDown = event.ctrlKey || event.metaKey;
+    modifierDown = hasLinkModifier(event);
     updateLinkCursor();
   };
   window.addEventListener("keydown", onKey);
@@ -111,7 +122,7 @@ export class CellLinks {
         event.clientY - rect.top,
       );
       linkHovered = cell !== null;
-      modifierDown = event.ctrlKey || event.metaKey;
+      modifierDown = hasLinkModifier(event);
       updateLinkCursor();
       this.options.onLinkHover?.(cell);
     };
@@ -120,10 +131,10 @@ export class CellLinks {
       updateLinkCursor();
       this.options.onLinkHover?.(null);
     };
-    // Ctrl+click (Cmd+click on Mac) on a link cell follows the link. Only the
-    // primary button: on Mac Ctrl+click is a right click (context menu).
+    // Cmd+click (Ctrl+click outside Mac) on a link cell follows the link,
+    // primary button only
     container.onpointerdown = (event) => {
-      if (event.button !== 0 || !(event.ctrlKey || event.metaKey)) {
+      if (event.button !== 0 || !hasLinkModifier(event)) {
         return;
       }
       const target = event.target as Element;

--- a/webapp/IronCalc/src/components/WorksheetCanvas/cellLinks.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/cellLinks.ts
@@ -26,6 +26,38 @@ export interface CellLinksOptions {
   tooltipCell: LinkHoverCell | null;
 }
 
+// Pointer cursor while Ctrl/Cmd+click would follow a link
+const LINK_CURSOR_CLASS = "ic-worksheet-link-cursor";
+let linkContainer: HTMLElement | null = null;
+let linkHovered = false;
+let modifierDown = false;
+let modifierTracked = false;
+
+function updateLinkCursor(): void {
+  linkContainer?.classList.toggle(
+    LINK_CURSOR_CLASS,
+    linkHovered && modifierDown,
+  );
+}
+
+// The container is never focused so Ctrl/Cmd is tracked on the window
+function trackModifierKey(): void {
+  if (modifierTracked || typeof window === "undefined") {
+    return;
+  }
+  modifierTracked = true;
+  const onKey = (event: KeyboardEvent): void => {
+    modifierDown = event.ctrlKey || event.metaKey;
+    updateLinkCursor();
+  };
+  window.addEventListener("keydown", onKey);
+  window.addEventListener("keyup", onKey);
+  window.addEventListener("blur", () => {
+    modifierDown = false;
+    updateLinkCursor();
+  });
+}
+
 // Handles the cell links of the selected sheet: hit-testing the rendered
 // cells on pointer moves (hover reporting) and following a link.
 // The tooltip itself is rendered by React (see Worksheet/LinkTooltip.tsx).
@@ -40,6 +72,7 @@ export class CellLinks {
     this.options = options;
     this.links = new Map<string, CellLink>();
     this.attachHandlers();
+    trackModifierKey();
   }
 
   setSheetLinks(cellLinks: CellLink[]): void {
@@ -64,6 +97,7 @@ export class CellLinks {
     // previous instance instead of accumulating stale ones.
     const canvas = this.worksheet.canvas;
     const container = canvas.parentElement ?? canvas;
+    linkContainer = container;
     container.onpointermove = (event) => {
       // While the pointer is over the tooltip it is not hovering any cell:
       // the tooltip component handles its own pointer events.
@@ -76,9 +110,14 @@ export class CellLinks {
         event.clientX - rect.left,
         event.clientY - rect.top,
       );
+      linkHovered = cell !== null;
+      modifierDown = event.ctrlKey || event.metaKey;
+      updateLinkCursor();
       this.options.onLinkHover?.(cell);
     };
     container.onpointerleave = () => {
+      linkHovered = false;
+      updateLinkCursor();
       this.options.onLinkHover?.(null);
     };
     // Ctrl+click (Cmd+click on Mac) on a link cell follows the link. Only the


### PR DESCRIPTION
This PR adds the change mentioned in #1336

Hovering links while pressing `cmd` (in MacOS) and `ctrl` (in Windows and Linux) should change the cursor to a `pointer`. It still opens the link in a new tab, that hasn't changed.