### PR TITLE
UPDATE: Autofill merged cells

### DIFF
--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -32,6 +32,7 @@ mod test_on_area_selection;
 mod test_on_expand_selected_range;
 mod test_on_paste_styles;
 mod test_paste_csv;
+mod test_paste_merged_cells;
 mod test_recursive;
 mod test_rename_sheet;
 mod test_row_column;

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -2,6 +2,7 @@ mod test_add_delete_sheets;
 mod test_array_formulas;
 mod test_auto_link;
 mod test_autofill_columns;
+mod test_autofill_merged_cells;
 mod test_autofill_rows;
 mod test_batch_row_column_diff;
 mod test_border;

--- a/base/src/test/user_model/test_autofill_merged_cells.rs
+++ b/base/src/test/user_model/test_autofill_merged_cells.rs
@@ -1,0 +1,592 @@
+#![allow(clippy::unwrap_used)]
+
+// Autofill and merged cells.
+//
+// The rules under test:
+//
+// * Containment: an existing merged cell intersecting the source area or the
+//   fill target must be fully contained in it; otherwise the fill is rejected.
+// * The merged cells of the source are tiled into the fill target, together
+//   with the values, styles and links of the source pattern. Merged cells
+//   fully contained in the target are removed first (replaced by the tiled
+//   pattern).
+// * The fill boundary must not cut a tiled merge: a partial last tile is
+//   valid only when every merge it contains fits whole.
+// * Value progressions are detected over the non-covered cells of the source
+//   and land on the non-covered cells of the target (covered cells stay
+//   empty).
+
+use bitcode::decode;
+
+use crate::expressions::types::Area;
+use crate::test::user_model::util::new_empty_user_model;
+use crate::types::{BorderItem, BorderStyle, Color, Link, MergedCell};
+use crate::user_model::history::QueueDiffs;
+use crate::UserModel;
+
+fn area(sheet: u32, row: i32, column: i32, width: i32, height: i32) -> Area {
+    Area {
+        sheet,
+        row,
+        column,
+        width,
+        height,
+    }
+}
+
+fn merged(row: i32, column: i32, width: i32, height: i32) -> MergedCell {
+    MergedCell {
+        row,
+        column,
+        width,
+        height,
+    }
+}
+
+// The merged cells of sheet 0, sorted, so the tests don't depend on the order
+// the implementation creates them in.
+fn merges_sorted(model: &UserModel) -> Vec<MergedCell> {
+    let mut merges = model.get_merged_cells(0).unwrap();
+    merges.sort_by_key(|m| (m.row, m.column));
+    merges
+}
+
+fn value(model: &UserModel, row: i32, column: i32) -> String {
+    model.get_formatted_cell_value(0, row, column).unwrap()
+}
+
+fn assert_history_is_clean(model: &mut UserModel) {
+    let queue: Vec<QueueDiffs> = decode(&model.flush_send_queue()).unwrap();
+    assert!(queue.is_empty());
+}
+
+const PARTIAL_OVERLAP: &str = "Cannot auto-fill: a merged cell partially overlaps the fill area";
+const CUT_MERGE: &str = "Cannot auto-fill: the fill size must fit whole merged cells";
+
+// ── Replicating the source pattern ───────────────────────────────────────────
+
+#[test]
+fn fill_down_replicates_the_merge_pattern() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 2, 2, "hello").unwrap();
+    // merge B2:C3
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+
+    // fill B2:C3 down to row 7: two tiles, B4:C5 and B6:C7
+    model.auto_fill_rows(&area(0, 2, 2, 2, 2), 7).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(2, 2, 2, 2), merged(4, 2, 2, 2), merged(6, 2, 2, 2)]
+    );
+    assert_eq!(value(&model, 4, 2), "hello");
+    assert_eq!(value(&model, 6, 2), "hello");
+    // covered cells of the new tiles are empty
+    assert_eq!(value(&model, 4, 3), "");
+    assert_eq!(value(&model, 5, 2), "");
+    assert_eq!(value(&model, 7, 3), "");
+}
+
+#[test]
+fn fill_up_replicates_the_merge_pattern() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 5, 2, "x").unwrap();
+    // merge B5:B6
+    model.merge_cells(&area(0, 5, 2, 1, 2)).unwrap();
+
+    // fill B5:B6 up to row 1: two tiles, B3:B4 and B1:B2
+    model.auto_fill_rows(&area(0, 5, 2, 1, 2), 1).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 2, 1, 2), merged(3, 2, 1, 2), merged(5, 2, 1, 2)]
+    );
+    assert_eq!(value(&model, 1, 2), "x");
+    assert_eq!(value(&model, 3, 2), "x");
+    assert_eq!(value(&model, 2, 2), "");
+    assert_eq!(value(&model, 4, 2), "");
+}
+
+#[test]
+fn fill_right_replicates_the_merge_pattern() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 2, 2, "hi").unwrap();
+    // merge B2:C3
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+
+    // fill B2:C3 right to column 7: two tiles, D2:E3 and F2:G3
+    model.auto_fill_columns(&area(0, 2, 2, 2, 2), 7).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(2, 2, 2, 2), merged(2, 4, 2, 2), merged(2, 6, 2, 2)]
+    );
+    assert_eq!(value(&model, 2, 4), "hi");
+    assert_eq!(value(&model, 2, 6), "hi");
+    assert_eq!(value(&model, 3, 4), "");
+    assert_eq!(value(&model, 2, 5), "");
+}
+
+#[test]
+fn fill_left_replicates_the_merge_pattern() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 5, "z").unwrap();
+    // merge E1:F1
+    model.merge_cells(&area(0, 1, 5, 2, 1)).unwrap();
+
+    // fill E1:F1 left to column 1: two tiles, C1:D1 and A1:B1
+    model.auto_fill_columns(&area(0, 1, 5, 2, 1), 1).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 2, 1), merged(1, 3, 2, 1), merged(1, 5, 2, 1)]
+    );
+    assert_eq!(value(&model, 1, 1), "z");
+    assert_eq!(value(&model, 1, 3), "z");
+    assert_eq!(value(&model, 1, 2), "");
+    assert_eq!(value(&model, 1, 4), "");
+}
+
+#[test]
+fn fill_right_tiles_a_vertical_merge_sideways() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "v").unwrap();
+    // merge A1:A2, one column wide
+    model.merge_cells(&area(0, 1, 1, 1, 2)).unwrap();
+
+    // fill A1:A2 right to column 3: each new column gets its own 1x2 merge
+    model.auto_fill_columns(&area(0, 1, 1, 1, 2), 3).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 1, 2), merged(1, 2, 1, 2), merged(1, 3, 1, 2)]
+    );
+    assert_eq!(value(&model, 1, 2), "v");
+    assert_eq!(value(&model, 1, 3), "v");
+    assert_eq!(value(&model, 2, 2), "");
+    assert_eq!(value(&model, 2, 3), "");
+}
+
+#[test]
+fn fill_down_mixes_merged_and_plain_rows() {
+    let mut model = new_empty_user_model();
+    // pattern: A1:A2 merged with "a", A3 plain with "b"
+    model.set_user_input(0, 1, 1, "a").unwrap();
+    model.merge_cells(&area(0, 1, 1, 1, 2)).unwrap();
+    model.set_user_input(0, 3, 1, "b").unwrap();
+
+    // fill A1:A3 down to row 8: a full tile (rows 4-6) plus a partial tile
+    // (rows 7-8) that contains the whole merge, so it is allowed
+    model.auto_fill_rows(&area(0, 1, 1, 1, 3), 8).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 1, 2), merged(4, 1, 1, 2), merged(7, 1, 1, 2)]
+    );
+    assert_eq!(value(&model, 4, 1), "a");
+    assert_eq!(value(&model, 6, 1), "b");
+    assert_eq!(value(&model, 7, 1), "a");
+    assert_eq!(value(&model, 5, 1), "");
+    assert_eq!(value(&model, 8, 1), "");
+}
+
+// ── Value progressions ───────────────────────────────────────────────────────
+
+#[test]
+fn fill_down_continues_a_progression_across_merged_anchors() {
+    let mut model = new_empty_user_model();
+    // A1:A2 merged with 1, A3:A4 merged with 2
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model.merge_cells(&area(0, 1, 1, 1, 2)).unwrap();
+    model.set_user_input(0, 3, 1, "2").unwrap();
+    model.merge_cells(&area(0, 3, 1, 1, 2)).unwrap();
+
+    // fill A1:A4 down to row 8: the progression continues on the new anchors
+    model.auto_fill_rows(&area(0, 1, 1, 1, 4), 8).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![
+            merged(1, 1, 1, 2),
+            merged(3, 1, 1, 2),
+            merged(5, 1, 1, 2),
+            merged(7, 1, 1, 2)
+        ]
+    );
+    assert_eq!(value(&model, 5, 1), "3");
+    assert_eq!(value(&model, 7, 1), "4");
+    assert_eq!(value(&model, 6, 1), "");
+    assert_eq!(value(&model, 8, 1), "");
+}
+
+#[test]
+fn fill_right_continues_a_progression_across_merged_anchors() {
+    let mut model = new_empty_user_model();
+    // B1:C1 merged with 1, D1:E1 merged with 2
+    model.set_user_input(0, 1, 2, "1").unwrap();
+    model.merge_cells(&area(0, 1, 2, 2, 1)).unwrap();
+    model.set_user_input(0, 1, 4, "2").unwrap();
+    model.merge_cells(&area(0, 1, 4, 2, 1)).unwrap();
+
+    // fill B1:E1 right to column 9: the progression continues on the new anchors
+    model.auto_fill_columns(&area(0, 1, 2, 4, 1), 9).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![
+            merged(1, 2, 2, 1),
+            merged(1, 4, 2, 1),
+            merged(1, 6, 2, 1),
+            merged(1, 8, 2, 1)
+        ]
+    );
+    assert_eq!(value(&model, 1, 6), "3");
+    assert_eq!(value(&model, 1, 8), "4");
+    assert_eq!(value(&model, 1, 7), "");
+    assert_eq!(value(&model, 1, 9), "");
+}
+
+// ── Merges already in the fill target ────────────────────────────────────────
+
+#[test]
+fn fill_down_from_a_plain_source_unmerges_a_contained_target_merge() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "x").unwrap();
+    // target merge A2:A3 with "b"
+    model.set_user_input(0, 2, 1, "b").unwrap();
+    model.merge_cells(&area(0, 2, 1, 1, 2)).unwrap();
+
+    // fill plain A1 down to row 5: the merge is fully inside the target, so
+    // it is unmerged and plain values land everywhere
+    model.auto_fill_rows(&area(0, 1, 1, 1, 1), 5).unwrap();
+
+    assert!(model.get_merged_cells(0).unwrap().is_empty());
+    for row in 2..=5 {
+        assert_eq!(value(&model, row, 1), "x");
+    }
+
+    // undo restores the merge and its content
+    model.undo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(2, 1, 1, 2)]);
+    assert_eq!(value(&model, 2, 1), "b");
+    assert_eq!(value(&model, 4, 1), "");
+    assert_eq!(value(&model, 5, 1), "");
+
+    model.redo().unwrap();
+    assert!(model.get_merged_cells(0).unwrap().is_empty());
+    assert_eq!(value(&model, 2, 1), "x");
+}
+
+#[test]
+fn fill_down_replaces_a_target_merge_of_the_same_shape() {
+    let mut model = new_empty_user_model();
+    // source merge A1:A2 with "a", target merge A3:A4 with "b"
+    model.set_user_input(0, 1, 1, "a").unwrap();
+    model.merge_cells(&area(0, 1, 1, 1, 2)).unwrap();
+    model.set_user_input(0, 3, 1, "b").unwrap();
+    model.merge_cells(&area(0, 3, 1, 1, 2)).unwrap();
+
+    model.auto_fill_rows(&area(0, 1, 1, 1, 2), 4).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 1, 2), merged(3, 1, 1, 2)]
+    );
+    assert_eq!(value(&model, 3, 1), "a");
+    assert_eq!(value(&model, 4, 1), "");
+
+    model.undo().unwrap();
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 1, 2), merged(3, 1, 1, 2)]
+    );
+    assert_eq!(value(&model, 3, 1), "b");
+
+    model.redo().unwrap();
+    assert_eq!(value(&model, 3, 1), "a");
+}
+
+#[test]
+fn fill_down_replaces_a_target_merge_of_a_different_shape() {
+    let mut model = new_empty_user_model();
+    // source merge A1:B1 (wide), target merge A3:A4 (tall) with "b"
+    model.set_user_input(0, 1, 1, "a").unwrap();
+    model.merge_cells(&area(0, 1, 1, 2, 1)).unwrap();
+    model.set_user_input(0, 3, 1, "b").unwrap();
+    model.merge_cells(&area(0, 3, 1, 1, 2)).unwrap();
+
+    // fill A1:B1 down to row 4: the tall merge is fully inside the target
+    // (rows 2-4, columns A-B contain A3:A4) and is replaced by wide tiles
+    model.auto_fill_rows(&area(0, 1, 1, 2, 1), 4).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![
+            merged(1, 1, 2, 1),
+            merged(2, 1, 2, 1),
+            merged(3, 1, 2, 1),
+            merged(4, 1, 2, 1)
+        ]
+    );
+    assert_eq!(value(&model, 2, 1), "a");
+    assert_eq!(value(&model, 3, 1), "a");
+    assert_eq!(value(&model, 4, 1), "a");
+}
+
+#[test]
+fn fill_down_clears_content_covered_by_a_new_tile_and_undo_restores_it() {
+    let mut model = new_empty_user_model();
+    // source merge A1:A2 with "x"; plain content at A6
+    model.set_user_input(0, 1, 1, "x").unwrap();
+    model.merge_cells(&area(0, 1, 1, 1, 2)).unwrap();
+    model.set_user_input(0, 6, 1, "old").unwrap();
+
+    // fill down to row 6: tiles A3:A4 and A5:A6; A6 becomes a covered cell
+    model.auto_fill_rows(&area(0, 1, 1, 1, 2), 6).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 1, 2), merged(3, 1, 1, 2), merged(5, 1, 1, 2)]
+    );
+    assert_eq!(value(&model, 5, 1), "x");
+    assert_eq!(value(&model, 6, 1), "");
+
+    model.undo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(1, 1, 1, 2)]);
+    assert_eq!(value(&model, 6, 1), "old");
+    assert_eq!(value(&model, 3, 1), "");
+    assert_eq!(value(&model, 5, 1), "");
+
+    model.redo().unwrap();
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 1, 2), merged(3, 1, 1, 2), merged(5, 1, 1, 2)]
+    );
+    assert_eq!(value(&model, 6, 1), "");
+}
+
+// ── Rejections ───────────────────────────────────────────────────────────────
+
+#[test]
+fn fill_extent_cutting_a_source_merge_tile_is_rejected() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "x").unwrap();
+    // merge A1:A2
+    model.merge_cells(&area(0, 1, 1, 1, 2)).unwrap();
+    model.flush_send_queue();
+
+    // one target row: the 2-tall tile does not fit
+    assert_eq!(
+        model.auto_fill_rows(&area(0, 1, 1, 1, 2), 3),
+        Err(CUT_MERGE.to_string())
+    );
+    assert_eq!(merges_sorted(&model), vec![merged(1, 1, 1, 2)]);
+    assert_eq!(value(&model, 3, 1), "");
+    assert_history_is_clean(&mut model);
+}
+
+#[test]
+fn fill_extent_cutting_a_partial_tile_merge_is_rejected() {
+    let mut model = new_empty_user_model();
+    // pattern: A1:A2 merged, A3 plain
+    model.set_user_input(0, 1, 1, "a").unwrap();
+    model.merge_cells(&area(0, 1, 1, 1, 2)).unwrap();
+    model.set_user_input(0, 3, 1, "b").unwrap();
+    model.flush_send_queue();
+
+    // fill to row 7: a full tile (rows 4-6) plus a partial tile of one row,
+    // which cuts the 2-tall merge of the pattern
+    assert_eq!(
+        model.auto_fill_rows(&area(0, 1, 1, 1, 3), 7),
+        Err(CUT_MERGE.to_string())
+    );
+    assert_eq!(merges_sorted(&model), vec![merged(1, 1, 1, 2)]);
+    assert_history_is_clean(&mut model);
+}
+
+#[test]
+fn fill_columns_extent_cutting_a_source_merge_tile_is_rejected() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 2, "x").unwrap();
+    // merge B1:C1
+    model.merge_cells(&area(0, 1, 2, 2, 1)).unwrap();
+    model.flush_send_queue();
+
+    // one target column: the 2-wide tile does not fit
+    assert_eq!(
+        model.auto_fill_columns(&area(0, 1, 2, 2, 1), 4),
+        Err(CUT_MERGE.to_string())
+    );
+    assert_eq!(merges_sorted(&model), vec![merged(1, 2, 2, 1)]);
+    assert_history_is_clean(&mut model);
+}
+
+#[test]
+fn fill_over_a_partially_overlapping_target_merge_is_rejected() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "x").unwrap();
+    // merge A4:B5 sticks out of the fill target (rows 2-4, column A)
+    model.merge_cells(&area(0, 4, 1, 2, 2)).unwrap();
+    model.flush_send_queue();
+
+    assert_eq!(
+        model.auto_fill_rows(&area(0, 1, 1, 1, 1), 4),
+        Err(PARTIAL_OVERLAP.to_string())
+    );
+    assert_eq!(merges_sorted(&model), vec![merged(4, 1, 2, 2)]);
+    assert_eq!(value(&model, 2, 1), "");
+    assert_history_is_clean(&mut model);
+}
+
+#[test]
+fn fill_from_a_source_partially_covering_a_merge_is_rejected() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 2, 2, "x").unwrap();
+    // merge B2:C3
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+    model.flush_send_queue();
+
+    // the source B2:B3 covers only the left half of the merge (the UI cannot
+    // produce this selection; the API guards against it)
+    assert_eq!(
+        model.auto_fill_rows(&area(0, 2, 2, 1, 2), 7),
+        Err(PARTIAL_OVERLAP.to_string())
+    );
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_history_is_clean(&mut model);
+}
+
+// ── Styles, borders and links ────────────────────────────────────────────────
+
+fn thin(color: &str) -> Option<BorderItem> {
+    Some(BorderItem {
+        style: BorderStyle::Thin,
+        color: Color::Rgb(color.to_string()),
+    })
+}
+
+#[test]
+fn fill_down_replicates_the_perimeter_borders_of_a_merged_cell() {
+    let mut model = new_empty_user_model();
+    // outline on B2, then merge B2:C3: the outline wraps the whole merged
+    // cell, so its bottom/right sides live on non-anchor cells
+    model._set_cell_border("B2", "#111111");
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+
+    // fill down to row 5: one tile, B4:C5
+    model.auto_fill_rows(&area(0, 2, 2, 2, 2), 5).unwrap();
+
+    // the tile keeps the full outline, including the sides that are not on
+    // its anchor
+    let b4 = model._get_cell_border("B4");
+    assert_eq!(b4.left, thin("#111111"));
+    assert_eq!(b4.top, thin("#111111"));
+    assert_eq!([b4.right, b4.bottom], [None, None]);
+    let c4 = model._get_cell_border("C4");
+    assert_eq!(c4.top, thin("#111111"));
+    assert_eq!(c4.right, thin("#111111"));
+    assert_eq!([c4.left, c4.bottom], [None, None]);
+    let b5 = model._get_cell_border("B5");
+    assert_eq!(b5.left, thin("#111111"));
+    assert_eq!(b5.bottom, thin("#111111"));
+    assert_eq!([b5.right, b5.top], [None, None]);
+    let c5 = model._get_cell_border("C5");
+    assert_eq!(c5.right, thin("#111111"));
+    assert_eq!(c5.bottom, thin("#111111"));
+    assert_eq!([c5.left, c5.top], [None, None]);
+}
+
+#[test]
+fn fill_down_replicates_the_fill_color_of_covered_cells() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "x").unwrap();
+    model.merge_cells(&area(0, 1, 1, 1, 2)).unwrap();
+    model
+        .update_range_style(&area(0, 1, 1, 1, 2), "fill.color", "#FF0000")
+        .unwrap();
+
+    model.auto_fill_rows(&area(0, 1, 1, 1, 2), 4).unwrap();
+
+    // both cells of the new tile carry the fill color
+    assert_eq!(
+        model.get_cell_style(0, 3, 1).unwrap().fill.color,
+        Color::Rgb("#FF0000".to_string())
+    );
+    assert_eq!(
+        model.get_cell_style(0, 4, 1).unwrap().fill.color,
+        Color::Rgb("#FF0000".to_string())
+    );
+}
+
+#[test]
+fn fill_down_replicates_the_anchor_link() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "ironcalc").unwrap();
+    let link = Link::External {
+        target: "https://www.ironcalc.com".to_string(),
+        tooltip: None,
+    };
+    model.set_cell_link(0, 1, 1, link.clone(), None).unwrap();
+    // merge A1:B1
+    model.merge_cells(&area(0, 1, 1, 2, 1)).unwrap();
+
+    // fill down to row 2: one tile, A2:B2
+    model.auto_fill_rows(&area(0, 1, 1, 2, 1), 2).unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 2, 1), merged(2, 1, 2, 1)]
+    );
+    assert_eq!(value(&model, 2, 1), "ironcalc");
+    assert_eq!(model.get_cell_link(0, 2, 1), Ok(Some(link)));
+}
+
+// ── Undo, redo and external replay ───────────────────────────────────────────
+
+#[test]
+fn fill_down_undo_redo_restores_the_merge_pattern() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 2, 2, "hello").unwrap();
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+
+    model.auto_fill_rows(&area(0, 2, 2, 2, 2), 7).unwrap();
+
+    model.undo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 4, 2), "");
+    assert_eq!(value(&model, 6, 2), "");
+    assert_eq!(value(&model, 2, 2), "hello");
+
+    model.redo().unwrap();
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(2, 2, 2, 2), merged(4, 2, 2, 2), merged(6, 2, 2, 2)]
+    );
+    assert_eq!(value(&model, 4, 2), "hello");
+    assert_eq!(value(&model, 6, 2), "hello");
+}
+
+#[test]
+fn fill_down_replays_on_external_models() {
+    let mut model1 = new_empty_user_model();
+    let mut model2 = new_empty_user_model();
+
+    model1.set_user_input(0, 2, 2, "hello").unwrap();
+    model1.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+    model1.auto_fill_rows(&area(0, 2, 2, 2, 2), 7).unwrap();
+    model2
+        .apply_external_diffs(&model1.flush_send_queue())
+        .unwrap();
+
+    assert_eq!(merges_sorted(&model2), merges_sorted(&model1));
+    assert_eq!(value(&model2, 4, 2), "hello");
+    assert_eq!(value(&model2, 6, 2), "hello");
+
+    // the undo also replays
+    model1.undo().unwrap();
+    model2
+        .apply_external_diffs(&model1.flush_send_queue())
+        .unwrap();
+    assert_eq!(merges_sorted(&model2), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model2, 4, 2), "");
+}

