### PR TITLE
update: promote the toggle to a reusable Switch component

### DIFF
--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/EditNamedStyle.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/EditNamedStyle.tsx
@@ -42,7 +42,7 @@ import { Input } from "../../Input/Input";
 import { Menu } from "../../Menu/Menu";
 import { MenuItem } from "../../Menu/MenuItem";
 import { Select } from "../../Select/Select";
-import { Toggle } from "../../Toggle/Toggle";
+import { Switch } from "../../Switch/Switch";
 import type { FormatStyle } from "../ConditionalFormatting/FormatStylePicker";
 import "./edit-named-style.css";
 import {
@@ -446,7 +446,7 @@ const EditNamedStyle = ({
         </div>
 
         <div className="ic-edit-style-styled-box ic-edit-style-format-group">
-          <Toggle
+          <Switch
             checked={includeFormat}
             onChange={setIncludeFormat}
             label={t("named_styles.number_label")}
@@ -483,7 +483,7 @@ const EditNamedStyle = ({
           )}
         </div>
         <div className="ic-edit-style-styled-box ic-edit-style-format-group">
-          <Toggle
+          <Switch
             checked={includeFont}
             onChange={(checked) => {
               setIncludeFont(checked);
@@ -562,7 +562,7 @@ const EditNamedStyle = ({
           )}
         </div>
         <div className="ic-edit-style-styled-box ic-edit-style-format-group">
-          <Toggle
+          <Switch
             checked={includeFill}
             onChange={(checked) => {
               setIncludeFill(checked);
@@ -611,7 +611,7 @@ const EditNamedStyle = ({
           )}
         </div>
         <div className="ic-edit-style-styled-box ic-edit-style-format-group">
-          <Toggle
+          <Switch
             checked={includeAlignment}
             onChange={setIncludeAlignment}
             label={t("named_styles.alignment_label")}
@@ -684,7 +684,7 @@ const EditNamedStyle = ({
           )}
         </div>
         <div className="ic-edit-style-styled-box ic-edit-style-format-group">
-          <Toggle
+          <Switch
             checked={includeBorder}
             onChange={(checked) => {
               setIncludeBorder(checked);

--- a/webapp/IronCalc/src/components/RightDrawer/NamedStyles/edit-named-style.css
+++ b/webapp/IronCalc/src/components/RightDrawer/NamedStyles/edit-named-style.css
@@ -150,12 +150,12 @@
   gap: 12px;
 }
 
-.ic-edit-style-format-group > .ic-toggle {
+.ic-edit-style-format-group > .ic-switch {
   display: flex;
   justify-content: space-between;
 }
 
-.ic-edit-style-format-group .ic-toggle-label {
+.ic-edit-style-format-group .ic-switch-label {
   font-weight: 800;
 }
 

--- a/webapp/IronCalc/src/components/Switch/Switch.stories.tsx
+++ b/webapp/IronCalc/src/components/Switch/Switch.stories.tsx
@@ -1,23 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
-import type { ToggleProperties } from "./Toggle";
-import { Toggle } from "./Toggle";
+import type { SwitchProperties } from "./Switch";
+import { Switch } from "./Switch";
 
-type ToggleStoryProps = Omit<ToggleProperties, "checked" | "onChange"> & {
+type SwitchStoryProps = Omit<SwitchProperties, "checked" | "onChange"> & {
   checked?: boolean;
 };
 
-// Wrapper so the toggle is controlled by the story, not by the caller.
-function ToggleStory({ checked = false, ...props }: ToggleStoryProps) {
+// Wrapper so the switch is controlled by the story, not by the caller.
+function SwitchStory({ checked = false, ...props }: SwitchStoryProps) {
   const [value, setValue] = useState(checked);
-  return <Toggle {...props} checked={value} onChange={setValue} />;
+  return <Switch {...props} checked={value} onChange={setValue} />;
 }
 
-const defaultArgs: ToggleStoryProps = {};
+const defaultArgs: SwitchStoryProps = {};
 
 const meta = {
-  title: "Components/Toggle",
-  component: ToggleStory,
+  title: "Components/Switch",
+  component: SwitchStory,
   parameters: {
     layout: "centered",
   },
@@ -26,18 +26,18 @@ const meta = {
   argTypes: {
     checked: {
       control: "boolean",
-      description: "Initial state of the toggle",
+      description: "Initial state of the switch",
     },
     disabled: {
       control: "boolean",
-      description: "Disable the toggle",
+      description: "Disable the switch",
     },
     label: {
       control: "text",
       description: "Optional label rendered on the left of the switch",
     },
   },
-} satisfies Meta<typeof ToggleStory>;
+} satisfies Meta<typeof SwitchStory>;
 
 export default meta;
 
@@ -53,8 +53,8 @@ export const Default: Story = {
   args: defaultArgs,
   render: () => (
     <Column>
-      <ToggleStory checked />
-      <ToggleStory />
+      <SwitchStory checked />
+      <SwitchStory />
     </Column>
   ),
 };
@@ -63,8 +63,8 @@ export const WithLabel: Story = {
   args: defaultArgs,
   render: () => (
     <Column>
-      <ToggleStory label="On" checked />
-      <ToggleStory label="Off" />
+      <SwitchStory label="On" checked />
+      <SwitchStory label="Off" />
     </Column>
   ),
 };
@@ -73,8 +73,8 @@ export const Disabled: Story = {
   args: defaultArgs,
   render: () => (
     <Column>
-      <ToggleStory label="On" checked disabled />
-      <ToggleStory label="Off" disabled />
+      <SwitchStory label="On" checked disabled />
+      <SwitchStory label="Off" disabled />
     </Column>
   ),
 };

--- a/webapp/IronCalc/src/components/Switch/Switch.tsx
+++ b/webapp/IronCalc/src/components/Switch/Switch.tsx
@@ -5,10 +5,10 @@ import {
   useId,
 } from "react";
 
-import "./toggle.css";
+import "./switch.css";
 
 /**
- * This is a reusable toggle switch with an optional label on its left.
+ * This is a reusable switch with an optional label on its left.
  * States: default, hover, focused, disabled.
  */
 
@@ -18,7 +18,7 @@ import "./toggle.css";
  * `onChange` receives the new checked value, not the event.
  */
 
-export interface ToggleProperties
+export interface SwitchProperties
   extends Omit<
     InputHTMLAttributes<HTMLInputElement>,
     "type" | "onChange" | "size"
@@ -28,8 +28,8 @@ export interface ToggleProperties
   label?: ReactNode;
 }
 
-export const Toggle = forwardRef<HTMLInputElement, ToggleProperties>(
-  function Toggle(
+export const Switch = forwardRef<HTMLInputElement, SwitchProperties>(
+  function Switch(
     {
       checked,
       onChange,
@@ -44,12 +44,12 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProperties>(
   ) {
     const autoId = useId();
     const id = idProperty ?? autoId;
-    const toggleClassName = ["ic-toggle", disabled && "disabled", className]
+    const switchClassName = ["ic-switch", disabled && "disabled", className]
       .filter(Boolean)
       .join(" ");
     return (
-      <label className={toggleClassName} style={style} htmlFor={id}>
-        {label && <span className="ic-toggle-label">{label}</span>}
+      <label className={switchClassName} style={style} htmlFor={id}>
+        {label && <span className="ic-switch-label">{label}</span>}
         <input
           ref={ref}
           id={id}
@@ -59,15 +59,15 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProperties>(
           checked={checked}
           disabled={disabled}
           onChange={(event) => onChange(event.target.checked)}
-          className="ic-toggle-input"
+          className="ic-switch-input"
           {...rest}
         />
-        <span className="ic-toggle-track" aria-hidden="true">
-          <span className="ic-toggle-thumb" />
+        <span className="ic-switch-track" aria-hidden="true">
+          <span className="ic-switch-thumb" />
         </span>
       </label>
     );
   },
 );
 
-Toggle.displayName = "Toggle";
+Switch.displayName = "Switch";

--- a/webapp/IronCalc/src/components/Switch/switch.css
+++ b/webapp/IronCalc/src/components/Switch/switch.css
@@ -1,4 +1,4 @@
-.ic-toggle {
+.ic-switch {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -8,22 +8,22 @@
   color: var(--palette-common-black);
 }
 
-.ic-toggle.disabled {
+.ic-switch.disabled {
   cursor: default;
   opacity: 0.5;
 }
 
-.ic-toggle-label {
+.ic-switch-label {
   font-weight: 500;
   transition: opacity 150ms ease;
 }
 
-.ic-toggle:has(.ic-toggle-input:not(:checked)) .ic-toggle-label {
+.ic-switch:has(.ic-switch-input:not(:checked)) .ic-switch-label {
   opacity: 0.5;
 }
 
 /* Visually hidden but focusable */
-.ic-toggle-input {
+.ic-switch-input {
   position: absolute;
   width: 1px;
   height: 1px;
@@ -35,7 +35,7 @@
   white-space: nowrap;
 }
 
-.ic-toggle-track {
+.ic-switch-track {
   position: relative;
   flex-shrink: 0;
   width: 28px;
@@ -45,24 +45,24 @@
   transition: background-color 150ms ease;
 }
 
-.ic-toggle:hover .ic-toggle-input:not(:disabled, :checked) + .ic-toggle-track {
+.ic-switch:hover .ic-switch-input:not(:disabled, :checked) + .ic-switch-track {
   background-color: var(--palette-grey-500);
 }
 
-.ic-toggle-input:checked + .ic-toggle-track {
+.ic-switch-input:checked + .ic-switch-track {
   background-color: var(--palette-primary-main);
 }
 
-.ic-toggle:hover .ic-toggle-input:checked:not(:disabled) + .ic-toggle-track {
+.ic-switch:hover .ic-switch-input:checked:not(:disabled) + .ic-switch-track {
   background-color: var(--palette-primary-dark);
 }
 
-.ic-toggle-input:focus-visible + .ic-toggle-track {
+.ic-switch-input:focus-visible + .ic-switch-track {
   outline: 2px solid var(--palette-primary-main);
   outline-offset: 2px;
 }
 
-.ic-toggle-thumb {
+.ic-switch-thumb {
   position: absolute;
   top: 2px;
   left: 2px;
@@ -73,6 +73,6 @@
   transition: transform 150ms ease;
 }
 
-.ic-toggle-input:checked + .ic-toggle-track .ic-toggle-thumb {
+.ic-switch-input:checked + .ic-switch-track .ic-switch-thumb {
   transform: translateX(12px);
 }

--- a/webapp/IronCalc/src/components/Toggle/Toggle.stories.tsx
+++ b/webapp/IronCalc/src/components/Toggle/Toggle.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import type { ToggleProperties } from "./Toggle";
+import { Toggle } from "./Toggle";
+
+type ToggleStoryProps = Omit<ToggleProperties, "checked" | "onChange"> & {
+  checked?: boolean;
+};
+
+// Wrapper so the toggle is controlled by the story, not by the caller.
+function ToggleStory({ checked = false, ...props }: ToggleStoryProps) {
+  const [value, setValue] = useState(checked);
+  return <Toggle {...props} checked={value} onChange={setValue} />;
+}
+
+const defaultArgs: ToggleStoryProps = {};
+
+const meta = {
+  title: "Components/Toggle",
+  component: ToggleStory,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: defaultArgs,
+  argTypes: {
+    checked: {
+      control: "boolean",
+      description: "Initial state of the toggle",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Disable the toggle",
+    },
+    label: {
+      control: "text",
+      description: "Optional label rendered on the left of the switch",
+    },
+  },
+} satisfies Meta<typeof ToggleStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Column = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+    {children}
+  </div>
+);
+
+export const Default: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <ToggleStory checked />
+      <ToggleStory />
+    </Column>
+  ),
+};
+
+export const WithLabel: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <ToggleStory label="On" checked />
+      <ToggleStory label="Off" />
+    </Column>
+  ),
+};
+
+export const Disabled: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <ToggleStory label="On" checked disabled />
+      <ToggleStory label="Off" disabled />
+    </Column>
+  ),
+};

--- a/webapp/IronCalc/src/components/Toggle/Toggle.tsx
+++ b/webapp/IronCalc/src/components/Toggle/Toggle.tsx
@@ -1,55 +1,73 @@
-import { type ReactNode, useId } from "react";
+import {
+  forwardRef,
+  type InputHTMLAttributes,
+  type ReactNode,
+  useId,
+} from "react";
 
 import "./toggle.css";
 
 /**
- * Reusable toggle switch with an optional label shown on its left.
+ * This is a reusable toggle switch with an optional label on its left.
  * States: default, hover, focused, disabled.
  */
 
-export interface ToggleProps {
+/** Extends native `<input type="checkbox">` props.
+ * Defaults: `disabled` false.
+ * Optional: `label`.
+ * `onChange` receives the new checked value, not the event.
+ */
+
+export interface ToggleProperties
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    "type" | "onChange" | "size"
+  > {
   checked: boolean;
   onChange: (checked: boolean) => void;
   label?: ReactNode;
-  disabled?: boolean;
-  id?: string;
-  className?: string;
 }
 
-export function Toggle({
-  checked,
-  onChange,
-  label,
-  disabled = false,
-  id,
-  className,
-}: ToggleProps) {
-  const autoId = useId();
-  const toggleId = id ?? autoId;
-
-  return (
-    <label
-      className={["ic-toggle", disabled && "disabled", className]
-        .filter(Boolean)
-        .join(" ")}
-      htmlFor={toggleId}
-    >
-      {label && <span className="ic-toggle-label">{label}</span>}
-      <input
-        id={toggleId}
-        type="checkbox"
-        role="switch"
-        aria-checked={checked}
-        className="ic-toggle-input"
-        checked={checked}
-        disabled={disabled}
-        onChange={(event) => onChange(event.target.checked)}
-      />
-      <span className="ic-toggle-track" aria-hidden="true">
-        <span className="ic-toggle-thumb" />
-      </span>
-    </label>
-  );
-}
+export const Toggle = forwardRef<HTMLInputElement, ToggleProperties>(
+  function Toggle(
+    {
+      checked,
+      onChange,
+      label,
+      disabled = false,
+      id: idProperty,
+      style,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const autoId = useId();
+    const id = idProperty ?? autoId;
+    const toggleClassName = ["ic-toggle", disabled && "disabled", className]
+      .filter(Boolean)
+      .join(" ");
+    return (
+      <label className={toggleClassName} style={style} htmlFor={id}>
+        {label && <span className="ic-toggle-label">{label}</span>}
+        <input
+          ref={ref}
+          id={id}
+          type="checkbox"
+          role="switch"
+          aria-checked={checked}
+          checked={checked}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.checked)}
+          className="ic-toggle-input"
+          {...rest}
+        />
+        <span className="ic-toggle-track" aria-hidden="true">
+          <span className="ic-toggle-thumb" />
+        </span>
+      </label>
+    );
+  },
+);
 
 Toggle.displayName = "Toggle";

--- a/webapp/IronCalc/src/index.ts
+++ b/webapp/IronCalc/src/index.ts
@@ -23,6 +23,8 @@ export type {
 export { MenuItem, MenuItemWithSubmenu } from "./components/Menu/MenuItem";
 export type { ConfirmProperties } from "./components/Modal/Confirm";
 export { Confirm } from "./components/Modal/Confirm";
+export type { ToggleProperties } from "./components/Toggle/Toggle";
+export { Toggle } from "./components/Toggle/Toggle";
 export type { TooltipProperties } from "./components/Tooltip/Tooltip";
 export { Tooltip } from "./components/Tooltip/Tooltip";
 export type { IronCalcHandle } from "./IronCalc";

--- a/webapp/IronCalc/src/index.ts
+++ b/webapp/IronCalc/src/index.ts
@@ -23,8 +23,8 @@ export type {
 export { MenuItem, MenuItemWithSubmenu } from "./components/Menu/MenuItem";
 export type { ConfirmProperties } from "./components/Modal/Confirm";
 export { Confirm } from "./components/Modal/Confirm";
-export type { ToggleProperties } from "./components/Toggle/Toggle";
-export { Toggle } from "./components/Toggle/Toggle";
+export type { SwitchProperties } from "./components/Switch/Switch";
+export { Switch } from "./components/Switch/Switch";
 export type { TooltipProperties } from "./components/Tooltip/Tooltip";
 export { Tooltip } from "./components/Tooltip/Tooltip";
 export type { IronCalcHandle } from "./IronCalc";


### PR DESCRIPTION
This PR brings some cleanup to the design system and turns the internal toggle into a proper library component. It also renames it to **Switch**, which seems to be a more accurate name [1]. This component will be used in coming updates so better have this done now.

### Changes

- Renamed Toggle to Switch: folder, files, SwitchProperties, and the ic-toggle* CSS classes are now ic-switch*. Note that the large amount of additions is because the main file has been renamed.
- Rewrote the component to match other component's structure: forwardRef, extends native <input type="checkbox"> props, class list hoisted above the return, same doc comment format
- Added the missing `Switch.stories.tsx` 
- Exported Switch and SwitchProperties from `src/index.ts`
- Updated the 5 call sites in `EditNamedStyle.tsx` and its CSS overrides

No visual or behavioral change: the public API (checked, onChange, label, disabled) and the styles are the same.

---

[1] Some authorized voices like [Nielsen Norman group](https://www.nngroup.com/articles/toggle-switch-guidelines/) and [Shadcn's library](https://ui.shadcn.com/docs/components/base/switch) call this component switch.