### PR TITLE
update: add a reusable component for Toggle Buttons

### DIFF
--- a/webapp/IronCalc/src/components/Button/Button.tsx
+++ b/webapp/IronCalc/src/components/Button/Button.tsx
@@ -17,7 +17,7 @@ export type ButtonVariant =
 export type ButtonSize = "xs" | "sm" | "md";
 
 /** Extends native `<button>` props.
- * Defaults: `variant` "primary", `size` "md", `pressed` false.
+ * Defaults: `variant` "primary", `size` "md", `pressed` false, `type` "button".
  * Optional: `startIcon`, `endIcon`.
  */
 
@@ -57,6 +57,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProperties>(
     return (
       <button
         ref={ref}
+        type="button"
         disabled={disabled}
         aria-pressed={pressed}
         className={buttonClassName}

--- a/webapp/IronCalc/src/components/Button/IconButton.tsx
+++ b/webapp/IronCalc/src/components/Button/IconButton.tsx
@@ -6,7 +6,7 @@ export type { ButtonSize, ButtonVariant };
 /**
  * Icon-only button. Same variants and sizes as Button.
  * Use it for toolbar actions, to close drawers and modals, etc.
- * Defaults: `variant` "ghost", `size` "sm", `pressed` false.
+ * Defaults: `variant` "ghost", `size` "sm", `pressed` false, `type` "button".
  */
 export interface IconButtonProperties
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "aria-label"> {
@@ -44,6 +44,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProperties>(
     return (
       <button
         ref={ref}
+        type="button"
         className={buttonClassName}
         disabled={disabled}
         aria-pressed={pressed}

--- a/webapp/IronCalc/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/webapp/IronCalc/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AlignCenter, AlignLeft, AlignRight } from "lucide-react";
+import { useState } from "react";
+import type { ToggleButtonProperties } from "./ToggleButton";
+import { ToggleButton } from "./ToggleButton";
+
+type ToggleButtonStoryProps = Omit<
+  ToggleButtonProperties<string>,
+  "value" | "onChange"
+> & {
+  value?: string;
+};
+
+// Wrapper so the selection is controlled by the story, not by the caller.
+function ToggleButtonStory({
+  value,
+  options,
+  ...props
+}: ToggleButtonStoryProps) {
+  const [selected, setSelected] = useState(value ?? options[0].value);
+  return (
+    <ToggleButton
+      {...props}
+      options={options}
+      value={selected}
+      onChange={setSelected}
+    />
+  );
+}
+
+const modeOptions = [
+  { value: "preset", label: "Presets" },
+  { value: "ratings", label: "Ratings" },
+];
+
+const operatorOptions = [
+  { value: ">=", icon: "≥", "aria-label": "Greater than or equal" },
+  { value: ">", icon: ">", "aria-label": "Greater than" },
+];
+
+const alignOptions = [
+  { value: "left", icon: <AlignLeft />, "aria-label": "Align left" },
+  { value: "center", icon: <AlignCenter />, "aria-label": "Align center" },
+  { value: "right", icon: <AlignRight />, "aria-label": "Align right" },
+];
+
+const defaultArgs: ToggleButtonStoryProps = { options: modeOptions };
+
+const meta = {
+  title: "Components/ToggleButton",
+  component: ToggleButtonStory,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: defaultArgs,
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md"],
+      description: "Size of the buttons",
+    },
+    fullWidth: {
+      control: "boolean",
+      description: "Stretch the group and share its width between the options",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Disable every option",
+    },
+  },
+} satisfies Meta<typeof ToggleButtonStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const Column = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+    {children}
+  </div>
+);
+
+export const Default: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <ToggleButtonStory options={modeOptions} />
+      <ToggleButtonStory options={operatorOptions} />
+      <ToggleButtonStory options={alignOptions} />
+    </Column>
+  ),
+};
+
+export const Sizes: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <ToggleButtonStory options={alignOptions} size="xs" />
+      <ToggleButtonStory options={alignOptions} size="sm" />
+      <ToggleButtonStory options={alignOptions} size="md" />
+    </Column>
+  ),
+};
+
+export const FullWidth: Story = {
+  args: defaultArgs,
+  render: () => (
+    <div style={{ width: 260 }}>
+      <ToggleButtonStory options={modeOptions} fullWidth />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <ToggleButtonStory options={modeOptions} disabled />
+      <ToggleButtonStory
+        options={[
+          { value: "preset", label: "Presets" },
+          { value: "ratings", label: "Ratings", disabled: true },
+        ]}
+      />
+    </Column>
+  ),
+};

