### PR TITLE
update: add a reusable Checkbox component

### DIFF
--- a/webapp/IronCalc/src/components/Checkbox/Checkbox.stories.tsx
+++ b/webapp/IronCalc/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import type { CheckboxProperties } from "./Checkbox";
+import { Checkbox } from "./Checkbox";
+
+type CheckboxStoryProps = Omit<CheckboxProperties, "checked" | "onChange"> & {
+  checked?: boolean;
+};
+
+// Wrapper so the checkbox is controlled by the story, not by the caller.
+function CheckboxStory({ checked = false, ...props }: CheckboxStoryProps) {
+  const [value, setValue] = useState(checked);
+  return <Checkbox {...props} checked={value} onChange={setValue} />;
+}
+
+const defaultArgs: CheckboxStoryProps = {};
+
+const meta = {
+  title: "Components/Checkbox",
+  component: CheckboxStory,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: defaultArgs,
+  argTypes: {
+    checked: {
+      control: "boolean",
+      description: "Initial state of the checkbox",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Disable the checkbox",
+    },
+    label: {
+      control: "text",
+      description: "Optional label rendered on the right of the checkbox",
+    },
+  },
+} satisfies Meta<typeof CheckboxStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Column = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+    {children}
+  </div>
+);
+
+export const Default: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <CheckboxStory checked />
+      <CheckboxStory />
+    </Column>
+  ),
+};
+
+export const WithLabel: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <CheckboxStory label="Checked" checked />
+      <CheckboxStory label="Unchecked" />
+    </Column>
+  ),
+};
+
+export const Disabled: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <CheckboxStory label="Checked" checked disabled />
+      <CheckboxStory label="Unchecked" disabled />
+    </Column>
+  ),
+};

--- a/webapp/IronCalc/src/components/Checkbox/Checkbox.tsx
+++ b/webapp/IronCalc/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,69 @@
+import {
+  forwardRef,
+  type InputHTMLAttributes,
+  type ReactNode,
+  useId,
+} from "react";
+
+import "./checkbox.css";
+
+/**
+ * This is a reusable checkbox with an optional label on its right.
+ * States: default, hover, focused, disabled.
+ */
+
+/** Extends native `<input type="checkbox">` props.
+ * Defaults: `disabled` false.
+ * Optional: `label`.
+ * `onChange` receives the new checked value, not the event.
+ */
+
+export interface CheckboxProperties
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    "type" | "onChange" | "size"
+  > {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label?: ReactNode;
+}
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProperties>(
+  function Checkbox(
+    {
+      checked,
+      onChange,
+      label,
+      disabled = false,
+      id: idProperty,
+      style,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const autoId = useId();
+    const id = idProperty ?? autoId;
+    const checkboxClassName = ["ic-checkbox", disabled && "disabled", className]
+      .filter(Boolean)
+      .join(" ");
+    return (
+      <label className={checkboxClassName} style={style} htmlFor={id}>
+        <input
+          ref={ref}
+          id={id}
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.checked)}
+          className="ic-checkbox-input"
+          {...rest}
+        />
+        <span className="ic-checkbox-box" aria-hidden="true" />
+        {label && <span className="ic-checkbox-label">{label}</span>}
+      </label>
+    );
+  },
+);
+
+Checkbox.displayName = "Checkbox";

--- a/webapp/IronCalc/src/components/Checkbox/checkbox.css
+++ b/webapp/IronCalc/src/components/Checkbox/checkbox.css
@@ -1,0 +1,76 @@
+.ic-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: var(--typography-font-size);
+  font-family: var(--typography-font-family);
+  color: var(--palette-common-black);
+}
+
+.ic-checkbox.disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+/* Visually hidden but focusable */
+.ic-checkbox-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.ic-checkbox-box {
+  position: relative;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid var(--palette-grey-400);
+  border-radius: 4px;
+  background-color: var(--palette-common-white);
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease;
+}
+
+.ic-checkbox:hover
+  .ic-checkbox-input:not(:disabled, :checked)
+  + .ic-checkbox-box {
+  border-color: var(--palette-grey-500);
+}
+
+.ic-checkbox-input:checked + .ic-checkbox-box {
+  background-color: var(--palette-primary-main);
+  border-color: var(--palette-primary-main);
+}
+
+.ic-checkbox:hover
+  .ic-checkbox-input:checked:not(:disabled)
+  + .ic-checkbox-box {
+  background-color: var(--palette-primary-dark);
+  border-color: var(--palette-primary-dark);
+}
+
+.ic-checkbox-input:focus-visible + .ic-checkbox-box {
+  outline: 2px solid var(--palette-primary-main);
+  outline-offset: 2px;
+}
+
+.ic-checkbox-input:checked + .ic-checkbox-box::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 3px;
+  height: 6px;
+  border: 2px solid var(--palette-common-white);
+  border-top: none;
+  border-left: none;
+  transform: rotate(45deg) translate(-1px, -1px);
+}

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/ClassicRule.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/ClassicRule.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../Button/Button";
 import { IconButton } from "../../Button/IconButton";
+import { Checkbox } from "../../Checkbox/Checkbox";
 import { Input } from "../../Input/Input";
 import { Select } from "../../Select/Select";
 import { Tooltip } from "../../Tooltip/Tooltip";