--- a/base/src/test/user_model/test_merged_cells.rs
+++ b/base/src/test/user_model/test_merged_cells.rs
@@ -749,17 +749,17 @@ fn navigate_to_edge_treats_merge_as_one_cell() {
 // ── Autofill and clipboard ───────────────────────────────────────────────────
 
 #[test]
-fn auto_fill_over_merges_is_rejected() {
+fn auto_fill_partially_covering_a_merge_is_rejected() {
     let mut model = new_empty_user_model();
     model.set_user_input(0, 1, 2, "1").unwrap();
     // merge B3:C4
     model.merge_cells(&area(0, 3, 2, 2, 2)).unwrap();
     model.flush_send_queue();
 
-    // filling B1 down to B4 crosses the merge
+    // filling B1 down to B4 covers only the left half of the merge
     assert_eq!(
         model.auto_fill_rows(&area(0, 1, 2, 1, 1), 4),
-        Err("Cannot auto-fill over merged cells".to_string())
+        Err("Cannot auto-fill: a merged cell partially overlaps the fill area".to_string())
     );
     // filling B1 right to C1 is fine (the merge is below)
     model.auto_fill_columns(&area(0, 1, 2, 1, 1), 3).unwrap();

--- a/base/src/test/user_model/test_merged_cells.rs
+++ b/base/src/test/user_model/test_merged_cells.rs
@@ -766,24 +766,8 @@ fn auto_fill_partially_covering_a_merge_is_rejected() {
     assert_eq!(model.get_formatted_cell_value(0, 1, 3), Ok("1".to_string()));
 }
 
-#[test]
-fn paste_over_merges_is_rejected() {
-    let mut model = new_empty_user_model();
-    model.set_user_input(0, 1, 1, "42").unwrap();
-    // merge A2:B3
-    model.merge_cells(&area(0, 2, 1, 2, 2)).unwrap();
-
-    model.set_selected_cell(1, 1).unwrap();
-    let clipboard = model.copy_to_clipboard().unwrap();
-    model.set_selected_cell(2, 1).unwrap();
-    assert_eq!(
-        model.paste_from_clipboard(0, clipboard.range, &clipboard.data, false),
-        Err("Cannot paste over merged cells".to_string())
-    );
-    // the model is untouched
-    assert_eq!(model.get_merged_cells(0).unwrap(), vec![merged(2, 1, 2, 2)]);
-    assert_eq!(model.get_formatted_cell_value(0, 2, 1), Ok("".to_string()));
-}
+// Pasting over merged cells follows the containment rule; the cases live in
+// test_paste_merged_cells.rs.
 
 #[test]
 fn copy_paste_recreates_the_merge_at_the_target() {
@@ -892,26 +876,6 @@ fn cut_paste_moves_the_merge_to_the_target() {
     assert_eq!(
         model.get_formatted_cell_value(0, 10, 10),
         Ok("5".to_string())
-    );
-}
-
-#[test]
-fn paste_csv_over_merges_is_rejected() {
-    let mut model = new_empty_user_model();
-    // merge B2:C3
-    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
-    assert_eq!(
-        model.paste_csv_string(&area(0, 1, 1, 1, 1), "1\t2\n3\t4"),
-        Err("Cannot paste over merged cells".to_string())
-    );
-    // pasting away from the merge works
-    model.set_selected_cell(10, 1).unwrap();
-    model
-        .paste_csv_string(&area(0, 10, 1, 1, 1), "1\t2\n3\t4")
-        .unwrap();
-    assert_eq!(
-        model.get_formatted_cell_value(0, 11, 2),
-        Ok("4".to_string())
     );
 }
 

--- a/base/src/test/user_model/test_paste_merged_cells.rs
+++ b/base/src/test/user_model/test_paste_merged_cells.rs
@@ -1,0 +1,443 @@
+#![allow(clippy::unwrap_used)]
+
+// Paste and merged cells: the containment rule.
+//
+// * A merged cell intersecting the paste target must be fully contained in
+//   it. A contained merge is removed and replaced by whatever the paste
+//   carries (the merge pattern of the copied area, or nothing for plain
+//   data); a merge sticking out of the target rejects the paste.
+// * Exception: a single-cell paste whose target is the anchor of a merged
+//   cell writes the anchor and keeps the merge.
+// * The merges of the copied area are matched against the merge list as it
+//   was before the paste, so a paste overlapping its own source still
+//   recreates every merge.
+
+use bitcode::decode;
+
+use crate::expressions::types::Area;
+use crate::test::user_model::util::new_empty_user_model;
+use crate::types::MergedCell;
+use crate::user_model::history::QueueDiffs;
+use crate::UserModel;
+
+fn area(sheet: u32, row: i32, column: i32, width: i32, height: i32) -> Area {
+    Area {
+        sheet,
+        row,
+        column,
+        width,
+        height,
+    }
+}
+
+fn merged(row: i32, column: i32, width: i32, height: i32) -> MergedCell {
+    MergedCell {
+        row,
+        column,
+        width,
+        height,
+    }
+}
+
+// The merged cells of sheet 0, sorted, so the tests don't depend on the order
+// the implementation creates them in.
+fn merges_sorted(model: &UserModel) -> Vec<MergedCell> {
+    let mut merges = model.get_merged_cells(0).unwrap();
+    merges.sort_by_key(|m| (m.row, m.column));
+    merges
+}
+
+fn value(model: &UserModel, row: i32, column: i32) -> String {
+    model.get_formatted_cell_value(0, row, column).unwrap()
+}
+
+fn assert_history_is_clean(model: &mut UserModel) {
+    let queue: Vec<QueueDiffs> = decode(&model.flush_send_queue()).unwrap();
+    assert!(queue.is_empty());
+}
+
+const PARTIAL_OVERLAP: &str = "Cannot paste: a merged cell partially overlaps the paste area";
+
+// ── Copy-paste ───────────────────────────────────────────────────────────────
+
+#[test]
+fn paste_replaces_a_contained_target_merge() {
+    let mut model = new_empty_user_model();
+    // a plain 2x2 block A1:B2
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model.set_user_input(0, 1, 2, "2").unwrap();
+    model.set_user_input(0, 2, 1, "3").unwrap();
+    model.set_user_input(0, 2, 2, "4").unwrap();
+    // target merge D1:D2 with content, fully inside the paste target D1:E2
+    model.set_user_input(0, 1, 4, "x").unwrap();
+    model.merge_cells(&area(0, 1, 4, 1, 2)).unwrap();
+
+    model.set_selected_range(1, 1, 2, 2).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    model.set_selected_cell(1, 4).unwrap();
+    model
+        .paste_from_clipboard(0, clipboard.range, &clipboard.data, false)
+        .unwrap();
+
+    // the merge is gone and the plain values landed everywhere
+    assert!(model.get_merged_cells(0).unwrap().is_empty());
+    assert_eq!(value(&model, 1, 4), "1");
+    assert_eq!(value(&model, 1, 5), "2");
+    assert_eq!(value(&model, 2, 4), "3");
+    assert_eq!(value(&model, 2, 5), "4");
+
+    // undo restores the merge and its content
+    model.undo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(1, 4, 1, 2)]);
+    assert_eq!(value(&model, 1, 4), "x");
+    assert_eq!(value(&model, 1, 5), "");
+    assert_eq!(value(&model, 2, 5), "");
+
+    model.redo().unwrap();
+    assert!(model.get_merged_cells(0).unwrap().is_empty());
+    assert_eq!(value(&model, 1, 4), "1");
+}
+
+#[test]
+fn paste_a_merged_block_onto_an_identical_merge() {
+    let mut model = new_empty_user_model();
+    // source merge B2:C3 with "5", target merge E2:F3 with "9"
+    model.set_user_input(0, 2, 2, "5").unwrap();
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+    model.set_user_input(0, 2, 5, "9").unwrap();
+    model.merge_cells(&area(0, 2, 5, 2, 2)).unwrap();
+
+    model.set_selected_cell(2, 2).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    model.set_selected_cell(2, 5).unwrap();
+    model
+        .paste_from_clipboard(0, clipboard.range, &clipboard.data, false)
+        .unwrap();
+
+    // the target merge was replaced by the identical pasted one
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(2, 2, 2, 2), merged(2, 5, 2, 2)]
+    );
+    assert_eq!(value(&model, 2, 5), "5");
+
+    model.undo().unwrap();
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(2, 2, 2, 2), merged(2, 5, 2, 2)]
+    );
+    assert_eq!(value(&model, 2, 5), "9");
+
+    model.redo().unwrap();
+    assert_eq!(value(&model, 2, 5), "5");
+}
+
+#[test]
+fn paste_a_merged_block_onto_itself_is_a_no_op_paste() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 2, 2, "5").unwrap();
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+
+    // copy the merged cell and paste it back in place
+    model.set_selected_cell(2, 2).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    model
+        .paste_from_clipboard(0, clipboard.range, &clipboard.data, false)
+        .unwrap();
+
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 2, 2), "5");
+
+    model.undo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 2, 2), "5");
+}
+
+#[test]
+fn paste_partially_overlapping_a_merge_is_rejected() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "1").unwrap();
+    model.set_user_input(0, 1, 2, "2").unwrap();
+    // merge E1:E2 sticks out of the paste target D1:E1
+    model.merge_cells(&area(0, 1, 5, 1, 2)).unwrap();
+
+    model.set_selected_range(1, 1, 1, 2).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    model.set_selected_cell(1, 4).unwrap();
+    model.flush_send_queue();
+
+    assert_eq!(
+        model.paste_from_clipboard(0, clipboard.range, &clipboard.data, false),
+        Err(PARTIAL_OVERLAP.to_string())
+    );
+    // the model is untouched and the history is clean
+    assert_eq!(merges_sorted(&model), vec![merged(1, 5, 1, 2)]);
+    assert_eq!(value(&model, 1, 4), "");
+    assert_history_is_clean(&mut model);
+}
+
+#[test]
+fn paste_single_cell_into_a_merged_cell_keeps_the_merge() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "42").unwrap();
+    // merge B2:C3 with "x"
+    model.set_user_input(0, 2, 2, "x").unwrap();
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+
+    model.set_selected_cell(1, 1).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    // selecting the merged cell puts the anchor B2 in the view
+    model.set_selected_cell(2, 2).unwrap();
+    model
+        .paste_from_clipboard(0, clipboard.range, &clipboard.data, false)
+        .unwrap();
+
+    // the merge survives and the anchor got the pasted value
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 2, 2), "42");
+
+    model.undo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 2, 2), "x");
+
+    model.redo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 2, 2), "42");
+}
+
+#[test]
+fn cut_paste_single_cell_into_a_merged_cell_keeps_the_merge() {
+    let mut model = new_empty_user_model();
+    model.set_user_input(0, 1, 1, "42").unwrap();
+    // merge B2:C3
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+
+    model.set_selected_cell(1, 1).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    model.set_selected_cell(2, 2).unwrap();
+    model
+        .paste_from_clipboard(0, clipboard.range, &clipboard.data, true)
+        .unwrap();
+
+    // the value moved into the merged cell's anchor and the source is empty
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 2, 2), "42");
+    assert_eq!(value(&model, 1, 1), "");
+
+    model.undo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 2, 2), "");
+    assert_eq!(value(&model, 1, 1), "42");
+}
+
+// ── Cut-paste ────────────────────────────────────────────────────────────────
+
+#[test]
+fn cut_paste_replaces_a_contained_target_merge() {
+    let mut model = new_empty_user_model();
+    // source merge B2:C3 with "5", target merge E2:F3 with "9"
+    model.set_user_input(0, 2, 2, "5").unwrap();
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+    model.set_user_input(0, 2, 5, "9").unwrap();
+    model.merge_cells(&area(0, 2, 5, 2, 2)).unwrap();
+
+    model.set_selected_cell(2, 2).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    model.set_selected_cell(2, 5).unwrap();
+    model
+        .paste_from_clipboard(0, clipboard.range, &clipboard.data, true)
+        .unwrap();
+
+    // the merge moved onto the replaced target: gone from the source
+    assert_eq!(merges_sorted(&model), vec![merged(2, 5, 2, 2)]);
+    assert_eq!(value(&model, 2, 5), "5");
+    assert_eq!(value(&model, 2, 2), "");
+
+    // undo restores both merges and both contents
+    model.undo().unwrap();
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(2, 2, 2, 2), merged(2, 5, 2, 2)]
+    );
+    assert_eq!(value(&model, 2, 2), "5");
+    assert_eq!(value(&model, 2, 5), "9");
+
+    model.redo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(2, 5, 2, 2)]);
+    assert_eq!(value(&model, 2, 5), "5");
+}
+
+// ── Paste overlapping its own source ─────────────────────────────────────────
+
+#[test]
+fn paste_overlapping_the_source_recreates_all_merges() {
+    let mut model = new_empty_user_model();
+    // two stacked merges: A1:A2 with "a", A3:A4 with "b"
+    model.set_user_input(0, 1, 1, "a").unwrap();
+    model.merge_cells(&area(0, 1, 1, 1, 2)).unwrap();
+    model.set_user_input(0, 3, 1, "b").unwrap();
+    model.merge_cells(&area(0, 3, 1, 1, 2)).unwrap();
+
+    // copy A1:A4 and paste it at A3: the target overlaps the copied area, and
+    // the merge A3:A4 is both a source merge and a replaced target merge
+    model.set_selected_range(1, 1, 4, 1).unwrap();
+    let clipboard = model.copy_to_clipboard().unwrap();
+    model.set_selected_cell(3, 1).unwrap();
+    model
+        .paste_from_clipboard(0, clipboard.range, &clipboard.data, false)
+        .unwrap();
+
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 1, 2), merged(3, 1, 1, 2), merged(5, 1, 1, 2)]
+    );
+    assert_eq!(value(&model, 1, 1), "a");
+    assert_eq!(value(&model, 3, 1), "a");
+    assert_eq!(value(&model, 5, 1), "b");
+
+    model.undo().unwrap();
+    assert_eq!(
+        merges_sorted(&model),
+        vec![merged(1, 1, 1, 2), merged(3, 1, 1, 2)]
+    );
+    assert_eq!(value(&model, 3, 1), "b");
+    assert_eq!(value(&model, 5, 1), "");
+}
+
+// ── External replay ──────────────────────────────────────────────────────────
+
+#[test]
+fn paste_over_a_merge_replays_on_external_models() {
+    let mut model1 = new_empty_user_model();
+    let mut model2 = new_empty_user_model();
+
+    // like paste_replaces_a_contained_target_merge, replayed on model2: the
+    // unmerge diff must come before the cell writes for the replay to work
+    model1.set_user_input(0, 1, 1, "1").unwrap();
+    model1.set_user_input(0, 2, 1, "3").unwrap();
+    model1.set_user_input(0, 1, 4, "x").unwrap();
+    model1.merge_cells(&area(0, 1, 4, 1, 2)).unwrap();
+    model2
+        .apply_external_diffs(&model1.flush_send_queue())
+        .unwrap();
+
+    model1.set_selected_range(1, 1, 2, 1).unwrap();
+    let clipboard = model1.copy_to_clipboard().unwrap();
+    model1.set_selected_cell(1, 4).unwrap();
+    model1
+        .paste_from_clipboard(0, clipboard.range, &clipboard.data, false)
+        .unwrap();
+    model2
+        .apply_external_diffs(&model1.flush_send_queue())
+        .unwrap();
+
+    assert!(model2.get_merged_cells(0).unwrap().is_empty());
+    assert_eq!(value(&model2, 1, 4), "1");
+    assert_eq!(value(&model2, 2, 4), "3");
+
+    // the undo also replays
+    model1.undo().unwrap();
+    model2
+        .apply_external_diffs(&model1.flush_send_queue())
+        .unwrap();
+    assert_eq!(merges_sorted(&model2), vec![merged(1, 4, 1, 2)]);
+    assert_eq!(value(&model2, 1, 4), "x");
+}
+
+// ── CSV (external text) paste ────────────────────────────────────────────────
+
+#[test]
+fn paste_csv_replaces_a_contained_target_merge() {
+    let mut model = new_empty_user_model();
+    // merge A2:B3 with "x", exactly the extent of the pasted text
+    model.set_user_input(0, 2, 1, "x").unwrap();
+    model.merge_cells(&area(0, 2, 1, 2, 2)).unwrap();
+
+    model.set_selected_cell(2, 1).unwrap();
+    model
+        .paste_csv_string(&area(0, 2, 1, 1, 1), "1\t2\n3\t4")
+        .unwrap();
+
+    // plain text carries no merges: the target merge is simply gone
+    assert!(model.get_merged_cells(0).unwrap().is_empty());
+    assert_eq!(value(&model, 2, 1), "1");
+    assert_eq!(value(&model, 2, 2), "2");
+    assert_eq!(value(&model, 3, 1), "3");
+    assert_eq!(value(&model, 3, 2), "4");
+
+    model.undo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(2, 1, 2, 2)]);
+    assert_eq!(value(&model, 2, 1), "x");
+    assert_eq!(value(&model, 3, 2), "");
+
+    model.redo().unwrap();
+    assert!(model.get_merged_cells(0).unwrap().is_empty());
+    assert_eq!(value(&model, 2, 1), "1");
+}
+
+#[test]
+fn paste_csv_partially_overlapping_a_merge_is_rejected() {
+    let mut model = new_empty_user_model();
+    // merge B2:C3 sticks out of the paste target A1:B2
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+    model.flush_send_queue();
+
+    assert_eq!(
+        model.paste_csv_string(&area(0, 1, 1, 1, 1), "1\t2\n3\t4"),
+        Err(PARTIAL_OVERLAP.to_string())
+    );
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 1, 1), "");
+    assert_history_is_clean(&mut model);
+}
+
+#[test]
+fn paste_csv_single_value_into_a_merged_cell_keeps_the_merge() {
+    let mut model = new_empty_user_model();
+    // merge B2:C3 with "x"
+    model.set_user_input(0, 2, 2, "x").unwrap();
+    model.merge_cells(&area(0, 2, 2, 2, 2)).unwrap();
+
+    // paste a single value at the anchor
+    model.set_selected_cell(2, 2).unwrap();
+    model.paste_csv_string(&area(0, 2, 2, 1, 1), "42").unwrap();
+
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 2, 2), "42");
+
+    model.undo().unwrap();
+    assert_eq!(merges_sorted(&model), vec![merged(2, 2, 2, 2)]);
+    assert_eq!(value(&model, 2, 2), "x");
+}
+
+#[test]
+fn paste_csv_over_a_merge_replays_on_external_models() {
+    let mut model1 = new_empty_user_model();
+    let mut model2 = new_empty_user_model();
+
+    model1.set_user_input(0, 2, 1, "x").unwrap();
+    model1.merge_cells(&area(0, 2, 1, 2, 2)).unwrap();
+    model2
+        .apply_external_diffs(&model1.flush_send_queue())
+        .unwrap();
+
+    model1.set_selected_cell(2, 1).unwrap();
+    model1
+        .paste_csv_string(&area(0, 2, 1, 1, 1), "1\t2\n3\t4")
+        .unwrap();
+    model2
+        .apply_external_diffs(&model1.flush_send_queue())
+        .unwrap();
+
+    assert!(model2.get_merged_cells(0).unwrap().is_empty());
+    assert_eq!(value(&model2, 2, 1), "1");
+    assert_eq!(value(&model2, 3, 2), "4");
+
+    // the undo also replays
+    model1.undo().unwrap();
+    model2
+        .apply_external_diffs(&model1.flush_send_queue())
+        .unwrap();
+    assert_eq!(merges_sorted(&model2), vec![merged(2, 1, 2, 2)]);
+    assert_eq!(value(&model2, 2, 1), "x");
+}

