### PR TITLE
update[app]: add a mode switch to File Menu

### DIFF
--- a/webapp/IronCalc/src/index.ts
+++ b/webapp/IronCalc/src/index.ts
@@ -35,6 +35,7 @@ export { ToggleButton } from "./components/ToggleButton/ToggleButton";
 export type { TooltipProperties } from "./components/Tooltip/Tooltip";
 export { Tooltip } from "./components/Tooltip/Tooltip";
 export type { IronCalcHandle } from "./IronCalc";
+export { darkThemeVariables } from "./theme";
 export { IronCalc, IronCalcIcon, IronCalcIconWhite, IronCalcLogo, Model };
 
 export const init: typeof initWasm = async (module_or_path) => {

--- a/webapp/app.ironcalc.com/frontend/src/App.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/App.tsx
@@ -1,7 +1,13 @@
 import "./App.css";
 import type { IronCalcHandle } from "@ironcalc/workbook";
 // From IronCalc
-import { IronCalc, IronCalcIcon, init, Model } from "@ironcalc/workbook";
+import {
+  darkThemeVariables,
+  IronCalc,
+  IronCalcIcon,
+  init,
+  Model,
+} from "@ironcalc/workbook";
 import "@ironcalc/workbook/style.css";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,8 +26,10 @@ import {
   getLanguageFromLocale,
   getShortLocaleCode,
   isStorageEmpty,
+  loadDarkModeFromStorage,
   loadDefaultLocaleFromStorage,
   loadSelectedModelFromStorage,
+  saveDarkModeInStorage,
   saveDefaultLocaleInStorage,
   saveModelToStorage,
   saveSelectedModelInStorage,
@@ -36,6 +44,7 @@ function App() {
   const [isTemplatesDialogOpen, setTemplatesDialogOpen] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [localStorageId, setLocalStorageId] = useState<number>(1);
+  const [isDarkMode, setIsDarkMode] = useState(loadDarkModeFromStorage);
 
   const ironCalcRef = useRef<IronCalcHandle>(null);
 
@@ -48,6 +57,11 @@ function App() {
         saveSelectedModelInStorage(model);
       }
     }
+  };
+
+  const handleDarkModeChange = (isDark: boolean) => {
+    setIsDarkMode(isDark);
+    saveDarkModeInStorage(isDark);
   };
 
   const { t, i18n } = useTranslation();
@@ -212,8 +226,14 @@ function App() {
           setIsDrawerOpen={setIsDrawerOpen}
           setLocalStorageId={setLocalStorageId}
           onLanguageChange={handleLanguageChange}
+          isDarkMode={isDarkMode}
+          onDarkModeChange={handleDarkModeChange}
         />
-        <IronCalc model={model} ref={ironCalcRef} />
+        <IronCalc
+          model={model}
+          ref={ironCalcRef}
+          themeVariables={isDarkMode ? darkThemeVariables : undefined}
+        />
         {isDrawerOpen && (
           <div
             className="app-ic-mobile-overlay"

--- a/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/FileBar.tsx
@@ -29,6 +29,8 @@ export function FileBar(properties: {
   setIsDrawerOpen: (open: boolean) => void;
   setLocalStorageId: (updater: (id: number) => number) => void;
   onLanguageChange: (language: string) => void;
+  isDarkMode: boolean;
+  onDarkModeChange: (isDark: boolean) => void;
 }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [openMenu, setOpenMenu] = useState<OpenMenu>(null);
@@ -82,6 +84,8 @@ export function FileBar(properties: {
           onModelUpload={properties.onModelUpload}
           onDelete={properties.onDelete}
           onLanguageChange={properties.onLanguageChange}
+          isDarkMode={properties.isDarkMode}
+          onDarkModeChange={properties.onDarkModeChange}
         />
       ) : (
         <div className="app-ic-file-bar-desktop-menu">
@@ -96,6 +100,8 @@ export function FileBar(properties: {
             onClose={closeMenus}
             onHover={() => openMenu && setOpenMenu("file")}
             onLanguageChange={properties.onLanguageChange}
+            isDarkMode={properties.isDarkMode}
+            onDarkModeChange={properties.onDarkModeChange}
           />
           <HelpMenu
             isOpen={openMenu === "help"}

--- a/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/LeftDrawer/left-drawer.css
@@ -70,6 +70,7 @@
   margin: 0;
   font-size: calc(var(--typography-font-size) + 2px);
   font-weight: 600;
+  color: var(--palette-common-black);
 }
 
 .app-ic-drawer-header-actions {

--- a/webapp/app.ironcalc.com/frontend/src/components/Navigation/FileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/Navigation/FileMenu.tsx
@@ -5,7 +5,15 @@ import {
   MenuItem,
   MenuItemWithSubmenu,
 } from "@ironcalc/workbook";
-import { FileDown, FileUp, Globe, Plus, Table2, Trash2 } from "lucide-react";
+import {
+  FileDown,
+  FileUp,
+  Globe,
+  Plus,
+  Sun,
+  Table2,
+  Trash2,
+} from "lucide-react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import DeleteWorkbookDialog from "../DeleteWorkbookDialog";
@@ -21,6 +29,11 @@ const LANGUAGES = [
   ["it-IT", "Italiano"],
 ] as const;
 
+const THEMES = [
+  [false, "file_bar.file_menu.theme_light"],
+  [true, "file_bar.file_menu.theme_dark"],
+] as const;
+
 export function FileMenu(props: {
   newModel: () => void;
   newModelFromTemplate: () => void;
@@ -28,6 +41,8 @@ export function FileMenu(props: {
   onModelUpload: (blob: ArrayBuffer, fileName: string) => Promise<void>;
   onDelete: () => void;
   onLanguageChange: (language: string) => void;
+  isDarkMode: boolean;
+  onDarkModeChange: (isDark: boolean) => void;
   isOpen: boolean;
   onOpen: () => void;
   onClose: () => void;
@@ -114,6 +129,20 @@ export function FileMenu(props: {
           ))}
         >
           {t("file_bar.file_menu.default_language")}
+        </MenuItemWithSubmenu>
+        <MenuItemWithSubmenu
+          icon={<Sun />}
+          submenu={THEMES.map(([isDark, labelKey]) => (
+            <MenuItem
+              key={labelKey}
+              checked={props.isDarkMode === isDark}
+              onClick={() => props.onDarkModeChange(isDark)}
+            >
+              {t(labelKey)}
+            </MenuItem>
+          ))}
+        >
+          {t("file_bar.file_menu.theme")}
         </MenuItemWithSubmenu>
       </Menu>
 

--- a/webapp/app.ironcalc.com/frontend/src/components/Navigation/MobileMenu.tsx
+++ b/webapp/app.ironcalc.com/frontend/src/components/Navigation/MobileMenu.tsx
@@ -14,6 +14,7 @@ import {
   Keyboard,
   Menu as MenuIcon,
   Plus,
+  Sun,
   Table2,
   Trash2,
 } from "lucide-react";
@@ -32,6 +33,11 @@ const LANGUAGES = [
   ["it-IT", "Italiano"],
 ] as const;
 
+const THEMES = [
+  [false, "file_bar.file_menu.theme_light"],
+  [true, "file_bar.file_menu.theme_dark"],
+] as const;
+
 interface MobileMenuProps {
   newModel: () => void;
   newModelFromTemplate: () => void;
@@ -39,6 +45,8 @@ interface MobileMenuProps {
   onModelUpload: (blob: ArrayBuffer, fileName: string) => Promise<void>;
   onDelete: () => void;
   onLanguageChange: (language: string) => void;
+  isDarkMode: boolean;
+  onDarkModeChange: (isDark: boolean) => void;
 }
 
 export function MobileMenu(props: MobileMenuProps) {
@@ -118,6 +126,20 @@ export function MobileMenu(props: MobileMenuProps) {
           ))}
         >
           {t("file_bar.file_menu.default_language")}
+        </MenuItemWithSubmenu>
+        <MenuItemWithSubmenu
+          icon={<Sun />}
+          submenu={THEMES.map(([isDark, labelKey]) => (
+            <MenuItem
+              key={labelKey}
+              checked={props.isDarkMode === isDark}
+              onClick={() => props.onDarkModeChange(isDark)}
+            >
+              {t(labelKey)}
+            </MenuItem>
+          ))}
+        >
+          {t("file_bar.file_menu.theme")}
         </MenuItemWithSubmenu>
         <MenuDivider />
         <MenuItem

--- a/webapp/app.ironcalc.com/frontend/src/components/storage.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/storage.ts
@@ -97,9 +97,7 @@ export function loadDarkModeFromStorage(): boolean {
   if (stored) {
     return stored === "true";
   }
-  const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-  saveDarkModeInStorage(isDark);
-  return isDark;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
 }
 
 export function updateNameSelectedWorkbook(model: Model, newName: string) {

--- a/webapp/app.ironcalc.com/frontend/src/components/storage.ts
+++ b/webapp/app.ironcalc.com/frontend/src/components/storage.ts
@@ -88,6 +88,20 @@ export function loadDefaultLocaleFromStorage(): string {
   return l;
 }
 
+export function saveDarkModeInStorage(isDark: boolean) {
+  localStorage.setItem("dark_mode", isDark ? "true" : "false");
+}
+
+export function loadDarkModeFromStorage(): boolean {
+  const stored = localStorage.getItem("dark_mode");
+  if (stored) {
+    return stored === "true";
+  }
+  const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  saveDarkModeInStorage(isDark);
+  return isDark;
+}
+
 export function updateNameSelectedWorkbook(model: Model, newName: string) {
   const uuid = localStorage.getItem("selected");
   if (uuid) {

--- a/webapp/app.ironcalc.com/frontend/src/components/workbook-title.css
+++ b/webapp/app.ironcalc.com/frontend/src/components/workbook-title.css
@@ -17,6 +17,7 @@
   font-weight: inherit;
   font-family: inherit;
   font-size: inherit;
+  color: var(--palette-common-black);
   background: transparent;
 }
 

--- a/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/de_de.json
@@ -101,7 +101,10 @@
         "confirm_button": "Ja, löschen",
         "cancel_button": "Abbrechen"
       },
-      "default_language": "Standardsprache"
+      "default_language": "Standardsprache",
+      "theme": "Design",
+      "theme_light": "Hell",
+      "theme_dark": "Dunkel"
     },
     "help_menu": {
       "button": "Hilfe",

--- a/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/en_us.json
@@ -101,7 +101,10 @@
         "confirm_button": "Yes, delete",
         "cancel_button": "Cancel"
       },
-      "default_language": "Default language"
+      "default_language": "Default language",
+      "theme": "Theme",
+      "theme_light": "Light",
+      "theme_dark": "Dark"
     },
     "help_menu": {
       "button": "Help",

--- a/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/es_es.json
@@ -101,7 +101,10 @@
         "confirm_button": "Sí, eliminar",
         "cancel_button": "Cancelar"
       },
-      "default_language": "Idioma predeterminado"
+      "default_language": "Idioma predeterminado",
+      "theme": "Tema",
+      "theme_light": "Claro",
+      "theme_dark": "Oscuro"
     },
     "help_menu": {
       "button": "Ayuda",

--- a/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/fr_fr.json
@@ -101,7 +101,10 @@
         "confirm_button": "Oui, supprimer",
         "cancel_button": "Annuler"
       },
-      "default_language": "Langue par défaut"
+      "default_language": "Langue par défaut",
+      "theme": "Thème",
+      "theme_light": "Clair",
+      "theme_dark": "Sombre"
     },
     "help_menu": {
       "button": "Aide",

--- a/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
+++ b/webapp/app.ironcalc.com/frontend/src/locale/it_it.json
@@ -101,7 +101,10 @@
         "confirm_button": "Sì, elimina",
         "cancel_button": "Annulla"
       },
-      "default_language": "Lingua predefinita"
+      "default_language": "Lingua predefinita",
+      "theme": "Tema",
+      "theme_light": "Chiaro",
+      "theme_dark": "Scuro"
     },
     "help_menu": {
       "button": "Aiuto",


### PR DESCRIPTION
This PR adds a new switch to the File menu to allow users to switch mode in the app.

<img width="auto" height="320" alt="image" src="https://github.com/user-attachments/assets/0b07e3d0-c30a-444a-b02c-21421b802861" /> 
<img width="auto" height="320" alt="image" src="https://github.com/user-attachments/assets/3b10ddce-69f1-4cea-8fc9-bf4c647c055c" />

We still need to polish a few more edges but with this we have almost full dark mode support!