--- a/webapp/IronCalc/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/webapp/IronCalc/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -1,7 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { AlignCenter, AlignLeft, AlignRight } from "lucide-react";
+import {
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  Bold,
+  Italic,
+  Strikethrough,
+  Underline,
+} from "lucide-react";
 import { useState } from "react";
-import type { ToggleButtonProperties } from "./ToggleButton";
+import type {
+  ToggleButtonOption,
+  ToggleButtonProperties,
+} from "./ToggleButton";
 import { ToggleButton } from "./ToggleButton";
 
 type ToggleButtonStoryProps = Omit<
@@ -24,6 +35,18 @@ function ToggleButtonStory({
       options={options}
       value={selected}
       onChange={setSelected}
+    />
+  );
+}
+
+// A lone option toggles on and off: the empty value matches no option.
+function SingleOptionStory({ option }: { option: ToggleButtonOption<string> }) {
+  const [value, setValue] = useState(option.value);
+  return (
+    <ToggleButton
+      options={[option]}
+      value={value}
+      onChange={(next) => setValue(value === next ? "" : next)}
     />
   );
 }
@@ -88,6 +111,37 @@ export const Default: Story = {
       <ToggleButtonStory options={modeOptions} />
       <ToggleButtonStory options={operatorOptions} />
       <ToggleButtonStory options={alignOptions} />
+    </Column>
+  ),
+};
+
+export const SingleOption: Story = {
+  args: defaultArgs,
+  render: () => (
+    <Column>
+      <SingleOptionStory option={{ value: "bold", label: "Bold" }} />
+      <div style={{ display: "flex", gap: 4 }}>
+        <SingleOptionStory
+          option={{ value: "bold", icon: <Bold />, "aria-label": "Bold" }}
+        />
+        <SingleOptionStory
+          option={{ value: "italic", icon: <Italic />, "aria-label": "Italic" }}
+        />
+        <SingleOptionStory
+          option={{
+            value: "underline",
+            icon: <Underline />,
+            "aria-label": "Underline",
+          }}
+        />
+        <SingleOptionStory
+          option={{
+            value: "strikethrough",
+            icon: <Strikethrough />,
+            "aria-label": "Strikethrough",
+          }}
+        />
+      </div>
     </Column>
   ),
 };

--- a/webapp/IronCalc/src/components/ToggleButton/ToggleButton.tsx
+++ b/webapp/IronCalc/src/components/ToggleButton/ToggleButton.tsx
@@ -12,11 +12,9 @@ import "./toggle-button.css";
 
 export interface ToggleButtonOption<T extends string> {
   value: T;
-  /** Text of the button. Omit it to get an icon-only button. */
-  label?: ReactNode;
+  label?: ReactNode /** Text of the button. Omit it to get an icon-only button. */;
   icon?: ReactNode;
-  /** Required when there is no `label`. */
-  "aria-label"?: string;
+  "aria-label"?: string /** Required when there is no `label`. */;
   disabled?: boolean;
 }
 
@@ -31,13 +29,10 @@ export interface ToggleButtonProperties<T extends string>
   value: T;
   onChange: (value: T) => void;
   size?: ButtonSize;
