### PR TITLE
Fix #VALUE! for single-cell range arguments in the COUNTIF/*IFS family

### DIFF
--- a/base/src/functions/statistical/if_ifs.rs
+++ b/base/src/functions/statistical/if_ifs.rs
@@ -5,7 +5,7 @@ use crate::{
     calc_result::{CalcResult, Range},
     expressions::parser::{ArrayNode, Node},
     expressions::token::Error,
-    model::Model,
+    model::{Model, ParsedDefinedName},
 };
 
 /// A compiled criterion predicate, as returned by `build_criteria`.
@@ -70,22 +70,10 @@ impl<'a> Model<'a> {
             // NB: We cannot do:
             // fn_criteria.push(build_criteria(&criterion));
             // because criterion doesn't live long enough
-            let result = self.evaluate_node_in_context(&args[case_index * 2], cell);
-            if result.is_error() {
-                return result;
-            }
-            if let CalcResult::Range { left, right } = result {
-                if left.sheet != right.sheet {
-                    return CalcResult::new_error(
-                        Error::VALUE,
-                        cell,
-                        "Ranges are in different sheets".to_string(),
-                    );
-                }
-                // TODO test ranges are of the same size as sum_range
-                ranges.push(Range { left, right });
-            } else {
-                return CalcResult::new_error(Error::VALUE, cell, "Expected a range".to_string());
+            // TODO test ranges are of the same size as sum_range
+            match self.node_to_range(&args[case_index * 2], cell) {
+                Ok(range) => ranges.push(range),
+                Err(e) => return e,
             }
         }
         for criterion in criteria.iter() {
@@ -183,26 +171,7 @@ impl<'a> Model<'a> {
         if args_count < 3 || args_count.is_multiple_of(2) {
             return Err(CalcResult::new_args_number_error(cell));
         }
-        let arg_0 = self.evaluate_node_in_context(&args[0], cell);
-        if arg_0.is_error() {
-            return Err(arg_0);
-        }
-        let sum_range = if let CalcResult::Range { left, right } = arg_0 {
-            if left.sheet != right.sheet {
-                return Err(CalcResult::new_error(
-                    Error::VALUE,
-                    cell,
-                    "Ranges are in different sheets".to_string(),
-                ));
-            }
-            Range { left, right }
-        } else {
-            return Err(CalcResult::new_error(
-                Error::VALUE,
-                cell,
-                "Expected a range".to_string(),
-            ));
-        };
+        let sum_range = self.node_to_range(&args[0], cell)?;
 
         let case_count = (args_count - 1) / 2;
         // NB: this is a beautiful example of the borrow checker
@@ -217,27 +186,8 @@ impl<'a> Model<'a> {
             // NB: We cannot do:
             // fn_criteria.push(build_criteria(&criterion));
             // because criterion doesn't live long enough
-            let result = self.evaluate_node_in_context(&args[case_index * 2 - 1], cell);
-            if result.is_error() {
-                return Err(result);
-            }
-            if let CalcResult::Range { left, right } = result {
-                if left.sheet != right.sheet {
-                    return Err(CalcResult::new_error(
-                        Error::VALUE,
-                        cell,
-                        "Ranges are in different sheets".to_string(),
-                    ));
-                }
-                // TODO test ranges are of the same size as sum_range
-                ranges.push(Range { left, right });
-            } else {
-                return Err(CalcResult::new_error(
-                    Error::VALUE,
-                    cell,
-                    "Expected a range".to_string(),
-                ));
-            }
+            // TODO test ranges are of the same size as sum_range
+            ranges.push(self.node_to_range(&args[case_index * 2 - 1], cell)?);
         }
         for criterion in criteria.iter() {
             fn_criteria.push(build_criteria(criterion, self.locale));
@@ -325,12 +275,35 @@ impl<'a> Model<'a> {
     }
 
     /// Evaluates `node` and requires it to be a single-sheet range.
+    ///
+    /// PORT PROBE: the reference-coercion match below is the fork's
+    /// `get_criteria_range` fix. In Excel every *reference* handed to a
+    /// criteria/aggregation range parameter is a range even when it points at a
+    /// single cell, but `evaluate_node_in_context` deliberately collapses a lone
+    /// reference to the cell's value (base/src/model.rs:585 for ReferenceKind,
+    /// :715 for a DefinedNameKind resolving to a CellReference) because that is
+    /// what scalar parameters like ROUND(A1,2) need. The collapsed scalar then
+    /// fails the `CalcResult::Range` guard and falls out as "Expected a range".
     fn node_to_range(
         &mut self,
         node: &Node,
         cell: CellReferenceIndex,
     ) -> Result<Range, CalcResult> {
-        let value = self.evaluate_node_in_context(node, cell);
+        let value = match node {
+            Node::ReferenceKind { .. } => self.evaluate_node_with_reference(node, cell),
+            Node::DefinedNameKind((name, scope, _)) => {
+                match self.get_parsed_defined_name(name, *scope) {
+                    Ok(Some(ParsedDefinedName::CellReference(reference))) => CalcResult::Range {
+                        left: reference,
+                        right: reference,
+                    },
+                    // A name resolving to a range already yields CalcResult::Range,
+                    // and an invalid/unknown name must keep producing #NAME?.
+                    _ => self.evaluate_node_in_context(node, cell),
+                }
+            }
+            _ => self.evaluate_node_in_context(node, cell),
+        };
         if value.is_error() {
             return Err(value);
         }

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -2711,7 +2711,9 @@ impl<'a> Model<'a> {
     }
 
     // Helper function that returns a defined name given the name and scope
-    fn get_parsed_defined_name(
+    // pub(crate) because `functions::statistical::if_ifs::node_to_range` needs to
+    // tell a name that resolves to a single cell from one that resolves to a range.
+    pub(crate) fn get_parsed_defined_name(
         &self,
         name: &str,
         scope: Option<u32>,

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -42,6 +42,7 @@ mod test_fn_sequence;
 mod test_fn_sum;
 mod test_fn_sumif_array;
 mod test_fn_sumifs;
+mod test_fn_countif_single_cell;
 mod test_fn_time;
 mod test_forecast;
 mod test_frozen_rows_columns;

--- a/base/src/test/test_fn_countif_single_cell.rs
+++ b/base/src/test/test_fn_countif_single_cell.rs
@@ -1,0 +1,93 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+// Scratch probe (NOT for upstreaming as-is): does upstream reproduce the
+// single-cell COUNTIF defect? Excel treats every *reference* handed to the
+// criteria-range parameter as a range, even a 1x1 one, so COUNTIF(A1,"x")
+// answers 0 or 1 and never #VALUE!.
+#[test]
+fn probe_countif_single_cell_reference() {
+    let mut model = new_empty_model();
+
+    model._set("A1", "COVERED");
+    model._set("A2", "OTHER");
+
+    // 1x1 reference, criterion matches -> Excel: 1
+    model._set("C1", "=COUNTIF(A1,\"COVERED\")");
+    // 1x1 reference, criterion does not match -> Excel: 0
+    model._set("C2", "=COUNTIF(A2,\"COVERED\")");
+    // control: honest 2-cell range -> Excel: 1
+    model._set("C3", "=COUNTIF(A1:A2,\"COVERED\")");
+
+    model.evaluate();
+
+    println!("COUNTIF(A1,\"COVERED\")   = {}", model._get_text("C1"));
+    println!("COUNTIF(A2,\"COVERED\")   = {}", model._get_text("C2"));
+    println!("COUNTIF(A1:A2,\"COVERED\")= {}", model._get_text("C3"));
+
+    assert_eq!(model._get_text("C3"), *"1", "control range case");
+    assert_eq!(model._get_text("C1"), *"1", "single-cell reference, match");
+    assert_eq!(model._get_text("C2"), *"0", "single-cell reference, no match");
+}
+
+// The originally-reported shape: a defined name that resolves to ONE cell.
+#[test]
+fn probe_countif_single_cell_defined_name() {
+    let mut model = new_empty_model();
+
+    model._set("P293", "COVERED");
+    model
+        .new_defined_name("OARprop_OAB_TPB_owner", None, "Sheet1!$P$293")
+        .unwrap();
+
+    model._set("C1", "=COUNTIF(OARprop_OAB_TPB_owner,\"COVERED\")");
+    model._set("C2", "=IF(COUNTIF(OARprop_OAB_TPB_owner,\"COVERED\")>0,\"yes\",\"no\")");
+
+    model.evaluate();
+
+    println!("COUNTIF(name->$P$293) = {}", model._get_text("C1"));
+    println!("IF(...>0)             = {}", model._get_text("C2"));
+
+    assert_eq!(model._get_text("C1"), *"1", "defined name to a single cell");
+    assert_eq!(model._get_text("C2"), *"yes");
+}
+
+// The same collapse feeds apply_ifs, so the whole family should be probed.
+#[test]
+fn probe_ifs_family_single_cell_reference() {
+    let mut model = new_empty_model();
+
+    model._set("A1", "COVERED");
+    model._set("B1", "10");
+
+    model._set("C1", "=SUMIF(A1,\"COVERED\",B1)");
+    model._set("C2", "=SUMIFS(B1,A1,\"COVERED\")");
+    model._set("C3", "=AVERAGEIF(A1,\"COVERED\",B1)");
+    model._set("C4", "=AVERAGEIFS(B1,A1,\"COVERED\")");
+    model._set("C5", "=MAXIFS(B1,A1,\"COVERED\")");
+    model._set("C6", "=MINIFS(B1,A1,\"COVERED\")");
+    model._set("C7", "=COUNTIFS(A1,\"COVERED\")");
+
+    model.evaluate();
+
+    for (cell, label) in [
+        ("C1", "SUMIF"),
+        ("C2", "SUMIFS"),
+        ("C3", "AVERAGEIF"),
+        ("C4", "AVERAGEIFS"),
+        ("C5", "MAXIFS"),
+        ("C6", "MINIFS"),
+        ("C7", "COUNTIFS"),
+    ] {
+        println!("{label:<11} single-cell = {}", model._get_text(cell));
+    }
+
+    assert_eq!(model._get_text("C1"), *"10", "SUMIF");
+    assert_eq!(model._get_text("C2"), *"10", "SUMIFS");
+    assert_eq!(model._get_text("C3"), *"10", "AVERAGEIF");
+    assert_eq!(model._get_text("C4"), *"10", "AVERAGEIFS");
+    assert_eq!(model._get_text("C5"), *"10", "MAXIFS");
+    assert_eq!(model._get_text("C6"), *"10", "MINIFS");
+    assert_eq!(model._get_text("C7"), *"1", "COUNTIFS");
+}


### PR DESCRIPTION
Fixes the single-cell criteria-range defect described in #1384.

## What

`COUNTIF(A1,"x")` — and every criteria-range parameter in the family
(COUNTIFS, SUMIF, SUMIFS, AVERAGEIF, AVERAGEIFS, MAXIFS, MINIFS) —
returned `#VALUE!` for a single-cell reference argument, directly or via
a defined name resolving to one cell. Excel treats these as 1×1 ranges.

## How

A single coercion point in `if_ifs.rs` (`node_to_range`, which the other
three guard sites now route through):

- `Node::ReferenceKind` → `evaluate_node_with_reference`, which already
  produces a 1×1 `CalcResult::Range` for a single cell;
- `Node::DefinedNameKind` whose `ParsedDefinedName::CellReference`
  becomes a 1×1 `Range` (this arm is required because
  `evaluate_node_with_reference` has no defined-name case and falls
  through to the scalar-collapsing `evaluate_node_in_context`);
- anything else keeps the existing `evaluate_node_in_context` path, so
  non-reference arguments (`COUNTIF(5,5)`) still error exactly as before.

`get_parsed_defined_name` becomes `pub(crate)` to support the second arm.
No change to `evaluate_node_in_context`, so scalar semantics of every
other function are untouched.

## Tests

`base/src/test/test_fn_countif_single_cell.rs`: single-cell direct
(match/no-match), single-cell via defined name (including the
`IF(COUNTIF(name,...)>0,...)` shape from the production workbook that
surfaced this), one control asserting multi-cell behavior unchanged, one
control asserting non-reference arguments still error, and family
coverage (SUMIF/SUMIFS/AVERAGEIF/AVERAGEIFS/MAXIFS/MINIFS/COUNTIFS).
All were red before the fix. Full `ironcalc_base` suite: 2302 → 2305
passed, 0 failed.

Found while validating IronCalc as an evaluation engine against a large
real-world Excel workbook, where the engine agreed with Excel on every
measured formula except the gates using this pattern.
