### PR TITLE
update: add a light/dark toggle to the settings drawer

### DIFF
--- a/webapp/IronCalc/src/IronCalc.tsx
+++ b/webapp/IronCalc/src/IronCalc.tsx
@@ -49,6 +49,7 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
             workbookState={new WorkbookState()}
             canEdit={canEdit}
             themeVariables={themeVariables}
+            themeRoot={root}
           />
         </I18nextProvider>
       </div>

--- a/webapp/IronCalc/src/IronCalc.tsx
+++ b/webapp/IronCalc/src/IronCalc.tsx
@@ -6,11 +6,7 @@ import { WorkbookState } from "./components/workbookState.ts";
 import i18n from "./i18n";
 import "./theme/theme.css";
 import "./index.css";
-import {
-  type PartialIronCalcThemeVariables,
-  setThemeVariables,
-  unsetThemeVariables,
-} from "./theme";
+import type { PartialIronCalcThemeVariables } from "./theme";
 
 interface IronCalcProperties {
   model: Model;
@@ -35,13 +31,6 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
       return () => root.classList.remove("ic-root");
     }, [root]);
 
-    useEffect(() => {
-      if (themeVariables) {
-        setThemeVariables(themeVariables, root);
-        return () => unsetThemeVariables(root);
-      }
-    }, [root, themeVariables]);
-
     useImperativeHandle(ref, () => ({
       setLanguage(language: string) {
         if (i18n.language !== language) {
@@ -59,6 +48,7 @@ const IronCalc = forwardRef<IronCalcHandle, IronCalcProperties>(
             model={model}
             workbookState={new WorkbookState()}
             canEdit={canEdit}
+            themeVariables={themeVariables}
           />
         </I18nextProvider>
       </div>

--- a/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/RegionalSettings.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/RegionalSettings.tsx
@@ -1,5 +1,5 @@
 import { getAllTimezones, getSupportedLocales } from "@ironcalc/wasm";
-import { Check, X } from "lucide-react";
+import { Check, Moon, Sun, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../Button/Button";
@@ -85,6 +85,7 @@ const RegionalSettings = (properties: RegionalSettingsProps) => {
   const [selectedLanguage, setSelectedLanguage] = useState(
     properties.initialLanguage,
   );
+  const [selectedTheme, setSelectedTheme] = useState<"light" | "dark">("light");
 
   useEffect(() => {
     setSelectedLocale(properties.initialLocale);
@@ -182,6 +183,34 @@ const RegionalSettings = (properties: RegionalSettingsProps) => {
                 triggerLabel: timezone,
               }))}
             />
+          </div>
+        </div>
+        <div className="ic-regional-settings-section">
+          <div className="ic-regional-settings-section-title">
+            {t("regional_settings.appearance.title")}
+          </div>
+          <div className="ic-regional-settings-field-wrapper">
+            <span className="ic-regional-settings-label">
+              {t("regional_settings.appearance.theme_label")}
+            </span>
+            <div className="ic-regional-settings-toggle-group">
+              <Button
+                variant={selectedTheme === "light" ? "secondary" : "ghost"}
+                size="sm"
+                startIcon={<Sun size={14} />}
+                onClick={() => setSelectedTheme("light")}
+              >
+                {t("regional_settings.appearance.light")}
+              </Button>
+              <Button
+                variant={selectedTheme === "dark" ? "secondary" : "ghost"}
+                size="sm"
+                startIcon={<Moon size={14} />}
+                onClick={() => setSelectedTheme("dark")}
+              >
+                {t("regional_settings.appearance.dark")}
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/RegionalSettings.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/RegionalSettings.tsx
@@ -123,7 +123,7 @@ const RegionalSettings = (properties: RegionalSettingsProps) => {
       <div className="ic-regional-settings-content">
         <div className="ic-regional-settings-section">
           <div className="ic-regional-settings-section-title">
-            {t("regional_settings.locale.title")}
+            {t("regional_settings.regional_title")}
           </div>
           <div className="ic-regional-settings-field-wrapper">
             <Select
@@ -168,11 +168,6 @@ const RegionalSettings = (properties: RegionalSettingsProps) => {
                 </span>
               </div>
             </div>
-          </div>
-        </div>
-        <div className="ic-regional-settings-section">
-          <div className="ic-regional-settings-section-title">
-            {t("regional_settings.timezone.title")}
           </div>
           <div className="ic-regional-settings-field-wrapper">
             <Select

--- a/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/RegionalSettings.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/RegionalSettings.tsx
@@ -2,6 +2,7 @@ import { getAllTimezones, getSupportedLocales } from "@ironcalc/wasm";
 import { Check, Moon, Sun, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { ColorMode } from "../../../theme";
 import { Button } from "../../Button/Button";
 import { IconButton } from "../../Button/IconButton";
 import "./regional-settings.css";
@@ -13,6 +14,9 @@ type RegionalSettingsProps = {
   initialTimezone: string;
   initialLanguage: string;
   onSave: (locale: string, timezone: string, language: string) => void;
+  colorMode: ColorMode;
+  /** Applied immediately, it is not part of the workbook settings saved below */
+  onColorModeChange: (mode: ColorMode) => void;
 };
 
 // Display mapping for locale codes (e.g., "en" -> "en-US")
@@ -85,7 +89,6 @@ const RegionalSettings = (properties: RegionalSettingsProps) => {
   const [selectedLanguage, setSelectedLanguage] = useState(
     properties.initialLanguage,
   );
-  const [selectedTheme, setSelectedTheme] = useState<"light" | "dark">("light");
 
   useEffect(() => {
     setSelectedLocale(properties.initialLocale);
@@ -195,18 +198,22 @@ const RegionalSettings = (properties: RegionalSettingsProps) => {
             </span>
             <div className="ic-regional-settings-toggle-group">
               <Button
-                variant={selectedTheme === "light" ? "secondary" : "ghost"}
+                variant={
+                  properties.colorMode === "light" ? "secondary" : "ghost"
+                }
                 size="sm"
                 startIcon={<Sun size={14} />}
-                onClick={() => setSelectedTheme("light")}
+                onClick={() => properties.onColorModeChange("light")}
               >
                 {t("regional_settings.appearance.light")}
               </Button>
               <Button
-                variant={selectedTheme === "dark" ? "secondary" : "ghost"}
+                variant={
+                  properties.colorMode === "dark" ? "secondary" : "ghost"
+                }
                 size="sm"
                 startIcon={<Moon size={14} />}
-                onClick={() => setSelectedTheme("dark")}
+                onClick={() => properties.onColorModeChange("dark")}
               >
                 {t("regional_settings.appearance.dark")}
               </Button>

--- a/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/regional-settings.css
+++ b/webapp/IronCalc/src/components/RightDrawer/RegionalSettings/regional-settings.css
@@ -93,6 +93,47 @@
   width: 100%;
 }
 
+.ic-regional-settings-label {
+  font-size: var(--typography-font-size);
+  font-family: var(--typography-font-family);
+  font-weight: 500;
+  color: var(--palette-common-black);
+  margin-bottom: 8px;
+}
+
+/* Segmented toggle (same look as the icon sets mode toggle) */
+.ic-regional-settings-toggle-group {
+  position: relative;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  border: 1px solid var(--palette-grey-300);
+  border-radius: 6px;
+  background-color: var(--palette-common-white);
+  height: 32px;
+  padding: 0 1px;
+  overflow: hidden;
+  gap: 1px;
+}
+
+.ic-regional-settings-toggle-group .ic-button {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  gap: 6px;
+  border-radius: 4px;
+}
+
+.ic-regional-settings-toggle-group .ic-button__icon {
+  width: 14px;
+  height: 14px;
+}
+
+.ic-regional-settings-toggle-group .ic-button__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
 .ic-regional-settings-footer {
   color: var(--palette-grey-700);
   display: flex;

--- a/webapp/IronCalc/src/components/RightDrawer/RightDrawer.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/RightDrawer.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@ironcalc/wasm";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { useCallback, useEffect, useState } from "react";
+import type { ColorMode } from "../../theme";
 import ConditionalFormatting from "./ConditionalFormatting/ConditionalFormatting";
 import NamedRanges from "./NamedRanges/NamedRanges";
 import NamedStylesPanel from "./NamedStyles/NamedStylesPanel";
@@ -61,6 +62,8 @@ interface RightDrawerProps {
   initialTimezone: string;
   initialLanguage: string;
   onSettingsSave: (locale: string, timezone: string, language: string) => void;
+  colorMode: ColorMode;
+  onColorModeChange: (mode: ColorMode) => void;
 }
 
 const RightDrawer = ({
@@ -86,6 +89,8 @@ const RightDrawer = ({
   initialTimezone,
   initialLanguage,
   onSettingsSave,
+  colorMode,
+  onColorModeChange,
 }: RightDrawerProps) => {
   const [drawerWidth, setDrawerWidth] = useState(width);
   const [isResizing, setIsResizing] = useState(false);
@@ -194,6 +199,8 @@ const RightDrawer = ({
             initialTimezone={initialTimezone}
             initialLanguage={initialLanguage}
             onSave={onSettingsSave}
+            colorMode={colorMode}
+            onColorModeChange={onColorModeChange}
           />
         );
       case "conditionalFormatting":

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -67,8 +67,16 @@ const Workbook = (props: {
   canEdit?: boolean;
   /** Host overrides, applied on top of the active color mode. */
   themeVariables?: PartialIronCalcThemeVariables;
+  /** Element the theme variables are written to. IronCalc only marks it `.ic-root` in an effect, too late to look it up here. */
+  themeRoot?: HTMLElement;
 }) => {
-  const { model, workbookState, canEdit = true, themeVariables } = props;
+  const {
+    model,
+    workbookState,
+    canEdit = true,
+    themeVariables,
+    themeRoot,
+  } = props;
   const { t } = useTranslation();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const worksheetRef = useRef<{
@@ -98,14 +106,17 @@ const Workbook = (props: {
   // A layout effect, so the variables are in place before the browser paints
   // and before the canvas (a plain effect in Worksheet) reads them from CSS.
   useLayoutEffect(() => {
-    const root = rootRef.current?.closest<HTMLElement>(".ic-root");
+    const root = themeRoot ?? rootRef.current?.closest<HTMLElement>(".ic-root");
     if (!root) {
       return;
     }
     applyColorMode(colorMode, root, themeVariables);
-    storeColorMode(colorMode);
     return () => unsetThemeVariables(root);
-  }, [colorMode, themeVariables]);
+  }, [colorMode, themeVariables, themeRoot]);
+
+  useEffect(() => {
+    storeColorMode(colorMode);
+  }, [colorMode]);
 
   const openDrawer = useCallback((type: DrawerType) => {
     setDrawerType(type);

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -7,8 +7,22 @@ import type {
   WorksheetProperties,
 } from "@ironcalc/wasm";
 import { type Color, getThemeList } from "@ironcalc/wasm";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
+import {
+  applyColorMode,
+  type ColorMode,
+  type PartialIronCalcThemeVariables,
+  readStoredColorMode,
+  storeColorMode,
+  unsetThemeVariables,
+} from "../../theme";
 import {
   CLIPBOARD_ID_SESSION_STORAGE_KEY,
   getNewClipboardId,
@@ -51,8 +65,10 @@ const Workbook = (props: {
   workbookState: WorkbookState;
   /** When false, the toolbar is hidden, the formula bar is read-only and all edits are blocked. */
   canEdit?: boolean;
+  /** Host overrides, applied on top of the active color mode. */
+  themeVariables?: PartialIronCalcThemeVariables;
 }) => {
-  const { model, workbookState, canEdit = true } = props;
+  const { model, workbookState, canEdit = true, themeVariables } = props;
   const { t } = useTranslation();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const worksheetRef = useRef<{
@@ -76,6 +92,20 @@ const Workbook = (props: {
     row: number;
     column: number;
   } | null>(null);
+
+  const [colorMode, setColorMode] = useState<ColorMode>(readStoredColorMode);
+
+  // A layout effect, so the variables are in place before the browser paints
+  // and before the canvas (a plain effect in Worksheet) reads them from CSS.
+  useLayoutEffect(() => {
+    const root = rootRef.current?.closest<HTMLElement>(".ic-root");
+    if (!root) {
+      return;
+    }
+    applyColorMode(colorMode, root, themeVariables);
+    storeColorMode(colorMode);
+    return () => unsetThemeVariables(root);
+  }, [colorMode, themeVariables]);
 
   const openDrawer = useCallback((type: DrawerType) => {
     setDrawerType(type);
@@ -1073,6 +1103,8 @@ const Workbook = (props: {
         initialLocale={model.getLocale()}
         initialTimezone={model.getTimezone()}
         initialLanguage={model.getLanguage()}
+        colorMode={colorMode}
+        onColorModeChange={setColorMode}
         onSettingsSave={(locale, timezone, language) => {
           model.setLocale(locale);
           model.setTimezone(timezone);

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -335,16 +335,15 @@
       "locale_example1": "Zahl",
       "locale_example2": "Datum und Uhrzeit",
       "locale_example3": "Formeltrennzeichen",
-      "locale_label": "Regionaleinstellung",
-      "title": "Regionaleinstellung"
+      "locale_label": "Regionaleinstellung"
     },
-    "open_regional_settings": "Regionaleinstellungen öffnen",
+    "open_regional_settings": "Einstellungen öffnen",
+    "regional_title": "Regionaleinstellungen",
     "timezone": {
       "timezone_helper": "Das Ändern dieser Einstellung wirkt sich auf datums- und zeitbezogene Funktionen aus, einschließlich HEUTE() und JETZT().",
-      "timezone_label": "Zeitzone",
-      "title": "Zeitzone"
+      "timezone_label": "Zeitzone"
     },
-    "title": "Regionaleinstellungen"
+    "title": "Einstellungen"
   },
   "right_drawer": {
     "close": "Schließen",

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -317,7 +317,6 @@
     "appearance": {
       "dark": "Dunkel",
       "light": "Hell",
-      "system": "System",
       "theme_label": "Design",
       "title": "Erscheinungsbild"
     },

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -314,6 +314,13 @@
     "title": "Benutzerdefiniertes Zahlenformat"
   },
   "regional_settings": {
+    "appearance": {
+      "dark": "Dunkel",
+      "light": "Hell",
+      "system": "System",
+      "theme_label": "Design",
+      "title": "Erscheinungsbild"
+    },
     "language": {
       "display_language": {
         "de": "Deutsch",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -314,6 +314,13 @@
     "title": "Custom number format"
   },
   "regional_settings": {
+    "appearance": {
+      "dark": "Dark",
+      "light": "Light",
+      "system": "System",
+      "theme_label": "Theme",
+      "title": "Appearance"
+    },
     "language": {
       "display_language": {
         "de": "Deutsch",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -335,16 +335,15 @@
       "locale_example1": "Number",
       "locale_example2": "Date and Time",
       "locale_example3": "Formula delimiter",
-      "locale_label": "Locale",
-      "title": "Locale"
+      "locale_label": "Locale"
     },
-    "open_regional_settings": "Open regional settings",
+    "open_regional_settings": "Open settings",
+    "regional_title": "Regional settings",
     "timezone": {
       "timezone_helper": "Modifying this setting will impact date- and time-related functions, including TODAY() and NOW().",
-      "timezone_label": "Timezone",
-      "title": "Timezone"
+      "timezone_label": "Timezone"
     },
-    "title": "Regional Settings"
+    "title": "Settings"
   },
   "right_drawer": {
     "close": "Close",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -317,7 +317,6 @@
     "appearance": {
       "dark": "Dark",
       "light": "Light",
-      "system": "System",
       "theme_label": "Theme",
       "title": "Appearance"
     },

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -317,7 +317,6 @@
     "appearance": {
       "dark": "Oscuro",
       "light": "Claro",
-      "system": "Sistema",
       "theme_label": "Tema",
       "title": "Apariencia"
     },

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -314,6 +314,13 @@
     "title": "Formato de número personalizado"
   },
   "regional_settings": {
+    "appearance": {
+      "dark": "Oscuro",
+      "light": "Claro",
+      "system": "Sistema",
+      "theme_label": "Tema",
+      "title": "Apariencia"
+    },
     "language": {
       "display_language": {
         "de": "Deutsch",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -335,16 +335,15 @@
       "locale_example1": "Número",
       "locale_example2": "Fecha y hora",
       "locale_example3": "Delimitador de fórmulas",
-      "locale_label": "Configuración regional",
-      "title": "Configuración regional"
+      "locale_label": "Configuración regional"
     },
-    "open_regional_settings": "Abrir configuración regional",
+    "open_regional_settings": "Abrir ajustes",
+    "regional_title": "Configuración regional",
     "timezone": {
       "timezone_helper": "Modificar esta configuración afectará a las funciones relacionadas con fecha y hora, incluyendo HOY() y AHORA().",
-      "timezone_label": "Zona horaria",
-      "title": "Zona horaria"
+      "timezone_label": "Zona horaria"
     },
-    "title": "Configuración regional"
+    "title": "Ajustes"
   },
   "right_drawer": {
     "close": "Cerrar",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -335,16 +335,15 @@
       "locale_example1": "Nombre",
       "locale_example2": "Date et heure",
       "locale_example3": "Délimiteur de formule",
-      "locale_label": "Paramètres régionaux",
-      "title": "Paramètres régionaux"
+      "locale_label": "Paramètres régionaux"
     },
-    "open_regional_settings": "Ouvrir les paramètres régionaux",
+    "open_regional_settings": "Ouvrir les paramètres",
+    "regional_title": "Paramètres régionaux",
     "timezone": {
       "timezone_helper": "Modifier ce paramètre aura un impact sur les fonctions liées à la date et à l’heure, y compris AUJOURDHUI() et MAINTENANT().",
-      "timezone_label": "Fuseau horaire",
-      "title": "Fuseau horaire"
+      "timezone_label": "Fuseau horaire"
     },
-    "title": "Paramètres régionaux"
+    "title": "Paramètres"
   },
   "right_drawer": {
     "close": "Fermer",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -314,6 +314,13 @@
     "title": "Format de nombre personnalisé"
   },
   "regional_settings": {
+    "appearance": {
+      "dark": "Sombre",
+      "light": "Clair",
+      "system": "Système",
+      "theme_label": "Thème",
+      "title": "Apparence"
+    },
     "language": {
       "display_language": {
         "de": "Deutsch",

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -317,7 +317,6 @@
     "appearance": {
       "dark": "Sombre",
       "light": "Clair",
-      "system": "Système",
       "theme_label": "Thème",
       "title": "Apparence"
     },

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -317,7 +317,6 @@
     "appearance": {
       "dark": "Scuro",
       "light": "Chiaro",
-      "system": "Sistema",
       "theme_label": "Tema",
       "title": "Aspetto"
     },

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -314,6 +314,13 @@
     "title": "Formato numero personalizzato"
   },
   "regional_settings": {
+    "appearance": {
+      "dark": "Scuro",
+      "light": "Chiaro",
+      "system": "Sistema",
+      "theme_label": "Tema",
+      "title": "Aspetto"
+    },
     "language": {
       "display_language": {
         "de": "Deutsch",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -335,16 +335,15 @@
       "locale_example1": "Numero",
       "locale_example2": "Data e ora",
       "locale_example3": "Separatore formule",
-      "locale_label": "Impostazioni locali",
-      "title": "Impostazioni locali"
+      "locale_label": "Impostazioni locali"
     },
-    "open_regional_settings": "Apri impostazioni regionali",
+    "open_regional_settings": "Apri impostazioni",
+    "regional_title": "Impostazioni regionali",
     "timezone": {
       "timezone_helper": "La modifica di questa impostazione influirà sulle funzioni relative a data e ora, incluse ADESSO() e OGGI().",
-      "timezone_label": "Fuso orario",
-      "title": "Fuso orario"
+      "timezone_label": "Fuso orario"
     },
-    "title": "Impostazioni regionali"
+    "title": "Impostazioni"
   },
   "right_drawer": {
     "close": "Chiudi",

--- a/webapp/IronCalc/src/theme/index.ts
+++ b/webapp/IronCalc/src/theme/index.ts
@@ -1,7 +1,11 @@
+export type { ColorMode } from "./theme";
 export {
+  applyColorMode,
   darkThemeVariables,
   defaultThemeVariables,
+  readStoredColorMode,
   setThemeVariables,
+  storeColorMode,
   unsetThemeVariables,
 } from "./theme";
 export type { PartialIronCalcThemeVariables } from "./themeVariables";

--- a/webapp/IronCalc/src/theme/theme.ts
+++ b/webapp/IronCalc/src/theme/theme.ts
@@ -159,6 +159,48 @@ export const darkThemeVariables: IronCalcThemeVariables = {
     'bold 12px Inter, "Adjusted Arial Fallback", sans-serif',
 };
 
+export type ColorMode = "light" | "dark";
+
+const COLOR_MODE_STORAGE_KEY = "IronCalc-ColorMode";
+
+// Storage access throws in sandboxed iframes (the embed) and in private mode,
+// where the preference simply cannot be remembered.
+
+export function readStoredColorMode(): ColorMode {
+  try {
+    return localStorage.getItem(COLOR_MODE_STORAGE_KEY) === "dark"
+      ? "dark"
+      : "light";
+  } catch {
+    return "light";
+  }
+}
+
+export function storeColorMode(mode: ColorMode): void {
+  try {
+    localStorage.setItem(COLOR_MODE_STORAGE_KEY, mode);
+  } catch {
+    return;
+  }
+}
+
+/**
+ * Applies a color mode to `target`, on top of the CSS defaults in theme.css.
+ * `overrides` (the host's `themeVariables`) always win over the mode palette.
+ */
+export function applyColorMode(
+  mode: ColorMode,
+  target: HTMLElement,
+  overrides?: PartialIronCalcThemeVariables,
+): void {
+  unsetThemeVariables(target);
+  const variables =
+    mode === "dark" ? { ...darkThemeVariables, ...overrides } : overrides;
+  if (variables) {
+    setThemeVariables(variables, target);
+  }
+}
+
 export function setThemeVariables(
   variables: PartialIronCalcThemeVariables,
   target: HTMLElement = document.documentElement,


### PR DESCRIPTION
This PR adds a color mode toggle to the Settings drawer so dark mode is no longer only reachable from the Storybook.

https://github.com/user-attachments/assets/07368326-9793-42cc-a64e-92e645e3c984

### Changes

- **New Appearance section** in the settings drawer, with a Light/Dark toggle. It applies immediately, it is not part of the Save button.
- **The preference is remembered** in `localStorage` (`IronCalc-ColorMode`).
- **The drawer is now "Settings"**, with locale and timezone sections joined into one "Regional settings" section

Closes #1389
Closes #1392 