@@ -329,14 +330,11 @@ const ClassicRule = ({
           />
         </div>
         <div className="ic-edit-rule-section">
-          <label className="ic-edit-rule-checkbox-row">
-            <input
-              type="checkbox"
-              checked={stopIfTrue}
-              onChange={(e) => setStopIfTrue(e.target.checked)}
-            />
-            {t("conditional_formatting.stop_if_true")}
-          </label>
+          <Checkbox
+            checked={stopIfTrue}
+            onChange={setStopIfTrue}
+            label={t("conditional_formatting.stop_if_true")}
+          />
         </div>
       </div>
       <div className="ic-edit-rule-footer">

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/DataBarsRule.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/DataBarsRule.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../Button/Button";
 import { IconButton } from "../../Button/IconButton";
+import { Checkbox } from "../../Checkbox/Checkbox";
 import ColorPicker from "../../ColorPicker/ColorPicker";
 import { resolveColorToHex } from "../../ColorPicker/util";
 import { Input } from "../../Input/Input";
@@ -460,19 +461,16 @@ const DataBarsRule = ({
             <div className="ic-edit-rule-label">
               {t("conditional_formatting.data_bars_preferences")}
             </div>
-            <label className="ic-edit-rule-checkbox-row">
-              <input
-                type="checkbox"
-                checked={!selected.hideCellContent}
-                onChange={(e) =>
-                  setSelected((s) => ({
-                    ...s,
-                    hideCellContent: !e.target.checked,
-                  }))
-                }
-              />
-              {t("conditional_formatting.data_bars_show_value")}
-            </label>
+            <Checkbox
+              checked={!selected.hideCellContent}
+              onChange={(checked) =>
+                setSelected((s) => ({
+                  ...s,
+                  hideCellContent: !checked,
+                }))
+              }
+              label={t("conditional_formatting.data_bars_show_value")}
+            />
           </div>
         </div>
       </div>

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/IconSetsRule.tsx
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/IconSetsRule.tsx
@@ -26,6 +26,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../Button/Button";
 import { IconButton } from "../../Button/IconButton";
+import { Checkbox } from "../../Checkbox/Checkbox";
 import ColorPicker from "../../ColorPicker/ColorPicker";
 import { resolveColorToHex } from "../../ColorPicker/util";
 import IconPicker, { iconSpecFor } from "../../IconPicker/IconPicker";
@@ -880,14 +881,11 @@ const IconSetsRule = ({
             <div className="ic-edit-rule-label">
               {t("conditional_formatting.data_bars_preferences")}
             </div>
-            <label className="ic-edit-rule-checkbox-row">
-              <input
-                type="checkbox"
-                checked={showValue}
-                onChange={(e) => setShowValue(e.target.checked)}
-              />
-              {t("conditional_formatting.icon_sets_show_value")}
-            </label>
+            <Checkbox
+              checked={showValue}
+              onChange={setShowValue}
+              label={t("conditional_formatting.icon_sets_show_value")}
+            />
           </div>
         </div>
       </div>

--- a/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/edit-rule.css
+++ b/webapp/IronCalc/src/components/RightDrawer/ConditionalFormatting/edit-rule.css
@@ -254,48 +254,6 @@
   height: 100%;
 }
 
-.ic-edit-rule-checkbox-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: var(--typography-font-size);
-  font-family: var(--typography-font-family);
-  color: var(--palette-common-black);
-  cursor: pointer;
-  margin: 4px 0;
-}
-
-.ic-edit-rule-checkbox-row input[type="checkbox"] {
-  appearance: none;
-  width: 14px;
-  height: 14px;
-  border: 1.5px solid var(--palette-grey-400);
-  border-radius: 4px;
-  background: var(--palette-common-white);
-  cursor: pointer;
-  position: relative;
-  flex-shrink: 0;
-  margin: 0;
-}
-
-.ic-edit-rule-checkbox-row input[type="checkbox"]:checked {
-  background: var(--palette-primary-main);
-  border-color: var(--palette-primary-main);
-}
-
-.ic-edit-rule-checkbox-row input[type="checkbox"]:checked::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  margin: auto;
-  width: 3px;
-  height: 6px;
-  border: 2px solid var(--palette-common-white);
-  border-top: none;
-  border-left: none;
-  transform: rotate(45deg) translate(-1px, -1px);
-}
-
 .ic-fsp-preset[aria-pressed="true"] {
   outline: 1px solid var(--palette-common-black);
   outline-offset: 1px;

--- a/webapp/IronCalc/src/index.ts
+++ b/webapp/IronCalc/src/index.ts
@@ -11,6 +11,8 @@ export type {
 export { Button } from "./components/Button/Button";
 export type { IconButtonProperties } from "./components/Button/IconButton";
 export { IconButton } from "./components/Button/IconButton";
+export type { CheckboxProperties } from "./components/Checkbox/Checkbox";
+export { Checkbox } from "./components/Checkbox/Checkbox";
 export type { InputProperties, InputSize } from "./components/Input/Input";
 export { Input } from "./components/Input/Input";
 export type { MenuProperties } from "./components/Menu/Menu";


### PR DESCRIPTION
This new PR follows the same principle as #1405 and adds a Checkbox component as we were missing it. We already use it in a few places and will keep using it in the future so it's good to have it in one place instead of 3-4 as we have now.

<img width="100%" height="auto" alt="image" src="https://github.com/user-attachments/assets/0fe40d3c-1bd0-458e-a997-d33a8edea96e" />