-  /** Stretch the group and share its width equally between the options. */
   fullWidth?: boolean;
   disabled?: boolean;
 }
 
-// Not a forwardRef like the other components: a generic forwardRef needs a cast
-// that loses the inference on `value`/`onChange`, and nobody needs the ref.
 export function ToggleButton<T extends string>({
   options,
   value,

--- a/webapp/IronCalc/src/components/ToggleButton/ToggleButton.tsx
+++ b/webapp/IronCalc/src/components/ToggleButton/ToggleButton.tsx
@@ -1,0 +1,92 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { Button, type ButtonSize } from "../Button/Button";
+import { IconButton } from "../Button/IconButton";
+
+import "./toggle-button.css";
+
+/**
+ * A group of mutually exclusive buttons where exactly one option is selected.
+ * Every option is a "ghost" Button; the selected one is the pressed Button.
+ * Sizes: xs, sm, md (same as Button).
+ */
+
+export interface ToggleButtonOption<T extends string> {
+  value: T;
+  /** Text of the button. Omit it to get an icon-only button. */
+  label?: ReactNode;
+  icon?: ReactNode;
+  /** Required when there is no `label`. */
+  "aria-label"?: string;
+  disabled?: boolean;
+}
+
+/** Extends native `<div>` props.
+ * Defaults: `size` "sm", `fullWidth` false.
+ * `onChange` receives the new value, not the event.
+ */
+
+export interface ToggleButtonProperties<T extends string>
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+  options: ToggleButtonOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  size?: ButtonSize;
+  /** Stretch the group and share its width equally between the options. */
+  fullWidth?: boolean;
+  disabled?: boolean;
+}
+
+// Not a forwardRef like the other components: a generic forwardRef needs a cast
+// that loses the inference on `value`/`onChange`, and nobody needs the ref.
+export function ToggleButton<T extends string>({
+  options,
+  value,
+  onChange,
+  size = "sm",
+  fullWidth = false,
+  disabled = false,
+  className,
+  style,
+  ...rest
+}: ToggleButtonProperties<T>) {
+  const groupClassName = [
+    "ic-toggle-button",
+    fullWidth && "ic-toggle-button--full-width",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={groupClassName} style={style} {...rest}>
+      {options.map((option) => {
+        const selected = option.value === value;
+        const properties = {
+          size,
+          variant: "ghost",
+          pressed: selected,
+          disabled: disabled || option.disabled,
+          onClick: () => onChange(option.value),
+        } as const;
+
+        return option.label === undefined ? (
+          <IconButton
+            key={option.value}
+            icon={option.icon}
+            aria-label={option["aria-label"] ?? option.value}
+            {...properties}
+          />
+        ) : (
+          <Button
+            key={option.value}
+            startIcon={option.icon}
+            aria-label={option["aria-label"]}
+            {...properties}
+          >
+            {option.label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/webapp/IronCalc/src/components/ToggleButton/ToggleButton.tsx
+++ b/webapp/IronCalc/src/components/ToggleButton/ToggleButton.tsx
@@ -5,8 +5,10 @@ import { IconButton } from "../Button/IconButton";
 import "./toggle-button.css";
 
 /**
- * A group of mutually exclusive buttons where exactly one option is selected.
+ * A group of mutually exclusive buttons where at most one option is selected.
  * Every option is a "ghost" Button; the selected one is the pressed Button.
+ * A `value` that matches no option leaves them all unpressed, which is how a
+ * single option toggles on and off.
  * Sizes: xs, sm, md (same as Button).
  */
 
@@ -14,7 +16,7 @@ export interface ToggleButtonOption<T extends string> {
   value: T;
   label?: ReactNode /** Text of the button. Omit it to get an icon-only button. */;
   icon?: ReactNode;
-  "aria-label"?: string /** Required when there is no `label`. */;
+  "aria-label"?: string /** Accessible name. Icon-only buttons fall back to `value`. */;
   disabled?: boolean;
 }
 

--- a/webapp/IronCalc/src/components/ToggleButton/toggle-button.css
+++ b/webapp/IronCalc/src/components/ToggleButton/toggle-button.css
@@ -29,7 +29,7 @@
 }
 
 .ic-toggle-button .ic-button:not([aria-pressed="true"]) {
-  opacity: 0.6;
+  opacity: 0.5;
 }
 
 .ic-toggle-button

--- a/webapp/IronCalc/src/components/ToggleButton/toggle-button.css
+++ b/webapp/IronCalc/src/components/ToggleButton/toggle-button.css
@@ -1,0 +1,52 @@
+.ic-toggle-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+  width: fit-content;
+  border-radius: 6px;
+  background-color: var(--palette-grey-50);
+  overflow: hidden;
+  gap: 1px;
+  outline: 1px solid var(--palette-grey-300);
+  outline-offset: -1px;
+}
+
+.ic-toggle-button .ic-button.ic-button--ghost {
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 6px;
+}
+
+.ic-toggle-button .ic-button--ghost:not(:disabled)[aria-pressed="true"] {
+  background-color: var(--palette-common-white);
+  box-shadow: 0 1px 2px var(--black-12);
+}
+
+.ic-toggle-button
+  .ic-button--ghost:not(:disabled, :focus-visible)[aria-pressed="true"] {
+  border-color: var(--palette-grey-400);
+}
+
+.ic-toggle-button .ic-button:not([aria-pressed="true"]) {
+  opacity: 0.6;
+}
+
+.ic-toggle-button
+  .ic-button--ghost:not([aria-pressed="true"], :disabled):hover {
+  background-color: transparent;
+  opacity: 1;
+}
+
+.ic-toggle-button .ic-button:not(.ic-button--icon-only) {
+  padding: 0 8px;
+}
+
+.ic-toggle-button--full-width {
+  display: flex;
+  width: 100%;
+}
+
+.ic-toggle-button--full-width .ic-button {
+  flex: 1;
+}

--- a/webapp/IronCalc/src/index.ts
+++ b/webapp/IronCalc/src/index.ts
@@ -25,6 +25,11 @@ export type { ConfirmProperties } from "./components/Modal/Confirm";
 export { Confirm } from "./components/Modal/Confirm";
 export type { SwitchProperties } from "./components/Switch/Switch";
 export { Switch } from "./components/Switch/Switch";
+export type {
+  ToggleButtonOption,
+  ToggleButtonProperties,
+} from "./components/ToggleButton/ToggleButton";
+export { ToggleButton } from "./components/ToggleButton/ToggleButton";
 export type { TooltipProperties } from "./components/Tooltip/Tooltip";
 export { Tooltip } from "./components/Tooltip/Tooltip";
 export type { IronCalcHandle } from "./IronCalc";


### PR DESCRIPTION
This PR adds another reusable component to the design system, Toggle Button [1]. These are groups of mutually exclusive options where exactly one is selected, and are composed of Button components.

We already use this in Conditional Formatting and Edit Cell Styles, so once this is merged I will refactor these parts so they use the new component.

<img width="100%" height="auto" alt="image" src="https://github.com/user-attachments/assets/660f31eb-2290-4033-9712-51adf2e34e7c" />

## Changes

- Added `ToggleButton.tsx`: every option renders as a ghost Button (or IconButton when the option has no label), and the selected one is simply the pressed Button. Options are objects with value, label, icon, aria-label and disabled.
- Added `toggle-button.css` with the styling.
- Added `ToggleButton.stories.tsx`: default, single option, sizes, full width and disabled.
- Exported ToggleButton, ToggleButtonProperties and ToggleButtonOption from `src/index.ts`.

---
[1] The right name for this component is tricky as there are many ways of calling it. I've chosen 'Toggle button' based on this article by Smashing Mag https://www.smashingmagazine.com/2022/08/toggle-button-case-study-part-1/