### PR TITLE
FIX: Drop zip's `time` feature so xlsx export works on wasm32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,7 +1302,6 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "time",
 ]
 
 [[package]]

--- a/xlsx/Cargo.toml
+++ b/xlsx/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 mock_time = ["ironcalc_base/mock_time"]
 
 [dependencies]
-zip = { version = "0.6.6", default-features = false, features = ["deflate", "time"] }
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 roxmltree = "0.19"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
`save_xlsx_to_writer` traps on `wasm32-unknown-unknown`. With zip's `time` feature on, `FileOptions::default()` stamps each entry with `OffsetDateTime::now_utc()` (zip 0.6.6, `src/write.rs:217`). On that target this reaches `std::time::SystemTime::now()`, which is unimplemented and panics. In the browser it shows up as `RuntimeError: unreachable`.

The `xlsx` crate never reads or sets entry timestamps. Without the feature, entries get the DOS epoch (1980-01-01) as mtime. `time` and its transitive dependencies drop out of the dependency tree.

Same motivation as #1359, which dropped the C-backed compressors.

Tested under Node via wasm-bindgen: load a CSV, set `C2 =A2*B2+SUM(A3:B3)`, `save_xlsx_to_writer`, `load_from_xlsx_bytes`. After reload C2 still holds that formula and shows 9, and setting `D2 =C2*10` in the reopened model evaluates to 90. `cargo test -p ironcalc` passes.