--- a/base/src/user_model/autofill.rs
+++ b/base/src/user_model/autofill.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     expressions::{
@@ -8,13 +8,274 @@ use crate::{
         utils::{is_valid_column_number, is_valid_row},
     },
     model::CellStructure,
+    types::MergedCell,
     user_model::sequence_detector::detect_progression,
     UserModel,
 };
 
 use crate::user_model::history::Diff;
 
+const PARTIAL_MERGE_ERROR: &str =
+    "Cannot auto-fill: a merged cell partially overlaps the fill area";
+const CUT_MERGE_ERROR: &str = "Cannot auto-fill: the fill size must fit whole merged cells";
+
+// How the merged cells of the sheet interact with a fill:
+// the merges of the source are tiled into the fill target, and the merges
+// already in the target are replaced by that pattern.
+struct MergedFillPlan {
+    // source cells covered by a merge (every cell of a source merge except
+    // its anchor): they hold no content, and neither do their tiled copies
+    covered_source: HashSet<(i32, i32)>,
+    // the tiled copies of the source merges, to create in the fill target
+    new_merges: Vec<MergedCell>,
+    // the merged cells of the sheet before the fill
+    old_merged_cells: Vec<MergedCell>,
+    // the merged cells after removing the ones replaced by the fill, before
+    // adding `new_merges`
+    merged_cells_after_removal: Vec<MergedCell>,
+}
+
+fn merge_is_contained(m: &MergedCell, row1: i32, column1: i32, row2: i32, column2: i32) -> bool {
+    m.row >= row1
+        && m.column >= column1
+        && m.row + m.height - 1 <= row2
+        && m.column + m.width - 1 <= column2
+}
+
 impl<'a> UserModel<'a> {
+    // Validates the fill of `target` from `source` (both closed rectangles
+    // `(first_row, first_column, last_row, last_column)` on `sheet`) against
+    // the merged cells of the sheet and returns the resulting plan:
+    //
+    // * A merge intersecting the source or the target but not fully contained
+    //   in it fails with [PARTIAL_MERGE_ERROR].
+    // * The source merges are tiled into the target with period the source
+    //   height (`by_rows`) or width. A tiled merge that would stick out of
+    //   the target fails with [CUT_MERGE_ERROR]: the fill can stop mid-tile,
+    //   but only where it cuts no merge.
+    // * Merges fully contained in the target are replaced by the tiled
+    //   pattern (they are dropped from `merged_cells_after_removal`).
+    fn plan_fill_merges(
+        &self,
+        sheet: u32,
+        source: (i32, i32, i32, i32),
+        target: (i32, i32, i32, i32),
+        by_rows: bool,
+    ) -> Result<MergedFillPlan, String> {
+        let (s_row1, s_column1, s_row2, s_column2) = source;
+        let (t_row1, t_column1, t_row2, t_column2) = target;
+        let merged_cells = &self.model.workbook.worksheet(sheet)?.merged_cells;
+
+        let mut source_merges = Vec::new();
+        let mut merged_cells_after_removal = Vec::new();
+        for m in merged_cells {
+            if m.intersects(
+                s_row1,
+                s_column1,
+                s_column2 - s_column1 + 1,
+                s_row2 - s_row1 + 1,
+            ) {
+                if !merge_is_contained(m, s_row1, s_column1, s_row2, s_column2) {
+                    return Err(PARTIAL_MERGE_ERROR.to_string());
+                }
+                source_merges.push(*m);
+                merged_cells_after_removal.push(*m);
+            } else if m.intersects(
+                t_row1,
+                t_column1,
+                t_column2 - t_column1 + 1,
+                t_row2 - t_row1 + 1,
+            ) {
+                if !merge_is_contained(m, t_row1, t_column1, t_row2, t_column2) {
+                    return Err(PARTIAL_MERGE_ERROR.to_string());
+                }
+                // fully contained in the fill target: replaced by the fill
+            } else {
+                merged_cells_after_removal.push(*m);
+            }
+        }
+
+        let mut covered_source = HashSet::new();
+        for m in &source_merges {
+            for row in m.row..m.row + m.height {
+                for column in m.column..m.column + m.width {
+                    if (row, column) != (m.row, m.column) {
+                        covered_source.insert((row, column));
+                    }
+                }
+            }
+        }
+
+        // Tile the source merges into the target. Tiles start at the target
+        // edge next to the source and repeat away from it.
+        let mut new_merges = Vec::new();
+        if !source_merges.is_empty() {
+            let mut tile_starts = Vec::new();
+            if by_rows {
+                let period = s_row2 - s_row1 + 1;
+                if t_row1 > s_row2 {
+                    let mut start = t_row1;
+                    while start <= t_row2 {
+                        tile_starts.push(start);
+                        start += period;
+                    }
+                } else {
+                    let mut start = s_row1 - period;
+                    while start + period > t_row1 {
+                        tile_starts.push(start);
+                        start -= period;
+                    }
+                }
+                for tile_start in tile_starts {
+                    for m in &source_merges {
+                        let first_row = tile_start + (m.row - s_row1);
+                        let last_row = first_row + m.height - 1;
+                        if last_row < t_row1 || first_row > t_row2 {
+                            continue;
+                        }
+                        if first_row < t_row1 || last_row > t_row2 {
+                            return Err(CUT_MERGE_ERROR.to_string());
+                        }
+                        new_merges.push(MergedCell {
+                            row: first_row,
+                            column: m.column,
+                            width: m.width,
+                            height: m.height,
+                        });
+                    }
+                }
+            } else {
+                let period = s_column2 - s_column1 + 1;
+                if t_column1 > s_column2 {
+                    let mut start = t_column1;
+                    while start <= t_column2 {
+                        tile_starts.push(start);
+                        start += period;
+                    }
+                } else {
+                    let mut start = s_column1 - period;
+                    while start + period > t_column1 {
+                        tile_starts.push(start);
+                        start -= period;
+                    }
+                }
+                for tile_start in tile_starts {
+                    for m in &source_merges {
+                        let first_column = tile_start + (m.column - s_column1);
+                        let last_column = first_column + m.width - 1;
+                        if last_column < t_column1 || first_column > t_column2 {
+                            continue;
+                        }
+                        if first_column < t_column1 || last_column > t_column2 {
+                            return Err(CUT_MERGE_ERROR.to_string());
+                        }
+                        new_merges.push(MergedCell {
+                            row: m.row,
+                            column: first_column,
+                            width: m.width,
+                            height: m.height,
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(MergedFillPlan {
+            covered_source,
+            new_merges,
+            old_merged_cells: merged_cells.clone(),
+            merged_cells_after_removal,
+        })
+    }
+
+    // Removes the merges the fill target replaces, with its diff. Pushed
+    // before the cell diffs so a forward replay writes on unmerged cells.
+    fn apply_fill_merge_removal(
+        &mut self,
+        sheet: u32,
+        plan: &MergedFillPlan,
+        diff_list: &mut Vec<Diff>,
+    ) -> Result<(), String> {
+        if plan.merged_cells_after_removal != plan.old_merged_cells {
+            self.model.workbook.worksheet_mut(sheet)?.merged_cells =
+                plan.merged_cells_after_removal.clone();
+            diff_list.push(Diff::SetMergedCells {
+                sheet,
+                old_value: plan.old_merged_cells.clone(),
+                new_value: plan.merged_cells_after_removal.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    // Creates the tiled merges in the fill target, with its diff. Pushed
+    // after the cell diffs so an undo unmerges first and can then restore the
+    // old content of the covered cells.
+    fn apply_fill_merge_creation(
+        &mut self,
+        sheet: u32,
+        plan: &MergedFillPlan,
+        diff_list: &mut Vec<Diff>,
+    ) -> Result<(), String> {
+        if !plan.new_merges.is_empty() {
+            let worksheet = self.model.workbook.worksheet_mut(sheet)?;
+            worksheet
+                .merged_cells
+                .extend(plan.new_merges.iter().copied());
+            diff_list.push(Diff::SetMergedCells {
+                sheet,
+                old_value: plan.merged_cells_after_removal.clone(),
+                new_value: worksheet.merged_cells.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    // The fill target cell is covered by a tiled merge: it gets no value,
+    // only the style and (lack of) link of its source cell, and its old
+    // content is cleared. `source` and `target` are `(row, column)` pairs.
+    fn fill_covered_cell(
+        &mut self,
+        sheet: u32,
+        source: (i32, i32),
+        target: (i32, i32),
+        old_value: Option<crate::types::Cell>,
+        diff_list: &mut Vec<Diff>,
+    ) -> Result<(), String> {
+        let (source_row, source_column) = source;
+        let (row, column) = target;
+        let old_style = self.model.get_cell_style_or_none(sheet, row, column)?;
+        // Going through prepare_cell_for_user_input keeps dynamic array
+        // formulas consistent (an anchor spilling into the cell is reset)
+        self.model.prepare_cell_for_user_input(sheet, row, column)?;
+        let worksheet = self.model.workbook.worksheet_mut(sheet)?;
+        if worksheet.cell(row, column).is_some() {
+            worksheet.cell_clear_contents(row, column)?;
+        }
+        if old_value.is_some() {
+            diff_list.push(Diff::SetCellValue {
+                sheet,
+                row,
+                column,
+                new_value: "".to_string(),
+                old_value: Box::new(old_value),
+            });
+        }
+
+        let new_style = self
+            .model
+            .get_style_for_cell(sheet, source_row, source_column)?;
+        self.model.set_cell_style(sheet, row, column, &new_style)?;
+        diff_list.push(Diff::SetCellStyle {
+            sheet,
+            row,
+            column,
+            old_value: Box::new(old_style),
+            new_value: Box::new(new_style),
+        });
+
+        self.fill_cell_link(sheet, source_row, source_column, row, column, diff_list)
+    }
     /// Scans the fill target rectangle (`row_start..=row_end`, `col_start..=col_end`) for
     /// CSE array formulas and prepares them for overwriting:
     ///
@@ -121,20 +382,6 @@ impl<'a> UserModel<'a> {
             return Err(format!("Invalid row: '{to_row}'"));
         }
 
-        // Auto-filling over merged cells is not supported
-        let first_row = row1.min(to_row);
-        let fill_height = last_row.max(to_row) - first_row + 1;
-        if self
-            .model
-            .workbook
-            .worksheet(sheet)?
-            .merged_cells
-            .iter()
-            .any(|m| m.intersects(first_row, column1, width, fill_height))
-        {
-            return Err("Cannot auto-fill over merged cells".to_string());
-        }
-
         // anchor_row is the first row that repeats in each case.
         let anchor_row;
         let sign;
@@ -158,6 +405,18 @@ impl<'a> UserModel<'a> {
         // Fill target: rows in row_range, all source columns.
         let fill_row_start = if sign < 0 { to_row } else { last_row + 1 };
         let fill_row_end = if sign < 0 { row1 - 1 } else { to_row };
+
+        // The merged cells of the source are tiled into the fill target and
+        // replace the merges already there; a merge partially overlapping the
+        // source or the target, or cut by the fill boundary, is an error.
+        let plan = self.plan_fill_merges(
+            sheet,
+            (row1, column1, last_row, last_column),
+            (fill_row_start, column1, fill_row_end, last_column),
+            true,
+        )?;
+        self.apply_fill_merge_removal(sheet, &plan, &mut diff_list)?;
+
         let saved_cse = self.collect_and_clear_cse_in_fill_target(
             sheet,
             fill_row_start,
@@ -169,19 +428,28 @@ impl<'a> UserModel<'a> {
         for column in column1..=last_column {
             let mut index = 0;
             let locale = &self.model.locale;
+            // covered cells hold no content: the progression is detected over
+            // the rest and lands on the non-covered cells of the target
             let values = if sign < 0 {
                 (row1..=last_row)
                     .rev()
+                    .filter(|row| !plan.covered_source.contains(&(*row, column)))
                     .map(|row| self.get_cell_content(sheet, row, column))
                     .collect::<Result<Vec<_>, _>>()?
             } else {
                 (row1..=last_row)
+                    .filter(|row| !plan.covered_source.contains(&(*row, column)))
                     .map(|row| self.get_cell_content(sheet, row, column))
                     .collect::<Result<Vec<_>, _>>()?
             };
             let case_seed = self.get_cell_content(sheet, row1, column)?;
-            let possible_progression = detect_progression(&values, locale, &case_seed);
-            for (range_idx, row_ref) in row_range.iter().enumerate() {
+            let possible_progression = if values.is_empty() {
+                None
+            } else {
+                detect_progression(&values, locale, &case_seed)
+            };
+            let mut progression_idx = 0;
+            for row_ref in row_range.iter() {
                 let row = *row_ref;
 
                 let old_value = saved_cse.get(&(row, column)).cloned().unwrap_or_else(|| {
@@ -191,14 +459,29 @@ impl<'a> UserModel<'a> {
                         .ok()
                         .and_then(|ws| ws.cell(row, column).cloned())
                 });
-                let old_style = self.model.get_cell_style_or_none(sheet, row, column)?;
 
                 let source_row = anchor_row + index;
+
+                if plan.covered_source.contains(&(source_row, column)) {
+                    // the target cell is covered by a tiled merge
+                    self.fill_covered_cell(
+                        sheet,
+                        (source_row, column),
+                        (row, column),
+                        old_value,
+                        &mut diff_list,
+                    )?;
+                    index = (index + sign) % source_area.height;
+                    continue;
+                }
+
+                let old_style = self.model.get_cell_style_or_none(sheet, row, column)?;
                 let target_value;
 
                 // compute the new value and set it
                 if let Some(ref detected_progression) = possible_progression {
-                    target_value = detected_progression.next(range_idx);
+                    target_value = detected_progression.next(progression_idx);
+                    progression_idx += 1;
                 } else {
                     target_value = self
                         .model
@@ -233,6 +516,7 @@ impl<'a> UserModel<'a> {
                 index = (index + sign) % source_area.height;
             }
         }
+        self.apply_fill_merge_creation(sheet, &plan, &mut diff_list)?;
         self.push_diff_list(diff_list);
         self.evaluate();
         Ok(())
@@ -277,20 +561,6 @@ impl<'a> UserModel<'a> {
             return Err(format!("Invalid column: '{to_column}'"));
         }
 
-        // Auto-filling over merged cells is not supported
-        let first_column = column1.min(to_column);
-        let fill_width = last_column.max(to_column) - first_column + 1;
-        if self
-            .model
-            .workbook
-            .worksheet(sheet)?
-            .merged_cells
-            .iter()
-            .any(|m| m.intersects(row1, first_column, fill_width, height))
-        {
-            return Err("Cannot auto-fill over merged cells".to_string());
-        }
-
         // anchor_column is the first column that repeats in each case.
         let anchor_column;
         let sign;
@@ -314,6 +584,18 @@ impl<'a> UserModel<'a> {
         // Fill target: all source rows, columns in column_range.
         let fill_col_start = if sign < 0 { to_column } else { last_column + 1 };
         let fill_col_end = if sign < 0 { column1 - 1 } else { to_column };
+
+        // The merged cells of the source are tiled into the fill target and
+        // replace the merges already there; a merge partially overlapping the
+        // source or the target, or cut by the fill boundary, is an error.
+        let plan = self.plan_fill_merges(
+            sheet,
+            (row1, column1, last_row, last_column),
+            (row1, fill_col_start, last_row, fill_col_end),
+            false,
+        )?;
+        self.apply_fill_merge_removal(sheet, &plan, &mut diff_list)?;
+
         let saved_cse = self.collect_and_clear_cse_in_fill_target(
             sheet,
             row1,
@@ -325,19 +607,28 @@ impl<'a> UserModel<'a> {
         for row in row1..=last_row {
             let mut index = 0;
             let locale = &self.model.locale;
+            // covered cells hold no content: the progression is detected over
+            // the rest and lands on the non-covered cells of the target
             let values = if sign < 0 {
                 (column1..=last_column)
                     .rev()
+                    .filter(|column| !plan.covered_source.contains(&(row, *column)))
                     .map(|column| self.get_cell_content(sheet, row, column))
                     .collect::<Result<Vec<_>, _>>()?
             } else {
                 (column1..=last_column)
+                    .filter(|column| !plan.covered_source.contains(&(row, *column)))
                     .map(|column| self.get_cell_content(sheet, row, column))
                     .collect::<Result<Vec<_>, _>>()?
             };
             let case_seed = self.get_cell_content(sheet, row, column1)?;
-            let possible_progression = detect_progression(&values, locale, &case_seed);
-            for (range_idx, column_ref) in column_range.iter().enumerate() {
+            let possible_progression = if values.is_empty() {
+                None
+            } else {
+                detect_progression(&values, locale, &case_seed)
+            };
+            let mut progression_idx = 0;
+            for column_ref in column_range.iter() {
                 let column = *column_ref;
 
                 // Save value and style first
@@ -348,14 +639,29 @@ impl<'a> UserModel<'a> {
                         .ok()
                         .and_then(|ws| ws.cell(row, column).cloned())
                 });
-                let old_style = self.model.get_cell_style_or_none(sheet, row, column)?;
 
                 let source_column = anchor_column + index;
+
+                if plan.covered_source.contains(&(row, source_column)) {
+                    // the target cell is covered by a tiled merge
+                    self.fill_covered_cell(
+                        sheet,
+                        (row, source_column),
+                        (row, column),
+                        old_value,
+                        &mut diff_list,
+                    )?;
+                    index = (index + sign) % source_area.width;
+                    continue;
+                }
+
+                let old_style = self.model.get_cell_style_or_none(sheet, row, column)?;
                 let target_value;
 
                 // compute the new value and set it
                 if let Some(ref detected_progression) = possible_progression {
-                    target_value = detected_progression.next(range_idx);
+                    target_value = detected_progression.next(progression_idx);
+                    progression_idx += 1;
                 } else {
                     target_value = self
                         .model
@@ -392,6 +698,7 @@ impl<'a> UserModel<'a> {
                 index = (index + sign) % source_area.width;
             }
         }
+        self.apply_fill_merge_creation(sheet, &plan, &mut diff_list)?;
         self.push_diff_list(diff_list);
         self.evaluate();
         Ok(())

--- a/base/src/user_model/clipboard.rs
+++ b/base/src/user_model/clipboard.rs
@@ -12,11 +12,14 @@ use crate::{
     cf_types::ConditionalFormatting,
     expressions::types::{Area, CellReferenceIndex},
     model::CellStructure,
-    types::{ArrayKind, Cell, Link, Style},
+    types::{ArrayKind, Cell, Link, MergedCell, Style},
     UserModel,
 };
 
 use crate::user_model::history::Diff;
+
+const PARTIAL_MERGE_PASTE_ERROR: &str =
+    "Cannot paste: a merged cell partially overlaps the paste area";
 
 /// Data for the clipboard
 pub type ClipboardData = HashMap<i32, HashMap<i32, ClipboardCell>>;
@@ -43,6 +46,90 @@ pub struct Clipboard {
 }
 
 impl<'a> UserModel<'a> {
+    // Applies the merge containment rule to a paste into `target_area`
+    // (whose top-left cell is the paste anchor). The paste footprint is the
+    // target rectangle plus `pasted_merges`, the translated merges of the
+    // copied area it will recreate — they can stick out of the target
+    // because the copied range is clamped to the sheet dimension while a
+    // merge always travels whole.
+    //
+    // * a merged cell fully contained in the footprint is removed — the
+    //   paste replaces it. The removal diff is pushed before the cell diffs
+    //   so a forward replay writes on unmerged cells; the merges the paste
+    //   creates get their own diff afterwards, so an undo unmerges them
+    //   first.
+    // * a single-cell paste into the anchor of a merged cell keeps the
+    //   merge (only the anchor is written);
+    // * any other overlap rejects the paste, before anything changed.
+    fn remove_merges_replaced_by_paste(
+        &mut self,
+        target_area: &Area,
+        pasted_merges: &[MergedCell],
+        diff_list: &mut Vec<Diff>,
+    ) -> Result<(), String> {
+        let sheet = target_area.sheet;
+        let old_merged_cells = self.model.get_merged_cells(sheet)?.to_vec();
+        let single_cell_target = target_area.width == 1 && target_area.height == 1;
+        let cell_in_footprint = |row: i32, column: i32| -> bool {
+            (row >= target_area.row
+                && row < target_area.row + target_area.height
+                && column >= target_area.column
+                && column < target_area.column + target_area.width)
+                || pasted_merges.iter().any(|p| {
+                    row >= p.row
+                        && row < p.row + p.height
+                        && column >= p.column
+                        && column < p.column + p.width
+                })
+        };
+        let mut merged_cells_after_removal = Vec::new();
+        let mut removed_any = false;
+        for m in &old_merged_cells {
+            let intersects_footprint = m.intersects(
+                target_area.row,
+                target_area.column,
+                target_area.width,
+                target_area.height,
+            ) || pasted_merges
+                .iter()
+                .any(|p| m.intersects(p.row, p.column, p.width, p.height));
+            if !intersects_footprint {
+                merged_cells_after_removal.push(*m);
+                continue;
+            }
+            let mut contained = true;
+            'cells: for row in m.row..m.row + m.height {
+                for column in m.column..m.column + m.width {
+                    if !cell_in_footprint(row, column) {
+                        contained = false;
+                        break 'cells;
+                    }
+                }
+            }
+            if contained {
+                // replaced by the paste
+                removed_any = true;
+            } else if single_cell_target
+                && (m.row, m.column) == (target_area.row, target_area.column)
+            {
+                // pasting a single cell into a merged cell writes its anchor
+                merged_cells_after_removal.push(*m);
+            } else {
+                return Err(PARTIAL_MERGE_PASTE_ERROR.to_string());
+            }
+        }
+        if removed_any {
+            self.model.workbook.worksheet_mut(sheet)?.merged_cells =
+                merged_cells_after_removal.clone();
+            diff_list.push(Diff::SetMergedCells {
+                sheet,
+                old_value: old_merged_cells,
+                new_value: merged_cells_after_removal,
+            });
+        }
+        Ok(())
+    }
+
     /// Returns a copy of the selected area
     pub fn copy_to_clipboard(&self) -> Result<Clipboard, String> {
         let selected_area = self.get_selected_view();
@@ -129,24 +216,36 @@ impl<'a> UserModel<'a> {
             height: source_last_row - source_first_row + 1,
         };
 
-        // Pasting over merged cells is not supported
-        if self
+        // The merges of the copied area, captured before the containment
+        // step below can remove target merges: when the paste overlaps its
+        // own source, a source merge can also be a replaced target merge and
+        // must still be recreated.
+        let source_merges: Vec<MergedCell> = self
             .model
-            .workbook
-            .worksheet(sheet)?
-            .merged_cells
+            .get_merged_cells(source_sheet)?
             .iter()
-            .any(|m| {
+            .filter(|m| {
                 m.intersects(
-                    target_area.row,
-                    target_area.column,
-                    target_area.width,
-                    target_area.height,
+                    source_first_row,
+                    source_first_column,
+                    source_last_column - source_first_column + 1,
+                    source_last_row - source_first_row + 1,
                 )
             })
-        {
-            return Err("Cannot paste over merged cells".to_string());
-        }
+            .copied()
+            .collect();
+
+        // Merged cells in the target are replaced by the paste (or reject it)
+        let pasted_merges: Vec<MergedCell> = source_merges
+            .iter()
+            .map(|m| MergedCell {
+                row: m.row + selected_row - source_first_row,
+                column: m.column + selected_column - source_first_column,
+                width: m.width,
+                height: m.height,
+            })
+            .collect();
+        self.remove_merges_replaced_by_paste(target_area, &pasted_merges, &mut diff_list)?;
 
         let mut seen_cells = HashSet::new();
         // Compute all changes
@@ -284,20 +383,6 @@ impl<'a> UserModel<'a> {
             // stick out of the cut range when its covered cells are empty (the
             // copied range is clamped to the sheet dimension), and it moves
             // whole.
-            let source_merges: Vec<_> = self
-                .model
-                .get_merged_cells(source_sheet)?
-                .iter()
-                .filter(|m| {
-                    m.intersects(
-                        source_first_row,
-                        source_first_column,
-                        source_last_column - source_first_column + 1,
-                        source_last_row - source_first_row + 1,
-                    )
-                })
-                .cloned()
-                .collect();
             let old_source_merged_cells = self.model.get_merged_cells(source_sheet)?.to_vec();
             let old_target_merged_cells = self.model.get_merged_cells(sheet)?.to_vec();
             self.model.unmerge_cells(&Area {
@@ -518,20 +603,6 @@ impl<'a> UserModel<'a> {
             // target. A merge is matched by intersection: it can stick out of
             // the copied range when its covered cells are empty (the copied
             // range is clamped to the sheet dimension), and is recreated whole.
-            let source_merges: Vec<_> = self
-                .model
-                .get_merged_cells(source_sheet)?
-                .iter()
-                .filter(|m| {
-                    m.intersects(
-                        source_first_row,
-                        source_first_column,
-                        source_last_column - source_first_column + 1,
-                        source_last_row - source_first_row + 1,
-                    )
-                })
-                .cloned()
-                .collect();
             if !source_merges.is_empty() {
                 let old_merged_cells = self.model.get_merged_cells(sheet)?.to_vec();
                 for m in source_merges {
@@ -642,24 +713,10 @@ impl<'a> UserModel<'a> {
             height: records.len() as i32,
         };
 
-        // Pasting over merged cells is not supported
-        if self
-            .model
-            .workbook
-            .worksheet(sheet)?
-            .merged_cells
-            .iter()
-            .any(|m| {
-                m.intersects(
-                    paste_area.row,
-                    paste_area.column,
-                    paste_area.width,
-                    paste_area.height,
-                )
-            })
-        {
-            return Err("Cannot paste over merged cells".to_string());
-        }
+        // Merged cells in the target are replaced by the paste (or reject
+        // it); plain text carries no merges, so contained ones just go
+        let mut diff_list = Vec::new();
+        self.remove_merges_replaced_by_paste(&paste_area, &[], &mut diff_list)?;
 
         // Capture old values BEFORE clearing so undo can restore them correctly.
         let mut old_values: HashMap<(i32, i32), Option<Cell>> = HashMap::new();
@@ -673,7 +730,7 @@ impl<'a> UserModel<'a> {
         }
 
         // Clearing the target area also removes its links: capture them for undo
-        let mut diff_list = self.range_link_diffs(&paste_area)?;
+        diff_list.extend(self.range_link_diffs(&paste_area)?);
         self.model.range_clear_contents(&paste_area)?;
 
         // Second pass: write values and build diff list.

--- a/webapp/IronCalc/src/components/Workbook/Workbook.tsx
+++ b/webapp/IronCalc/src/components/Workbook/Workbook.tsx
@@ -239,6 +239,18 @@ const Workbook = (props: {
     setRedrawId((id) => id + 1);
   };
 
+  // A rejected paste (e.g. it would partially cover a merged cell) gets a
+  // dialog; the merged-cell case is localized, the rest show the raw error.
+  const showPasteError = (error: unknown) => {
+    const message = `${error}`;
+    setAlertDialog({
+      title: t("error_dialog.error_paste"),
+      message: message.includes("merged cell")
+        ? t("error_dialog.error_paste_merged")
+        : message,
+    });
+  };
+
   // Full-row and full-column selections can be neither merged nor unmerged.
   const getMergeCellsState = () => {
     const area = getSelectedArea();
@@ -718,10 +730,7 @@ const Workbook = (props: {
             );
             setRedrawId((id) => id + 1);
           } catch (e) {
-            setAlertDialog({
-              title: t("error_dialog.error_deleting_cells"),
-              message: `${e}`,
-            });
+            showPasteError(e);
           }
         } else if (mimeType === "text/plain") {
           const {
@@ -741,10 +750,7 @@ const Workbook = (props: {
             model.pasteCsvText(range, value);
             setRedrawId((id) => id + 1);
           } catch (e) {
-            setAlertDialog({
-              title: t("error_dialog.error_deleting_cells"),
-              message: `${e}`,
-            });
+            showPasteError(e);
           }
         } else {
           // NOT IMPLEMENTED

--- a/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
+++ b/webapp/IronCalc/src/components/Worksheet/Worksheet.tsx
@@ -86,6 +86,8 @@ const Worksheet = forwardRef(
     );
     const [columnWidthDialogOpen, setColumnWidthDialogOpen] = useState(false);
     const [columnWidthDefault, setColumnWidthDefault] = useState("");
+    // The raw engine error of a rejected autofill (localized when rendered)
+    const [autofillError, setAutofillError] = useState<string | null>(null);
     const [rowHeightDialogOpen, setRowHeightDialogOpen] = useState(false);
     const [rowHeightDefault, setRowHeightDefault] = useState("");
 
@@ -217,6 +219,15 @@ const Worksheet = forwardRef(
           }
         },
         onHideLinkTooltip: hideLinkTooltip,
+        onAutofillError: (message) => {
+          // the known rejections get a dialog; anything else stays silent
+          if (
+            message.includes("merged cell") ||
+            message.includes("array formula")
+          ) {
+            setAutofillError(message);
+          }
+        },
         linkTooltipCell,
         onRowHeightChanges(sheet, row, height) {
           if (height < 0) {
@@ -908,6 +919,16 @@ const Worksheet = forwardRef(
           onClose={() => setRowColErrorTitle(null)}
           title={rowColErrorTitle ?? ""}
           message={rowColErrorTitle ?? ""}
+        />
+        <Alert
+          open={autofillError !== null}
+          onClose={() => setAutofillError(null)}
+          title={t("error_dialog.error_autofill")}
+          message={
+            autofillError?.includes("merged cell")
+              ? t("error_dialog.error_autofill_merged")
+              : t("error_dialog.error_autofill_array")
+          }
         />
         <Prompt
           open={columnWidthDialogOpen}

--- a/webapp/IronCalc/src/components/WorksheetCanvas/outlineHandle.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/outlineHandle.ts
@@ -1,3 +1,4 @@
+import { type FillDirection, snapFillExtent } from "../util";
 import { AreaType } from "../workbookState";
 import { LAST_COLUMN, LAST_ROW } from "./constants";
 import type WorksheetCanvas from "./worksheetCanvas";
@@ -31,8 +32,35 @@ export function attachOutlineHandle(
     }
     const { row, column } = cell;
     const {
+      sheet,
       range: [rowStart, columnStart, rowEnd, columnEnd],
     } = worksheet.model.getSelectedView();
+    // A fill whose boundary cuts a merged cell of the tiled selection is
+    // rejected by the engine: the drag snaps back to the nearest valid extent
+    // (which can be none at all).
+    const snap = (direction: FillDirection, extent: number): number =>
+      snapFillExtent(
+        worksheet.model.getMergedCells(sheet),
+        { rowStart, rowEnd, columnStart, columnEnd },
+        direction,
+        extent,
+      );
+    const extendTo = (area: {
+      type: AreaType;
+      rowStart: number;
+      rowEnd: number;
+      columnStart: number;
+      columnEnd: number;
+    }): void => {
+      worksheet.workbookState.setExtendToArea(area);
+      worksheet.renderSheet();
+    };
+    const clearExtendTo = (): void => {
+      if (worksheet.workbookState.getExtendToArea()) {
+        worksheet.workbookState.clearExtendToArea();
+        worksheet.renderSheet();
+      }
+    };
     // We are either extending by rows or by columns
     // And we could be doing it in the positive direction (downwards or right)
     // or the negative direction (upwards or left)
@@ -44,15 +72,18 @@ export function attachOutlineHandle(
         (column > columnEnd && column - columnEnd < row - rowEnd))
     ) {
       // rows downwards
-      const area = {
+      const extent = snap("rowsDown", row - rowEnd);
+      if (extent === 0) {
+        clearExtendTo();
+        return;
+      }
+      extendTo({
         type: AreaType.rowsDown,
         rowStart: rowEnd + 1,
-        rowEnd: row,
+        rowEnd: rowEnd + extent,
         columnStart,
         columnEnd,
-      };
-      worksheet.workbookState.setExtendToArea(area);
-      worksheet.renderSheet();
+      });
     } else if (
       row < rowStart &&
       ((column <= columnEnd && column >= columnStart) ||
@@ -60,15 +91,18 @@ export function attachOutlineHandle(
         (column > columnEnd && column - columnEnd < rowStart - row))
     ) {
       // rows upwards
-      const area = {
+      const extent = snap("rowsUp", rowStart - row);
+      if (extent === 0) {
+        clearExtendTo();
+        return;
+      }
+      extendTo({
         type: AreaType.rowsUp,
-        rowStart: row,
+        rowStart: rowStart - extent,
         rowEnd: rowStart,
         columnStart,
         columnEnd,
-      };
-      worksheet.workbookState.setExtendToArea(area);
-      worksheet.renderSheet();
+      });
     } else if (
       column > columnEnd &&
       ((row <= rowEnd && row >= rowStart) ||
@@ -76,15 +110,18 @@ export function attachOutlineHandle(
         (row > rowEnd && row - rowEnd < column - columnEnd))
     ) {
       // columns right
-      const area = {
+      const extent = snap("columnsRight", column - columnEnd);
+      if (extent === 0) {
+        clearExtendTo();
+        return;
+      }
+      extendTo({
         type: AreaType.columnsRight,
         rowStart,
         rowEnd,
         columnStart: columnEnd + 1,
-        columnEnd: column,
-      };
-      worksheet.workbookState.setExtendToArea(area);
-      worksheet.renderSheet();
+        columnEnd: columnEnd + extent,
+      });
     } else if (
       column < columnStart &&
       ((row <= rowEnd && row >= rowStart) ||
@@ -92,15 +129,18 @@ export function attachOutlineHandle(
         (row > rowEnd && row - rowEnd < columnStart - column))
     ) {
       // columns left
-      const area = {
+      const extent = snap("columnsLeft", columnStart - column);
+      if (extent === 0) {
+        clearExtendTo();
+        return;
+      }
+      extendTo({
         type: AreaType.columnsLeft,
         rowStart,
         rowEnd,
-        columnStart: column,
+        columnStart: columnStart - extent,
         columnEnd: columnStart,
-      };
-      worksheet.workbookState.setExtendToArea(area);
-      worksheet.renderSheet();
+      });
     }
   };
 
@@ -144,10 +184,9 @@ export function attachOutlineHandle(
           break;
         }
       }
-    } catch (_) {
-      // This could fail if, for instnace we are breaking an array formula
-      // Here we fail silently
-      // TODO: Could we shouw a message to the user?
+    } catch (error) {
+      // e.g. the fill would partially cover a merged cell or an array formula
+      worksheet.onAutofillError?.(`${error}`);
     }
     const selectedRowStart = Math.min(rowStart, extendedArea.rowStart);
     const selectedColumnStart = Math.min(columnStart, extendedArea.columnStart);
@@ -244,6 +283,16 @@ export function attachOutlineHandle(
       }
     }
 
+    // the fill boundary must not cut a merged cell of the tiled selection
+    lastUsedRow =
+      rowEnd +
+      snapFillExtent(
+        worksheet.model.getMergedCells(sheet),
+        { rowStart, rowEnd, columnStart, columnEnd },
+        "rowsDown",
+        lastUsedRow - rowEnd,
+      );
+
     if (lastUsedRow <= rowEnd) {
       return;
     }
@@ -256,7 +305,13 @@ export function attachOutlineHandle(
       height,
     };
 
-    worksheet.model.autoFillRows(area, lastUsedRow);
+    try {
+      worksheet.model.autoFillRows(area, lastUsedRow);
+    } catch (error) {
+      // e.g. the fill would partially cover a merged cell or an array formula
+      worksheet.onAutofillError?.(`${error}`);
+      return;
+    }
     worksheet.model.setSelectedRange(
       rowStart,
       columnStart,

--- a/webapp/IronCalc/src/components/WorksheetCanvas/outlineHandle.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/outlineHandle.ts
@@ -185,8 +185,12 @@ export function attachOutlineHandle(
         }
       }
     } catch (error) {
-      // e.g. the fill would partially cover a merged cell or an array formula
+      // e.g. the fill would partially cover a merged cell or an array formula:
+      // nothing was filled, so the selection stays put
       worksheet.onAutofillError?.(`${error}`);
+      worksheet.workbookState.clearExtendToArea();
+      worksheet.renderSheet();
+      return;
     }
     const selectedRowStart = Math.min(rowStart, extendedArea.rowStart);
     const selectedColumnStart = Math.min(columnStart, extendedArea.columnStart);

--- a/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
+++ b/webapp/IronCalc/src/components/WorksheetCanvas/worksheetCanvas.ts
@@ -47,6 +47,9 @@ export interface CanvasSettings {
   onRowHeightChanges: (sheet: number, row: number, height: number) => void;
   onLinkHover?: (cell: LinkHoverCell | null) => void;
   onHideLinkTooltip?: () => void;
+  // Called with the engine error when an autofill (fill handle drag or
+  // double-click) is rejected
+  onAutofillError?: (message: string) => void;
   linkTooltipCell: LinkHoverCell | null;
   refresh: () => void;
 }
@@ -115,6 +118,8 @@ export default class WorksheetCanvas {
 
   onRowHeightChanges: (sheet: number, row: number, height: number) => void;
 
+  onAutofillError?: (message: string) => void;
+
   refresh: () => void;
 
   cells: TextProperties[];
@@ -167,6 +172,7 @@ export default class WorksheetCanvas {
 
     this.onColumnWidthChanges = options.onColumnWidthChanges;
     this.onRowHeightChanges = options.onRowHeightChanges;
+    this.onAutofillError = options.onAutofillError;
     this.resetHeaders();
     this.cellOutlineHandle = attachOutlineHandle(this);
 

--- a/webapp/IronCalc/src/components/util.ts
+++ b/webapp/IronCalc/src/components/util.ts
@@ -81,6 +81,83 @@ export function growRangeOverMergedCells(
   };
 }
 
+export type FillDirection =
+  | "rowsDown"
+  | "rowsUp"
+  | "columnsRight"
+  | "columnsLeft";
+
+/**
+ * Auto-filling tiles the merged cells of the selection into the fill target
+ * with period the selection height (filling by rows) or width (by columns),
+ * and the engine rejects a fill whose boundary would cut a tiled merge.
+ * Returns the largest extent <= `extent` whose boundary cuts no merge
+ * (possibly 0). The selection bounds must be normalized and, per the
+ * selection invariant, the selection fully contains every merge it touches.
+ */
+export function snapFillExtent(
+  mergedCells: MergedCell[],
+  selection: {
+    rowStart: number;
+    rowEnd: number;
+    columnStart: number;
+    columnEnd: number;
+  },
+  direction: FillDirection,
+  extent: number,
+): number {
+  if (extent <= 0) {
+    return 0;
+  }
+  const byRows = direction === "rowsDown" || direction === "rowsUp";
+  const period = byRows
+    ? selection.rowEnd - selection.rowStart + 1
+    : selection.columnEnd - selection.columnStart + 1;
+  // the merge spans along the fill axis, as 0-based offsets in the selection
+  const spans: [number, number][] = [];
+  for (const m of mergedCells) {
+    const lastRow = m.row + m.height - 1;
+    const lastColumn = m.column + m.width - 1;
+    const intersects =
+      m.row <= selection.rowEnd &&
+      lastRow >= selection.rowStart &&
+      m.column <= selection.columnEnd &&
+      lastColumn >= selection.columnStart;
+    if (!intersects) {
+      continue;
+    }
+    spans.push(
+      byRows
+        ? [m.row - selection.rowStart, lastRow - selection.rowStart]
+        : [
+            m.column - selection.columnStart,
+            lastColumn - selection.columnStart,
+          ],
+    );
+  }
+  if (spans.length === 0) {
+    return extent;
+  }
+  // With `filled` cells of the last tile filled, the fill boundary sits at
+  // pattern offset `filled` (filling away from the selection) or
+  // `period - filled` (filling towards the sheet start, where the last tile
+  // holds the tail of the pattern); a merge must not straddle it.
+  const towardStart = direction === "rowsUp" || direction === "columnsLeft";
+  const cutsAMerge = (filled: number): boolean => {
+    const boundary = towardStart ? period - filled : filled;
+    return spans.some(([start, end]) => start < boundary && end >= boundary);
+  };
+  let snapped = extent;
+  while (
+    snapped > 0 &&
+    snapped % period !== 0 &&
+    cutsAMerge(snapped % period)
+  ) {
+    snapped -= 1;
+  }
+  return snapped;
+}
+
 /**
  * Returns the size of the cell editor for a cell: the size of the cell itself,
  * or of the whole merged range if the cell is merged.

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -192,6 +192,9 @@
     }
   },
   "error_dialog": {
+    "error_autofill": "Automatisches Ausfüllen nicht möglich",
+    "error_autofill_array": "Der Ausfüllbereich kann eine Matrixformel nicht teilweise abdecken.",
+    "error_autofill_merged": "Der Ausfüllbereich kann eine verbundene Zelle nicht teilweise abdecken.",
     "error_clipboard_paste": "Zugriff auf die Zwischenablage verweigert. Bitte erlauben Sie Zwischenablage-Berechtigungen in Ihrem Browser.",
     "error_deleting_cells": "Zellen konnten nicht gelöscht werden",
     "error_deleting_columns": "Spalten konnten nicht gelöscht werden",

--- a/webapp/IronCalc/src/locale/de_de.json
+++ b/webapp/IronCalc/src/locale/de_de.json
@@ -205,7 +205,9 @@
     "error_merging_cells": "Zellen können nicht verbunden werden",
     "error_merging_cells_content": "Nur eine Zelle der Auswahl darf Inhalt haben.",
     "error_moving_columns": "Spalten konnten nicht verschoben werden",
-    "error_moving_rows": "Zeilen konnten nicht verschoben werden"
+    "error_moving_rows": "Zeilen konnten nicht verschoben werden",
+    "error_paste": "Einfügen nicht möglich",
+    "error_paste_merged": "Der eingefügte Bereich kann eine verbundene Zelle nicht teilweise abdecken."
   },
   "formula_bar": {
     "manage_named_ranges": "Benannte Bereiche verwalten"

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -192,6 +192,9 @@
     }
   },
   "error_dialog": {
+    "error_autofill": "Cannot auto-fill",
+    "error_autofill_array": "The fill area cannot cover part of an array formula.",
+    "error_autofill_merged": "The fill area cannot cover part of a merged cell.",
     "error_clipboard_paste": "Clipboard access denied. Please allow clipboard permissions in your browser.",
     "error_deleting_cells": "Failed to delete cells",
     "error_deleting_columns": "Failed to delete columns",

--- a/webapp/IronCalc/src/locale/en_us.json
+++ b/webapp/IronCalc/src/locale/en_us.json
@@ -205,7 +205,9 @@
     "error_merging_cells": "Cannot merge cells",
     "error_merging_cells_content": "Only one cell in the selection can have content.",
     "error_moving_columns": "Failed to move columns",
-    "error_moving_rows": "Failed to move rows"
+    "error_moving_rows": "Failed to move rows",
+    "error_paste": "Cannot paste",
+    "error_paste_merged": "The pasted area cannot cover part of a merged cell."
   },
   "formula_bar": {
     "manage_named_ranges": "Manage Named Ranges"

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -192,6 +192,9 @@
     }
   },
   "error_dialog": {
+    "error_autofill": "No se puede autorrellenar",
+    "error_autofill_array": "El área de relleno no puede cubrir parte de una fórmula matricial.",
+    "error_autofill_merged": "El área de relleno no puede cubrir parte de una celda combinada.",
     "error_clipboard_paste": "Acceso al portapapeles denegado. Por favor, permite el acceso al portapapeles en tu navegador.",
     "error_deleting_cells": "Error al eliminar las celdas",
     "error_deleting_columns": "Error al eliminar las columnas",

--- a/webapp/IronCalc/src/locale/es_es.json
+++ b/webapp/IronCalc/src/locale/es_es.json
@@ -205,7 +205,9 @@
     "error_merging_cells": "No se pueden combinar las celdas",
     "error_merging_cells_content": "Solo una celda de la selección puede tener contenido.",
     "error_moving_columns": "Error al mover las columnas",
-    "error_moving_rows": "Error al mover las filas"
+    "error_moving_rows": "Error al mover las filas",
+    "error_paste": "No se puede pegar",
+    "error_paste_merged": "El área pegada no puede cubrir parte de una celda combinada."
   },
   "formula_bar": {
     "manage_named_ranges": "Gestionar rangos con nombre"

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -205,7 +205,9 @@
     "error_merging_cells": "Impossible de fusionner les cellules",
     "error_merging_cells_content": "Une seule cellule de la sélection peut avoir du contenu.",
     "error_moving_columns": "Échec du déplacement des colonnes",
-    "error_moving_rows": "Échec du déplacement des lignes"
+    "error_moving_rows": "Échec du déplacement des lignes",
+    "error_paste": "Collage impossible",
+    "error_paste_merged": "La zone collée ne peut pas couvrir une partie d'une cellule fusionnée."
   },
   "formula_bar": {
     "manage_named_ranges": "Gérer les plages nommées"

--- a/webapp/IronCalc/src/locale/fr_fr.json
+++ b/webapp/IronCalc/src/locale/fr_fr.json
@@ -192,6 +192,9 @@
     }
   },
   "error_dialog": {
+    "error_autofill": "Recopie impossible",
+    "error_autofill_array": "La zone de recopie ne peut pas couvrir une partie d'une formule matricielle.",
+    "error_autofill_merged": "La zone de recopie ne peut pas couvrir une partie d'une cellule fusionnée.",
     "error_clipboard_paste": "Accès au presse-papiers refusé. Veuillez autoriser les permissions du presse-papiers dans votre navigateur.",
     "error_deleting_cells": "Échec de la suppression des cellules",
     "error_deleting_columns": "Échec de la suppression des colonnes",

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -205,7 +205,9 @@
     "error_merging_cells": "Impossibile unire le celle",
     "error_merging_cells_content": "Solo una cella della selezione può avere contenuto.",
     "error_moving_columns": "Impossibile spostare le colonne",
-    "error_moving_rows": "Impossibile spostare le righe"
+    "error_moving_rows": "Impossibile spostare le righe",
+    "error_paste": "Impossibile incollare",
+    "error_paste_merged": "L'area incollata non può coprire parte di una cella unita."
   },
   "formula_bar": {
     "manage_named_ranges": "Gestisci intervalli denominati"

--- a/webapp/IronCalc/src/locale/it_it.json
+++ b/webapp/IronCalc/src/locale/it_it.json
@@ -192,6 +192,9 @@
     }
   },
   "error_dialog": {
+    "error_autofill": "Riempimento automatico impossibile",
+    "error_autofill_array": "L'area di riempimento non può coprire parte di una formula matriciale.",
+    "error_autofill_merged": "L'area di riempimento non può coprire parte di una cella unita.",
     "error_clipboard_paste": "Accesso agli appunti negato. Consenti le autorizzazioni per gli appunti nel tuo browser.",
     "error_deleting_cells": "Impossibile eliminare le celle",
     "error_deleting_columns": "Impossibile eliminare le colonne",

--- a/webapp/IronCalc/tests/snapFillExtent.test.ts
+++ b/webapp/IronCalc/tests/snapFillExtent.test.ts
@@ -1,0 +1,74 @@
+import type { MergedCell } from "@ironcalc/wasm";
+import { expect, test } from "vitest";
+import { snapFillExtent } from "../src/components/util";
+
+const merged = (
+  row: number,
+  column: number,
+  width: number,
+  height: number,
+): MergedCell => ({ row, column, width, height });
+
+test("a selection without merges keeps the dragged extent", () => {
+  const selection = { rowStart: 1, rowEnd: 2, columnStart: 1, columnEnd: 1 };
+  expect(snapFillExtent([], selection, "rowsDown", 3)).toBe(3);
+  expect(snapFillExtent([], selection, "rowsUp", 1)).toBe(1);
+});
+
+test("merges outside the selection are ignored", () => {
+  const selection = { rowStart: 1, rowEnd: 1, columnStart: 1, columnEnd: 1 };
+  expect(snapFillExtent([merged(5, 5, 2, 2)], selection, "rowsDown", 3)).toBe(
+    3,
+  );
+});
+
+test("a merged selection snaps down to whole tiles", () => {
+  // the selection is a single 2-tall merge A1:A2
+  const selection = { rowStart: 1, rowEnd: 2, columnStart: 1, columnEnd: 1 };
+  const merges = [merged(1, 1, 1, 2)];
+  expect(snapFillExtent(merges, selection, "rowsDown", 4)).toBe(4);
+  expect(snapFillExtent(merges, selection, "rowsDown", 3)).toBe(2);
+  expect(snapFillExtent(merges, selection, "rowsDown", 1)).toBe(0);
+  expect(snapFillExtent(merges, selection, "rowsUp", 3)).toBe(2);
+});
+
+test("a partial tile is kept when its merges fit whole", () => {
+  // pattern: A1:A2 merged plus the plain row 3
+  const selection = { rowStart: 1, rowEnd: 3, columnStart: 1, columnEnd: 1 };
+  const merges = [merged(1, 1, 1, 2)];
+  // filling down, a partial tile of two rows holds the whole merge...
+  expect(snapFillExtent(merges, selection, "rowsDown", 5)).toBe(5);
+  // ...but one of a single row would cut it
+  expect(snapFillExtent(merges, selection, "rowsDown", 4)).toBe(3);
+  expect(snapFillExtent(merges, selection, "rowsDown", 1)).toBe(0);
+  // filling up the tiles flip: the partial tile holds the plain row first
+  expect(snapFillExtent(merges, selection, "rowsUp", 4)).toBe(4);
+  expect(snapFillExtent(merges, selection, "rowsUp", 2)).toBe(1);
+});
+
+test("stacked merges snap independently", () => {
+  // two 2-tall merges, A1:A2 and A3:A4
+  const selection = { rowStart: 1, rowEnd: 4, columnStart: 1, columnEnd: 1 };
+  const merges = [merged(1, 1, 1, 2), merged(3, 1, 1, 2)];
+  expect(snapFillExtent(merges, selection, "rowsDown", 6)).toBe(6);
+  expect(snapFillExtent(merges, selection, "rowsDown", 5)).toBe(4);
+  expect(snapFillExtent(merges, selection, "rowsDown", 3)).toBe(2);
+});
+
+test("column fills snap on the merge width", () => {
+  // the selection is a single 2-wide merge B1:C1
+  const selection = { rowStart: 1, rowEnd: 1, columnStart: 2, columnEnd: 3 };
+  const merges = [merged(1, 2, 2, 1)];
+  expect(snapFillExtent(merges, selection, "columnsRight", 4)).toBe(4);
+  expect(snapFillExtent(merges, selection, "columnsRight", 3)).toBe(2);
+  expect(snapFillExtent(merges, selection, "columnsLeft", 1)).toBe(0);
+  expect(snapFillExtent(merges, selection, "columnsLeft", 2)).toBe(2);
+});
+
+test("a vertical merge does not restrict a column fill", () => {
+  // A1:A2 is one column wide: every column extent tiles it whole
+  const selection = { rowStart: 1, rowEnd: 2, columnStart: 1, columnEnd: 1 };
+  const merges = [merged(1, 1, 1, 2)];
+  expect(snapFillExtent(merges, selection, "columnsRight", 3)).toBe(3);
+  expect(snapFillExtent(merges, selection, "columnsLeft", 1)).toBe(1);
+});


### PR DESCRIPTION
Autofill is now possible within mered cell under some condtions (so called contained).

The target must contain full merged cells (or no merged cells at all). It si a bit simmilar to what happens with array formulas. When doing an autofill the pattern of merged cells repeats itself.

Of course you cannot autofill from part of a merged cell. This is tested but in the UI that should be simply impossible.

The fill boundary should not cut a merged cell. For instnace if your merged cell is a three tall vertical merge the autofill will advance thrre by three. As another example if you have a two cell tall merge and the selection is three cells the the autofill will advance by 2,3,5,6,....

Also pasting works under the same or simmilar conditions

You can only copy full merged cells and when pasting you either break full merged cells or it is disallowed. The pasted area will have the same geometry as the copied area. When cut and paste the cut area will be unmerged.

External copy/paste will destroy all merged cell in the target (and fail if they don't cover full merged cells)

The is a small exception you can always copy or cut from a single cell to amerged cell